### PR TITLE
Fix crosshair scaling

### DIFF
--- a/client/InterfaceGraphics.pas
+++ b/client/InterfaceGraphics.pas
@@ -1869,7 +1869,6 @@ var
   CursorScale: Single;
   CursorScaledOffset: TVector2;
   CursorBinkScale: Single;
-  //CursorBinkOffset: TVector2;
   CursorColor: Integer;
   Alfa: Integer;
   CharacterOffset: TVector2;
@@ -2170,22 +2169,19 @@ begin
       CursorSize.x := T^[GFX_INTERFACE_CURSOR].Width * T^[GFX_INTERFACE_CURSOR].Scale;
       CursorSize.y := T^[GFX_INTERFACE_CURSOR].Height * T^[GFX_INTERFACE_CURSOR].Scale;
 
-      // Base crosshair offset. Larger offset if interface scaling is enabled
-      CursorScaledOffset.x := CursorSize.x / 2 * CursorScale / _rscala.x;
-      CursorScaledOffset.y := CursorSize.y / 2 * CursorScale / _rscala.y;
-
       Moveacc := SpriteMe.GetMoveacc;
       Inaccuracy := HitSprayCounter + Moveacc * 100;
 
-      // Embiggen the crosshair when binked, keeping it centered
+      // Embiggen the crosshair when binked
       if Inaccuracy > 0 then
       begin
         CursorBinkScale := Power(Inaccuracy, 0.6) / 20 * CursorScale;
-        //CursorBinkOffset.x := CursorSize.x / 2 * CursorBinkScale / _rscala.x;
-        //CursorBinkOffset.y := CursorSize.y / 2 * CursorBinkScale / _rscala.y;
-        // TODO: Finish
         CursorScale := CursorScale + CursorBinkScale;
       end;
+
+      // Scale crosshair from its center
+      CursorScaledOffset.x := CursorSize.x / 2 * CursorScale / _rscala.x;
+      CursorScaledOffset.y := CursorSize.y / 2 * CursorScale / _rscala.y;
 
       // Color and alpha for crosshair
       if CursorTextLength > 0 then


### PR DESCRIPTION
The crosshair was scaling from its top left corner and there was a TODO. Now it is done.
I did some side by side comparison with 1.7.1 and it all seems to be the same.