### PR TITLE
Fix without any bot files present the server segfaults

### DIFF
--- a/server/ServerHelper.pas
+++ b/server/ServerHelper.pas
@@ -257,11 +257,19 @@ begin
   end;
   FindClose(searchResult);
 
-  SelectedBot := BotList[Random(BotList.Count)];
-  SelectedBot := AnsiReplaceStr(SelectedBot, UserDirectory + 'configs/bots/', '');
-  SelectedBot := AnsiReplaceStr(SelectedBot, '.bot', '');
+  if BotList.Count > 0 then
+  begin
+    SelectedBot := BotList[Random(BotList.Count)];
+    SelectedBot := AnsiReplaceStr(SelectedBot, UserDirectory + 'configs/bots/', '');
+    SelectedBot := AnsiReplaceStr(SelectedBot, '.bot', '');
+  end else
+  begin
+    SelectedBot := 'Dummy';
+  end;
+
   if (SelectedBot = 'Boogie Man') or (SelectedBot = 'Dummy') then
     SelectedBot := 'Sniper';
+
   result := SelectedBot;
 end;
 


### PR DESCRIPTION
This makes sure that the server won't segfault if there are no bot files present in the soldat.smod file.
It will show an error that it cannot load a bot file.

See https://github.com/Soldat/soldat/issues/11 for how to reproduce this error.