### PR TITLE
Update GameNetworkingSockets bindings to v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains the source code of the so-called 1.8 version. Compared 
 - OpenAL
 - FreeType 2.6.1
 - PhysFS 3.0.2
-- GameNetworkingSockets
+- [GameNetworkingSockets v1.2.0](https://github.com/ValveSoftware/GameNetworkingSockets/releases/tag/v1.2.0)
 
 ## Building Soldat
 

--- a/shared/libs/GameNetworkingSockets/GameNetworkingSockets.pas
+++ b/shared/libs/GameNetworkingSockets/GameNetworkingSockets.pas
@@ -56,6 +56,10 @@ type SteamDatagramGameCoordinatorServerLogin = record;
 type PSteamDatagramGameCoordinatorServerLogin = ^SteamDatagramGameCoordinatorServerLogin;
 type SteamRelayNetworkStatus_t = record;
 type PSteamRelayNetworkStatus_t = ^SteamRelayNetworkStatus_t;
+type SteamNetworkingMessagesSessionRequest_t = record;
+type PSteamNetworkingMessagesSessionRequest_t = ^SteamNetworkingMessagesSessionRequest_t;
+type SteamNetworkingMessagesSessionFailed_t = record;
+type PSteamNetworkingMessagesSessionFailed_t = ^SteamNetworkingMessagesSessionFailed_t;
 
 /// Handle used to identify a connection to a remote host.
 type HSteamNetConnection = uint32;
@@ -223,21 +227,21 @@ type ESteamNetworkingAvailability = (
   // depends on of requests this resource, such as querying the status, attempting
   // to initiate a connection, receive a connection, etc.  If you do not take any
   // action at all, we do not automatically retry in the background.
-  k_ESteamNetworkingAvailability_CannotTry = -102,		// A dependent resource is missing, so this service is unavailable.  (E.g. we cannot talk to routers because Internet is down or we don't have the network config.)
-  k_ESteamNetworkingAvailability_Failed = -101,			// We have tried for enough time that we would expect to have been successful by now.  We have never been successful
-  k_ESteamNetworkingAvailability_Previously = -100,		// We tried and were successful at one time, but now it looks like we have a problem
+  k_ESteamNetworkingAvailability_CannotTry = -102,    // A dependent resource is missing, so this service is unavailable.  (E.g. we cannot talk to routers because Internet is down or we don't have the network config.)
+  k_ESteamNetworkingAvailability_Failed = -101,      // We have tried for enough time that we would expect to have been successful by now.  We have never been successful
+  k_ESteamNetworkingAvailability_Previously = -100,    // We tried and were successful at one time, but now it looks like we have a problem
 
-  k_ESteamNetworkingAvailability_Retrying = -10,		// We previously failed and are currently retrying
+  k_ESteamNetworkingAvailability_Retrying = -10,    // We previously failed and are currently retrying
 
   // Not a problem, but not ready either
-  k_ESteamNetworkingAvailability_NeverTried = 1,		// We don't know because we haven't ever checked/tried
-  k_ESteamNetworkingAvailability_Waiting = 2,			// We're waiting on a dependent resource to be acquired.  (E.g. we cannot obtain a cert until we are logged into Steam.  We cannot measure latency to relays until we have the network config.)
-  k_ESteamNetworkingAvailability_Attempting = 3,		// We're actively trying now, but are not yet successful.
+  k_ESteamNetworkingAvailability_NeverTried = 1,    // We don't know because we haven't ever checked/tried
+  k_ESteamNetworkingAvailability_Waiting = 2,      // We're waiting on a dependent resource to be acquired.  (E.g. we cannot obtain a cert until we are logged into Steam.  We cannot measure latency to relays until we have the network config.)
+  k_ESteamNetworkingAvailability_Attempting = 3,    // We're actively trying now, but are not yet successful.
 
-  k_ESteamNetworkingAvailability_Current = 100,			// Resource is online/available
+  k_ESteamNetworkingAvailability_Current = 100,      // Resource is online/available
 
 
-  k_ESteamNetworkingAvailability_Unknown = 0,			// Internal dummy/sentinel, or value is not applicable in this context
+  k_ESteamNetworkingAvailability_Unknown = 0,      // Internal dummy/sentinel, or value is not applicable in this context
   k_ESteamNetworkingAvailability__Force32bit = $7fffffff
 );
 
@@ -289,9 +293,10 @@ type ESteamNetworkingIdentityType = (
 );
 {$pop}
 
-{$PACKRECORDS 1}
 type
+{$PACKRECORDS 1}
   SteamNetworkingIPAddr = record
+{$PACKRECORDS 1}
   m_ip: record
     case integer of
       0: (m_ipv4: record
@@ -308,8 +313,7 @@ type
 
 type
   PSteamNetworkingIPAddr = ^SteamNetworkingIPAddr;
-{$PACKRECORDS 8}
-
+{$PACKRECORDS 1}
 type
  SteamNetworkingIdentity = record
   /// Type of identity.
@@ -528,6 +532,15 @@ type ESteamNetConnectionEnd =
     // to do this.
     k_ESteamNetConnectionEnd_Local_Rights = 3005,
 
+    // ICE P2P rendezvous failed because we were not able to
+    // determine our "public" address (e.g. reflexive address via STUN)
+    //
+    // If relay fallback is available (it always is on Steam), then
+    // this is only used internally and will not be returned as a high
+    // level failure.
+    k_ESteamNetConnectionEnd_Local_P2P_ICE_NoPublicAddresses = 3006,
+
+
   k_ESteamNetConnectionEnd_Local_Max = 3999,
 
   // 4xxx: Connection failed or ended, and it appears that the
@@ -570,6 +583,15 @@ type ESteamNetConnectionEnd =
     // (Probably the code you are running is too old.)
     k_ESteamNetConnectionEnd_Remote_BadProtocolVersion = 4006,
 
+    // NAT punch failed failed because we never received any public
+    // addresses from the remote host.  (But we did receive some
+    // signals form them.)
+    //
+    // If relay fallback is available (it always is on Steam), then
+    // this is only used internally and will not be returned as a high
+    // level failure.
+    k_ESteamNetConnectionEnd_Remote_P2P_ICE_NoPublicAddresses = 4007,
+
   k_ESteamNetConnectionEnd_Remote_Max = 4999,
 
   // 5xxx: Connection failed for some other reason.
@@ -602,6 +624,36 @@ type ESteamNetConnectionEnd =
     // job to open and maintain those sessions.)
     k_ESteamNetConnectionEnd_Misc_NoRelaySessionsToClient = 5006,
 
+    // While trying to initiate a connection, we never received
+    // *any* communication from the peer.
+    //k_ESteamNetConnectionEnd_Misc_ServerNeverReplied = 5007,
+
+    // P2P rendezvous failed in a way that we don't have more specific
+    // information
+    k_ESteamNetConnectionEnd_Misc_P2P_Rendezvous = 5008,
+
+    // NAT punch failed, probably due to NAT/firewall configuration.
+    //
+    // If relay fallback is available (it always is on Steam), then
+    // this is only used internally and will not be returned as a high
+    // level failure.
+    k_ESteamNetConnectionEnd_Misc_P2P_NAT_Firewall = 5009,
+
+    // Our peer replied that it has no record of the connection.
+    // This should not happen ordinarily, but can happen in a few
+    // exception cases:
+    //
+    // - This is an old connection, and the peer has already cleaned
+    //   up and forgotten about it.  (Perhaps it timed out and they
+    //   closed it and were not able to communicate this to us.)
+    // - A bug or internal protocol error has caused us to try to
+    //   talk to the peer about the connection before we received
+    //   confirmation that the peer has accepted the connection.
+    // - The peer thinks that we have closed the connection for some
+    //   reason (perhaps a bug), and believes that is it is
+    //   acknowledging our closure.
+    k_ESteamNetConnectionEnd_Misc_PeerSentNoConnection = 5010,
+
   k_ESteamNetConnectionEnd_Misc_Max = 5999,
 
   k_ESteamNetConnectionEnd__Force32Bit = $7fffffff
@@ -609,16 +661,16 @@ type ESteamNetConnectionEnd =
 
 type ESteamNetTransportKind =
 (
-	k_ESteamNetTransport_Unknown = 0,
-	k_ESteamNetTransport_LoopbackBuffers = 1, // Internal buffers, not using OS network stack
-	k_ESteamNetTransport_LocalHost = 2, // Using OS network stack to talk to localhost address
-	k_ESteamNetTransport_UDP = 3, // Ordinary UDP connection, remote address is not a LAN address
-	k_ESteamNetTransport_UDPLan = 4, // Ordinary UDP connection, remote address is a LAN address
-	k_ESteamNetTransport_TURN = 5, // Relayed over TURN server
-	k_ESteamNetTransport_SDRP2P = 6, // P2P connection relayed over Steam Datagram Relay
-	k_ESteamNetTransport_SDRHostedServer = 7, // Connection to a server hosted in a known data center via Steam Datagram Relay
+  k_ESteamNetTransport_Unknown = 0,
+  k_ESteamNetTransport_LoopbackBuffers = 1, // Internal buffers, not using OS network stack
+  k_ESteamNetTransport_LocalHost = 2, // Using OS network stack to talk to localhost address
+  k_ESteamNetTransport_UDP = 3, // Ordinary UDP connection, remote address is not a LAN address
+  k_ESteamNetTransport_UDPLan = 4, // Ordinary UDP connection, remote address is a LAN address
+  k_ESteamNetTransport_TURN = 5, // Relayed over TURN server
+  k_ESteamNetTransport_SDRP2P = 6, // P2P connection relayed over Steam Datagram Relay
+  k_ESteamNetTransport_SDRHostedServer = 7, // Connection to a server hosted in a known data center via Steam Datagram Relay
 
-	k_ESteamNetTransport_Force32Bit = $7fffffff
+  k_ESteamNetTransport_Force32Bit = $7fffffff
 );
 
 {$pop}
@@ -667,19 +719,21 @@ type SteamNetConnectionInfo_t = record
   /// have some details specific to the issue.
   m_szEndDebug: array [0..127] of Char;
 
-  /// Debug description.  This includes the connection handle,
-  /// connection type (and peer information), and the app name.
-  /// This string is used in various internal logging messages
+  /// Debug description.  This includes the internal connection ID,
+  /// connection type (and peer information), and any name
+  /// given to the connection by the app.  This string is used in various
+  /// internal logging messages.
   m_szConnectionDescription: array[0..127] of Char;
 
-  {$IFNDEF STEAM}
+  /// What kind of transport is currently being used?
+  /// Note that this is potentially a dynamic property!  Also, it may not
+  /// always be available, especially right as the connection starts, or
+  /// after the connection ends.
   m_eTransportKind: ESteamNetTransportKind;
 
   /// Internal stuff, room to change API easily
   //reserved: array[0..62] of uint32;
-  {$ELSE}
-  reserved: array[0..63] of uint32;
-  {$ENDIF}
+  reserved: array[0..62] of uint32;
 end;
 
 type
@@ -739,7 +793,7 @@ type SteamNetworkingQuickConnectionStatus = record
   ///
   /// In general, the estimated delay will be approximately equal to
   ///
-  ///		(m_cbPendingUnreliable+m_cbPendingReliable) / m_nSendRateBytesPerSecond
+  ///    (m_cbPendingUnreliable+m_cbPendingReliable) / m_nSendRateBytesPerSecond
   ///
   /// plus or minus one MTU.  It depends on how much time has elapsed since the last
   /// packet was put on the wire.  For example, the queue might have *just* been emptied,
@@ -935,6 +989,27 @@ const k_nSteamNetworkingSend_Reliable: Integer = 8;
 // Otherwise you will probably just make performance worse.
 const k_nSteamNetworkingSend_UseCurrentThread: Integer = 16;
 
+// When sending a message using ISteamNetworkingMessages, automatically re-establish
+// a broken session, without returning k_EResultNoConnection.  Without this flag,
+// if you attempt to send a message, and the session was proactively closed by the
+// peer, or an error occurred that disrupted communications, then you must close the
+// session using ISteamNetworkingMessages::CloseSessionWithUser before attempting to
+// send another message.  (Or you can simply add this flag and retry.)  In this way,
+// the disruption cannot go unnoticed, and a more clear order of events can be
+// ascertained. This is especially important when reliable messages are used, since
+// if the connection is disrupted, some of those messages will not have been delivered,
+// and it is in general not possible to know which.  Although a
+// SteamNetworkingMessagesSessionFailed_t callback will be posted when an error occurs
+// to notify you that a failure has happened, callbacks are asynchronous, so it is not
+// possible to tell exactly when it happened.  And because the primary purpose of
+// ISteamNetworkingMessages is to be like UDP, there is no notification when a peer closes
+// the session.
+//
+// If you are not using any reliable messages (e.g. you are using ISteamNetworkingMessages
+// exactly as a transport replacement for UDP-style datagrams only), you may not need to
+// know when an underlying connection fails, and so you may not need this notification.
+const k_nSteamNetworkingSend_AutoRestartBrokenSession: Integer = 32;
+
 //
 // Ping location / measurement
 //
@@ -1008,7 +1083,7 @@ type ESteamNetworkingConfigDataType = (
   k_ESteamNetworkingConfig_Int64 = 2,
   k_ESteamNetworkingConfig_Float = 3,
   k_ESteamNetworkingConfig_String = 4,
-  k_ESteamNetworkingConfig_FunctionPtr = 5, // NOTE: When setting	callbacks, you should put the pointer into a variable and pass a pointer to that variable.
+  k_ESteamNetworkingConfig_Ptr = 5, // NOTE: When setting  callbacks, you should put the pointer into a variable and pass a pointer to that variable.
 
   k_ESteamNetworkingConfigDataType__Force32Bit = $7fffffff
 );
@@ -1116,28 +1191,200 @@ type ESteamNetworkingConfigValue = (
   /// (This flag is itself a dev variable.)
   k_ESteamNetworkingConfig_EnumerateDevVars = 35,
 
+  /// [connection int32] Set this to 1 on outbound connections and listen sockets,
+  /// to enable "symmetric connect mode", which is useful in the following
+  /// common peer-to-peer use case:
+  ///
+  /// - The two peers are "equal" to each other.  (Neither is clearly the "client"
+  ///   or "server".)
+  /// - Either peer may initiate the connection, and indeed they may do this
+  ///   at the same time
+  /// - The peers only desire a single connection to each other, and if both
+  ///   peers initiate connections simultaneously, a protocol is needed for them
+  ///   to resolve the conflict, so that we end up with a single connection.
+  ///
+  /// This use case is both common, and involves subtle race conditions and tricky
+  /// pitfalls, which is why the API has support for dealing with it.
+  ///
+  /// If an incoming connection arrives on a listen socket or via custom signaling,
+  /// and the application has not attempted to make a matching outbound connection
+  /// in symmetric mode, then the incoming connection can be accepted as usual.
+  /// A "matching" connection means that the relevant endpoint information matches.
+  /// (At the time this comment is being written, this is only supported for P2P
+  /// connections, which means that the peer identities must match, and the virtual
+  /// port must match.  At a later time, symmetric mode may be supported for other
+  /// connection types.)
+  ///
+  /// If connections are initiated by both peers simultaneously, race conditions
+  /// can arise, but fortunately, most of them are handled internally and do not
+  /// require any special awareness from the application.  However, there
+  /// is one important case that application code must be aware of:
+  /// If application code attempts an outbound connection using a ConnectXxx
+  /// function in symmetric mode, and a matching incoming connection is already
+  /// waiting on a listen socket, then instead of forming a new connection,
+  /// the ConnectXxx call will accept the existing incoming connection, and return
+  /// a connection handle to this accepted connection.
+  /// IMPORTANT: in this case, a SteamNetConnectionStatusChangedCallback_t
+  /// has probably *already* been posted to the queue for the incoming connection!
+  /// (Once callbacks are posted to the queue, they are not modified.)  It doesn't
+  /// matter if the callback has not been consumed by the app.  Thus, application
+  /// code that makes use of symmetric connections must be aware that, when processing a
+  /// SteamNetConnectionStatusChangedCallback_t for an incoming connection, the
+  /// m_hConn may refer to a new connection that the app has has not
+  /// seen before (the usual case), but it may also refer to a connection that
+  /// has already been accepted implicitly through a call to Connect()!  In this
+  /// case, AcceptConnection() will return k_EResultDuplicateRequest.
+  ///
+  /// Only one symmetric connection to a given peer (on a given virtual port)
+  /// may exist at any given time.  If client code attempts to create a connection,
+  /// and a (live) connection already exists on the local host, then either the
+  /// existing connection will be accepted as described above, or the attempt
+  /// to create a new connection will fail.  Furthermore, linger mode functionality
+  /// is not supported on symmetric connections.
+  ///
+  /// A more complicated race condition can arise if both peers initiate a connection
+  /// at roughly the same time.  In this situation, each peer will receive an incoming
+  /// connection from the other peer, when the application code has already initiated
+  /// an outgoing connection to that peer.  The peers must resolve this conflict and
+  /// decide who is going to act as the "server" and who will act as the "client".
+  /// Typically the application does not need to be aware of this case as it is handled
+  /// internally.  On both sides, the will observe their outbound connection being
+  /// "accepted", although one of them one have been converted internally to act
+  /// as the "server".
+  ///
+  /// In general, symmetric mode should be all-or-nothing: do not mix symmetric
+  /// connections with a non-symmetric connection that it might possible "match"
+  /// with.  If you use symmetric mode on any connections, then both peers should
+  /// use it on all connections, and the corresponding listen socket, if any.  The
+  /// behaviour when symmetric and ordinary connections are mixed is not defined by
+  /// this API, and you should not rely on it.  (This advice only applies when connections
+  /// might possibly "match".  For example, it's OK to use all symmetric mode
+  /// connections on one virtual port, and all ordinary, non-symmetric connections
+  /// on a different virtual port, as there is no potential for ambiguity.)
+  ///
+  /// When using the feature, you should set it in the following situations on
+  /// applicable objects:
+  ///
+  /// - When creating an outbound connection using ConnectXxx function
+  /// - When creating a listen socket.  (Note that this will automatically cause
+  ///   any accepted connections to inherit the flag.)
+  /// - When using custom signaling, before accepting an incoming connection.
+  ///
+  /// Setting the flag on listen socket and accepted connections will enable the
+  /// API to automatically deal with duplicate incoming connections, even if the
+  /// local host has not made any outbound requests.  (In general, such duplicate
+  /// requests from a peer are ignored internally and will not be visible to the
+  /// application code.  The previous connection must be closed or resolved first.)
+  k_ESteamNetworkingConfig_SymmetricConnect = 37,
 
-  //	/// [listen socket int32] When you create a P2P listen socket, we will automatically
-  //	/// open up a UDP port to listen for LAN connections.  LAN connections can be made
-  //	/// without any signaling: both sides can be disconnected from the Internet.
-  //	///
-  //	/// This value can be set to zero to disable the feature.
-  //	k_ESteamNetworkingConfig_P2P_Discovery_Server_LocalPort = 101,
+  /// [connection int32] For connection types that use "virtual ports", this can be used
+  /// to assign a local virtual port.  For incoming connections, this will always be the
+  /// virtual port of the listen socket (or the port requested by the remote host if custom
+  /// signaling is used and the connection is accepted), and cannot be changed.  For
+  /// connections initiated locally, the local virtual port will default to the same as the
+  /// requested remote virtual port, if you do not specify a different option when creating
+  /// the connection.  The local port is only relevant for symmetric connections, when
+  /// determining if two connections "match."  In this case, if you need the local and remote
+  /// port to differ, you can set this value.
+  ///
+  /// You can also read back this value on listen sockets.
+  ///
+  /// This value should not be read or written in any other context.
+  k_ESteamNetworkingConfig_LocalVirtualPort = 38,
+
   //
-  //	/// [connection int32] P2P connections can perform broadcasts looking for the peer
-  //	/// on the LAN.
-  //	k_ESteamNetworkingConfig_P2P_Discovery_Client_RemotePort = 102,
+  // Callbacks
+  //
 
-    /// [connection string] Comma-separated list of STUN servers that can be used
-    /// for NAT piercing.  If you set this to an empty string, NAT piercing will
-    /// not be attempted
-    k_ESteamNetworkingConfig_P2P_STUN_ServerList = 103,
+  // On Steam, you may use the default Steam callback dispatch mechanism.  If you prefer
+  // to not use this dispatch mechanism (or you are not running with Steam), or you want
+  // to associate specific functions with specific listen sockets or connections, you can
+  // register them as configuration values.
+  //
+  // Note also that ISteamNetworkingUtils has some helpers to set these globally.
 
-  //	/// [connection string] Comma-separated list of TURN servers that can be used
-  //	/// for relay.  If you set this to an empty string, relaying over TURN will
-  //	/// not be attempted
-  //	k_ESteamNetworkingConfig_P2P_TURN_ServerList = 104,
+  /// [connection FnSteamNetConnectionStatusChanged] Callback that will be invoked
+  /// when the state of a connection changes.
+  ///
+  /// IMPORTANT: callbacks are dispatched to the handler that is in effect at the time
+  /// the event occurs, which might be in another thread.  For example, immediately after
+  /// creating a listen socket, you may receive an incoming connection.  And then immediately
+  /// after this, the remote host may close the connection.  All of this could happen
+  /// before the function to create the listen socket has returned.  For this reason,
+  /// callbacks usually must be in effect at the time of object creation.  This means
+  /// you should set them when you are creating the listen socket or connection, or have
+  /// them in effect so they will be inherited at the time of object creation.
+  ///
+  /// For example:
+  ///
+  /// exterm void MyStatusChangedFunc( SteamNetConnectionStatusChangedCallback_t *info );
+  /// SteamNetworkingConfigValue_t opt; opt.SetPtr( k_ESteamNetworkingConfig_Callback_ConnectionStatusChanged, MyStatusChangedFunc );
+  /// SteamNetworkingIPAddr localAddress; localAddress.Clear();
+  /// HSteamListenSocket hListenSock = SteamNetworkingSockets()->CreateListenSocketIP( localAddress, 1, &opt );
+  ///
+  /// When accepting an incoming connection, there is no atomic way to switch the
+  /// callback.  However, if the connection is DOA, AcceptConnection() will fail, and
+  /// you can fetch the state of the connection at that time.
+  ///
+  /// If all connections and listen sockets can use the same callback, the simplest
+  /// method is to set it globally before you create any listen sockets or connections.
+  k_ESteamNetworkingConfig_Callback_ConnectionStatusChanged = 201,
 
+  /// [global FnSteamNetAuthenticationStatusChanged] Callback that will be invoked
+  /// when our auth state changes.  If you use this, install the callback before creating
+  /// any connections or listen sockets, and don't change it.
+  /// See: ISteamNetworkingUtils::SetGlobalCallback_SteamNetAuthenticationStatusChanged
+  k_ESteamNetworkingConfig_Callback_AuthStatusChanged = 202,
+
+  /// [global FnSteamRelayNetworkStatusChanged] Callback that will be invoked
+  /// when our auth state changes.  If you use this, install the callback before creating
+  /// any connections or listen sockets, and don't change it.
+  /// See: ISteamNetworkingUtils::SetGlobalCallback_SteamRelayNetworkStatusChanged
+  k_ESteamNetworkingConfig_Callback_RelayNetworkStatusChanged = 203,
+
+  /// [global FnSteamNetworkingMessagesSessionRequest] Callback that will be invoked
+  /// when a peer wants to initiate a SteamNetworkingMessagesSessionRequest.
+  /// See: ISteamNetworkingUtils::SetGlobalCallback_MessagesSessionRequest
+  k_ESteamNetworkingConfig_Callback_MessagesSessionRequest = 204,
+
+  /// [global FnSteamNetworkingMessagesSessionFailed] Callback that will be invoked
+  /// when a session you have initiated, or accepted either fails to connect, or loses
+  /// connection in some unexpected way.
+  /// See: ISteamNetworkingUtils::SetGlobalCallback_MessagesSessionFailed
+  k_ESteamNetworkingConfig_Callback_MessagesSessionFailed = 205,
+
+  //
+  // P2P settings
+  //
+
+//	/// [listen socket int32] When you create a P2P listen socket, we will automatically
+//	/// open up a UDP port to listen for LAN connections.  LAN connections can be made
+//	/// without any signaling: both sides can be disconnected from the Internet.
+//	///
+//	/// This value can be set to zero to disable the feature.
+//	k_ESteamNetworkingConfig_P2P_Discovery_Server_LocalPort = 101,
+//
+//	/// [connection int32] P2P connections can perform broadcasts looking for the peer
+//	/// on the LAN.
+//	k_ESteamNetworkingConfig_P2P_Discovery_Client_RemotePort = 102,
+
+  /// [connection string] Comma-separated list of STUN servers that can be used
+  /// for NAT piercing.  If you set this to an empty string, NAT piercing will
+  /// not be attempted.  Also if "public" candidates are not allowed for
+  /// P2P_Transport_ICE_Enable, then this is ignored.
+  k_ESteamNetworkingConfig_P2P_STUN_ServerList = 103,
+
+  /// [connection int32] What types of ICE candidates to share with the peer.
+  /// See k_nSteamNetworkingConfig_P2P_Transport_ICE_Enable_xxx values
+  k_ESteamNetworkingConfig_P2P_Transport_ICE_Enable = 104,
+
+  /// [connection int32] When selecting P2P transport, add various
+  /// penalties to the scores for selected transports.  (Route selection
+  /// scores are on a scale of milliseconds.  The score begins with the
+  /// route ping time and is then adjusted.)
+  k_ESteamNetworkingConfig_P2P_Transport_ICE_Penalty = 105,
+  k_ESteamNetworkingConfig_P2P_Transport_SDR_Penalty = 106,
+  //k_ESteamNetworkingConfig_P2P_Transport_LANBeacon_Penalty = 107,
 
   //
   // Settings for SDR relayed connections
@@ -1189,11 +1436,15 @@ type ESteamNetworkingConfigValue = (
   k_ESteamNetworkingConfig_SDRClient_FakeClusterPing = 36,
 
   //
-  // Log levels for debuging information.  A higher priority
-  // (lower numeric value) will cause more stuff to be printed.
+  // Log levels for debugging information of various subsystems.
+  // Higher numeric values will cause more stuff to be printed.
+  // See ISteamNetworkingUtils::SetDebugOutputFunction for more
+  // information
+  //
+  // The default for all values is k_ESteamNetworkingSocketsDebugOutputType_Warning.
   //
   k_ESteamNetworkingConfig_LogLevel_AckRTT = 13, // [connection int32] RTT calculations for inline pings and replies
-  k_ESteamNetworkingConfig_LogLevel_PacketDecode = 14, // [connection int32] log SNP packets send
+  k_ESteamNetworkingConfig_LogLevel_PacketDecode = 14, // [connection int32] log SNP packets send/recv
   k_ESteamNetworkingConfig_LogLevel_Message = 15, // [connection int32] log each message send/recv
   k_ESteamNetworkingConfig_LogLevel_PacketGaps = 16, // [connection int32] dropped packets
   k_ESteamNetworkingConfig_LogLevel_P2PRendezvous = 17, // [connection int32] P2P rendezvous messages
@@ -1248,8 +1499,8 @@ type PSteamNetworkingConfigValue_t = ^SteamNetworkingConfigValue_t;
 {$push}
 {$notes off}
 type ESteamNetworkingGetConfigValueResult = (
-  k_ESteamNetworkingGetConfigValue_BadValue = -1,	// No such configuration value
-  k_ESteamNetworkingGetConfigValue_BadScopeObj = -2,	// Bad connection handle, etc
+  k_ESteamNetworkingGetConfigValue_BadValue = -1,  // No such configuration value
+  k_ESteamNetworkingGetConfigValue_BadScopeObj = -2,  // Bad connection handle, etc
   k_ESteamNetworkingGetConfigValue_BufferTooSmall = -3, // Couldn't fit the result in your buffer
   k_ESteamNetworkingGetConfigValue_OK = 1,
   k_ESteamNetworkingGetConfigValue_OKInherited = 2, // A value was not set at this level, but the effective (inherited) value was returned.
@@ -1352,9 +1603,11 @@ type PSteamNetAuthenticationStatus_t = ^SteamNetAuthenticationStatus_t;
 
 type FSteamNetworkingSocketsDebugOutput = procedure (nType: ESteamNetworkingSocketsDebugOutputType; pszMsg: PChar); cdecl;
 
-//type FSteamNetConnectionStatusChangedCallback = procedure(pInfo: PSteamNetConnectionStatusChangedCallback_t; context: intptr); cdecl;
-type FSteamNetConnectionStatusChangedCallback = procedure(pInfo: PSteamNetConnectionStatusChangedCallback_t; context: intptr); cdecl;
-
+type FnSteamNetConnectionStatusChanged = procedure(pInfo: PSteamNetConnectionStatusChangedCallback_t); cdecl;
+type FnSteamNetAuthenticationStatusChanged = procedure(pInfo: PSteamNetAuthenticationStatus_t); cdecl;
+type FnSteamRelayNetworkStatusChanged = procedure(pInfo: PSteamRelayNetworkStatus_t); cdecl;
+type FnSteamNetworkingMessagesSessionRequest = procedure(pInfo: PSteamNetworkingMessagesSessionRequest_t); cdecl;
+type FnSteamNetworkingMessagesSessionFailed = procedure(pInfo: PSteamRelayNetworkStatus_t); cdecl;
 
 {$IFNDEF STEAM}
 // Initialize the library.  Optionally, you can set an initial identity for the default
@@ -1369,7 +1622,7 @@ function SteamNetworkingSockets(): ISteamNetworkingSockets; cdecl; external GNSL
 function SteamNetworkingUtils(): ISteamNetworkingUtils; cdecl; external GNSLIB;
 
 
-function SteamAPI_SteamNetworkingSockets_v008(): ISteamNetworkingSockets; cdecl; external GNSLIB;
+function SteamAPI_SteamNetworkingSockets_v009(): ISteamNetworkingSockets; cdecl; external GNSLIB;
 function SteamAPI_SteamNetworkingUtils_v003(): ISteamNetworkingUtils; cdecl; external GNSLIB;
 
 //
@@ -1411,7 +1664,7 @@ function SteamAPI_ISteamNetworkingSockets_ReceiveMessagesOnPollGroup(instancePtr
 
 function SteamAPI_ISteamNetworkingSockets_InitAuthentication(instancePtr: ISteamNetworkingSockets): ESteamNetworkingAvailability; cdecl; external GNSLIB;
 function SteamAPI_ISteamNetworkingSockets_GetAuthenticationStatus(instancePtr: ISteamNetworkingSockets; pDetails: PSteamNetAuthenticationStatus_t): ESteamNetworkingAvailability; cdecl; external GNSLIB;
-procedure SteamAPI_ISteamNetworkingSockets_RunConnectionStatusChangedCallbacks(instancePtr: ISteamNetworkingSockets; callback: FSteamNetConnectionStatusChangedCallback; context: intptr); cdecl; external GNSLIB;
+procedure SteamAPI_ISteamNetworkingSockets_RunCallbacks(instancePtr: ISteamNetworkingSockets); cdecl; external GNSLIB;
 
 
 procedure SteamAPI_SteamNetworkingIPAddr_Clear(pThis: PSteamNetworkingIPAddr); cdecl; external GNSLIB;
@@ -1455,6 +1708,18 @@ function SteamAPI_SteamNetworkingIdentity_ParseString(pIdentity: PSteamNetworkin
 //
 function SteamAPI_ISteamNetworkingUtils_AllocateMessage(instancePtr: ISteamNetworkingUtils; cbAllocateBuffer: Integer): PSteamNetworkingMessage_t; cdecl; external GNSLIB;
 function SteamAPI_ISteamNetworkingUtils_GetLocalTimestamp(instancePtr: ISteamNetworkingUtils): SteamNetworkingMicroseconds; cdecl; external GNSLIB;
+
+function SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueInt32(instancePtr: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; val: Integer): Boolean; cdecl; external GNSLIB;
+function SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueFloat(instancePtr: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; val: Single): Boolean; cdecl; external GNSLIB;
+function SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueString(instancePtr: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; val: PChar): Boolean; cdecl; external GNSLIB;
+function SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValuePtr(instancePtr: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; val: Pointer): Boolean; cdecl; external GNSLIB;
+function SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueInt32(instancePtr: ISteamNetworkingUtils; hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: Integer): Boolean; cdecl; external GNSLIB;
+function SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueFloat(instancePtr: ISteamNetworkingUtils; hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: Single): Boolean; cdecl; external GNSLIB;
+function SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueString(instancePtr: ISteamNetworkingUtils; hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: PChar): Boolean; cdecl; external GNSLIB;
+function SteamAPI_ISteamNetworkingUtils_SetGlobalCallback_SteamNetConnectionStatusChanged(instancePtr: ISteamNetworkingUtils; fnCallback: FnSteamNetConnectionStatusChanged): Boolean; cdecl; external GNSLIB;
+function SteamAPI_ISteamNetworkingUtils_SetGlobalCallback_SteamNetAuthenticationStatusChanged(instancePtr: ISteamNetworkingUtils; fnCallback: FnSteamNetAuthenticationStatusChanged): Boolean; cdecl; external GNSLIB;
+function SteamAPI_ISteamNetworkingUtils_SetGlobalCallback_SteamRelayNetworkStatusChanged(instancePtr: ISteamNetworkingUtils; fnCallback: FnSteamRelayNetworkStatusChanged): Boolean; cdecl; external GNSLIB;
+
 procedure SteamAPI_ISteamNetworkingUtils_SetDebugOutputFunction(instancePtr: ISteamNetworkingUtils; eDetailLevel: ESteamNetworkingSocketsDebugOutputType; pfnFunc: FSteamNetworkingSocketsDebugOutput); cdecl; external GNSLIB;
 function SteamAPI_ISteamNetworkingUtils_SetConfigValue(instancePtr: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; eScopeType: ESteamNetworkingConfigScope; scopeObj: intptr;
   eDataType: ESteamNetworkingConfigDataType; const pValue: Pointer): Boolean; cdecl; external GNSLIB;
@@ -1486,14 +1751,10 @@ type
     function GetConnectionUserData(hPeer: HSteamNetConnection): Int64;
     procedure SetConnectionName(hPeer: HSteamNetConnection; pszName: PChar);
     function GetConnectionName(hPeer: HSteamNetConnection; pszName: PChar; nMaxLen: Integer): Boolean;
-    //function SendMessageToConnection(hConn: HSteamNetConnection; const pData: Pointer; cbData: uint32; nSendFlags: Integer): EResult;
     function SendMessageToConnection(hConn: HSteamNetConnection; pData: Pointer; cbData: uint32; nSendFlags: Integer; pOutMessageNumber: PInt64): EResult;
     procedure SendMessages(nMessages: Integer; const pMessages: PSteamNetworkingMessage_t; pOutMessageNumberOrResult: PInt64);
     function FlushMessagesOnConnection(hConn: HSteamNetConnection): EResult;
     function ReceiveMessagesOnConnection(hConn: HSteamNetConnection; ppOutMessages: PSteamNetworkingMessage_t; nMaxMessages: Integer): Integer;
-    {$IFDEF STEAM}
-    //function ReceiveMessagesOnListenSocket(hSocket: HSteamListenSocket; ppOutMessages: PSteamNetworkingMessage_t; nMaxMessages: Integer): Integer;
-    {$ENDIF}
     function GetConnectionInfo(hConn: HSteamNetConnection; pInfo: PSteamNetConnectionInfo_t): Boolean;
     function GetQuickConnectionStatus(hConn: HSteamNetConnection; pStats: PSteamNetworkingQuickConnectionStatus): Boolean;
     function GetDetailedConnectionStatus(hConn: HSteamNetConnection; pszBuf: PChar; cbBuf: Integer): Integer;
@@ -1510,7 +1771,7 @@ type
     function ReceiveMessagesOnPollGroup(hPollGroup: HSteamNetPollGroup; ppOutMessages: PSteamNetworkingMessage_t; nMaxMessages: Integer): Integer;
 
     {$IFNDEF STEAM}
-    procedure RunConnectionStatusChangedCallbacks(callback: FSteamNetConnectionStatusChangedCallback; context: intptr);
+    procedure RunCallbacks();
     {$ENDIF}
 
     {$IFDEF STEAM}
@@ -1549,15 +1810,17 @@ type
     function GetLocalTimestamp(): SteamNetworkingMicroseconds;cdecl;
     procedure SetDebugOutputFunction(eDetailLevel: ESteamNetworkingSocketsDebugOutputType; pfnFunc: FSteamNetworkingSocketsDebugOutput); cdecl;
 
-    {$IFDEF STEAM2}
-    //function SetGlobalConfigValueInt32(eValue: ESteamNetworkingConfigValue; val: int32): Boolean;cdecl;
-    //function SetGlobalConfigValueFloat(eValue: ESteamNetworkingConfigValue; val: Single): Boolean;cdecl;
-    //function SetGlobalConfigValueString(eValue: ESteamNetworkingConfigValue; val: PChar): Boolean;cdecl;
-    //function SetConnectionConfigValueInt32(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: int32): Boolean;cdecl;
-    //function SetConnectionConfigValueFloat(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: int32): Boolean;cdecl;
-    //function SetConnectionConfigValueString(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: int32): Boolean;cdecl;
+    function SetGlobalConfigValueInt32(eValue: ESteamNetworkingConfigValue; val: int32): Boolean;cdecl;
+    function SetGlobalConfigValueFloat(eValue: ESteamNetworkingConfigValue; val: Single): Boolean;cdecl;
+    function SetGlobalConfigValueString(eValue: ESteamNetworkingConfigValue; val: PChar): Boolean;cdecl;
+    function SetGlobalConfigValuePtr(eValue: ESteamNetworkingConfigValue; val: Pointer): Boolean; cdecl;
+    function SetConnectionConfigValueInt32(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: int32): Boolean;cdecl;
+    function SetConnectionConfigValueFloat(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: Single): Boolean;cdecl;
+    function SetConnectionConfigValueString(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: PChar): Boolean;cdecl;
+    function SetGlobalCallback_SteamNetConnectionStatusChanged(fnCallback: FnSteamNetConnectionStatusChanged): Boolean;
+    function SetGlobalCallback_SteamNetAuthenticationStatusChanged(fnCallback: FnSteamNetAuthenticationStatusChanged): Boolean;
+    function SetGlobalCallback_SteamRelayNetworkStatusChanged(fnCallback: FnSteamRelayNetworkStatusChanged): Boolean;
 
-    {$ENDIF}
     function SetConfigValue(eValue: ESteamNetworkingConfigValue; eScopeType: ESteamNetworkingConfigScope; scopeObj: intptr;
       eDataType: ESteamNetworkingConfigDataType; const pValue: Pointer): Boolean;
 
@@ -1625,11 +1888,7 @@ begin
     raise Exception.Create('GameNetworkingSockets_Init has failed: ' + PChar(ErrorMsg));
   {$ENDIF}
 
-  {$IF Defined(SERVER) AND Defined(STEAM)}
-  GameNetworkingSocketsInterface := SteamAPI_SteamGameServerNetworkingSockets_v008();
-  {$ELSE}
-  GameNetworkingSocketsInterface := SteamAPI_SteamNetworkingSockets_v008();
-  {$ENDIF}
+  GameNetworkingSocketsInterface := SteamAPI_SteamNetworkingSockets_v009();
 
   if GameNetworkingSocketsInterface = nil then
     raise Exception.Create('GameNetworkingSocketsInterface is null');
@@ -1744,9 +2003,9 @@ begin
   Result := SteamAPI_ISteamNetworkingSockets_GetAuthenticationStatus(GameNetworkingSocketsInterface, pDetails);
 end;
 {$IFNDEF STEAM}
-procedure TSteamNetworkingSockets.RunConnectionStatusChangedCallbacks(callback: FSteamNetConnectionStatusChangedCallback; context: intptr);
+procedure TSteamNetworkingSockets.RunCallbacks();
 begin
-  SteamAPI_ISteamNetworkingSockets_RunConnectionStatusChangedCallbacks(GameNetworkingSocketsInterface, callback, context);
+  SteamAPI_ISteamNetworkingSockets_RunCallbacks(GameNetworkingSocketsInterface);
 end;
 {$ENDIF}
 
@@ -1773,6 +2032,46 @@ end;
 procedure TSteamNetworkingUtils.SetDebugOutputFunction(eDetailLevel: ESteamNetworkingSocketsDebugOutputType; pfnFunc: FSteamNetworkingSocketsDebugOutput);
 begin
   SteamAPI_ISteamNetworkingUtils_SetDebugOutputFunction(GameNetworkingUtilsInterface, eDetailLevel, pfnFunc);
+end;
+function TSteamNetworkingUtils.SetGlobalConfigValueInt32(eValue: ESteamNetworkingConfigValue; val: int32): Boolean;
+begin
+  Result := SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueInt32(GameNetworkingUtilsInterface, eValue, val);
+end;
+function TSteamNetworkingUtils.SetGlobalConfigValueFloat(eValue: ESteamNetworkingConfigValue; val: Single): Boolean;
+begin
+  Result := SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueFloat(GameNetworkingUtilsInterface, eValue, val);
+end;
+function TSteamNetworkingUtils.SetGlobalConfigValueString(eValue: ESteamNetworkingConfigValue; val: PChar): Boolean;
+begin
+  Result := SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueString(GameNetworkingUtilsInterface, eValue, val);
+end;
+function TSteamNetworkingUtils.SetGlobalConfigValuePtr(eValue: ESteamNetworkingConfigValue; val: Pointer): Boolean;
+begin
+  Result := SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValuePtr(GameNetworkingUtilsInterface, eValue, val);
+end;
+function TSteamNetworkingUtils.SetConnectionConfigValueInt32(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: int32): Boolean;
+begin
+  Result := SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueInt32(GameNetworkingUtilsInterface, hConn, eValue, val);
+end;
+function TSteamNetworkingUtils.SetConnectionConfigValueFloat(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: Single): Boolean;
+begin
+  Result := SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueFloat(GameNetworkingUtilsInterface, hConn, eValue, val);
+end;
+function TSteamNetworkingUtils.SetConnectionConfigValueString(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: PChar): Boolean;
+begin
+  Result := SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueString(GameNetworkingUtilsInterface, hConn, eValue, val);
+end;
+function TSteamNetworkingUtils.SetGlobalCallback_SteamNetConnectionStatusChanged(fnCallback: FnSteamNetConnectionStatusChanged): Boolean;
+begin
+  Result := SteamAPI_ISteamNetworkingUtils_SetGlobalCallback_SteamNetConnectionStatusChanged(GameNetworkingUtilsInterface, fnCallback);
+end;
+function TSteamNetworkingUtils.SetGlobalCallback_SteamNetAuthenticationStatusChanged(fnCallback: FnSteamNetAuthenticationStatusChanged): Boolean;
+begin
+  Result := SteamAPI_ISteamNetworkingUtils_SetGlobalCallback_SteamNetAuthenticationStatusChanged(GameNetworkingUtilsInterface, fnCallback);
+end;
+function TSteamNetworkingUtils.SetGlobalCallback_SteamRelayNetworkStatusChanged(fnCallback: FnSteamRelayNetworkStatusChanged): Boolean;
+begin
+  Result := SteamAPI_ISteamNetworkingUtils_SetGlobalCallback_SteamRelayNetworkStatusChanged(GameNetworkingUtilsInterface, fnCallback);
 end;
 function TSteamNetworkingUtils.SetConfigValue(eValue: ESteamNetworkingConfigValue; eScopeType: ESteamNetworkingConfigScope; scopeObj: intptr;
   eDataType: ESteamNetworkingConfigDataType; const pValue: Pointer): Boolean;

--- a/shared/libs/SteamWrapper/Steam.pas
+++ b/shared/libs/SteamWrapper/Steam.pas
@@ -4,7 +4,7 @@
 {                                                       }
 {       Copyright (c) 2020 Soldat Team                  }
 {                                                       }
-{       For use with SteamWorks SDK 1.48a               }
+{       For use with SteamWorks SDK 1.50                }
 {                                                       }
 {*******************************************************}
 
@@ -109,7 +109,7 @@ function SteamAPI_ISteamClient_GetISteamParties(SteamInterface: ISteamClient; hS
 function SteamAPI_ISteamClient_GetISteamRemotePlay(SteamInterface: ISteamClient; hSteamUser: HSteamUser; hSteamPipe: HSteamPipe; pchVersion: PChar): ISteamRemotePlay; cdecl; external STEAMLIB;
 
 
-function SteamAPI_SteamUser_v020(): ISteamUser; cdecl; external STEAMLIB;
+function SteamAPI_SteamUser_v021(): ISteamUser; cdecl; external STEAMLIB;
 
 function SteamAPI_ISteamUser_GetHSteamUser(SteamInterface: ISteamUser): HSteamUser; cdecl; external STEAMLIB;
 function SteamAPI_ISteamUser_BLoggedOn(SteamInterface: ISteamUser): Boolean; cdecl; external STEAMLIB;
@@ -222,8 +222,8 @@ function SteamAPI_ISteamFriends_GetNumChatsWithUnreadPriorityMessages(SteamInter
 procedure SteamAPI_ISteamFriends_ActivateGameOverlayRemotePlayTogetherInviteDialog(SteamInterface: ISteamFriends; steamIDLobby: TSteamID); cdecl; external STEAMLIB;
 
 
-function SteamAPI_SteamUtils_v009(): ISteamUtils; cdecl; external STEAMLIB;
-function SteamAPI_SteamGameServerUtils_v009(): ISteamUtils; cdecl; external STEAMLIB;
+function SteamAPI_SteamUtils_v010(): ISteamUtils; cdecl; external STEAMLIB;
+function SteamAPI_SteamGameServerUtils_v010(): ISteamUtils; cdecl; external STEAMLIB;
 
 function SteamAPI_ISteamUtils_GetSecondsSinceAppActive(SteamInterface: ISteamUtils): uint32; cdecl; external STEAMLIB;
 function SteamAPI_ISteamUtils_GetSecondsSinceComputerActive(SteamInterface: ISteamUtils): uint32; cdecl; external STEAMLIB;
@@ -982,8 +982,8 @@ function SteamAPI_ISteamRemotePlay_BGetSessionClientResolution(SteamInterface: I
 function SteamAPI_ISteamRemotePlay_BSendRemotePlayTogetherInvite(SteamInterface: ISteamRemotePlay; steamIDFriend: TSteamID): Boolean; cdecl; external STEAMLIB;
 
 
-function SteamAPI_SteamNetworkingSockets_v008(): ISteamNetworkingSockets; cdecl; external STEAMLIB;
-function SteamAPI_SteamGameServerNetworkingSockets_v008(): ISteamNetworkingSockets; cdecl; external STEAMLIB;
+function SteamAPI_SteamNetworkingSockets_v009(): ISteamNetworkingSockets; cdecl; external STEAMLIB;
+function SteamAPI_SteamGameServerNetworkingSockets_v009(): ISteamNetworkingSockets; cdecl; external STEAMLIB;
 
 function SteamAPI_ISteamNetworkingSockets_CreateListenSocketIP(SteamInterface: ISteamNetworkingSockets; localAddress: PSteamNetworkingIPAddr; nOptions: Longint; pOptions: pSteamNetworkingConfigValue_t): HSteamListenSocket; cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingSockets_ConnectByIPAddress(SteamInterface: ISteamNetworkingSockets; address: PSteamNetworkingIPAddr; nOptions: Longint; pOptions: pSteamNetworkingConfigValue_t): HSteamNetConnection; cdecl; external STEAMLIB;
@@ -1056,9 +1056,13 @@ procedure SteamAPI_ISteamNetworkingUtils_SetDebugOutputFunction(SteamInterface: 
 function SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueInt32(SteamInterface: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; val: int32): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueFloat(SteamInterface: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; val: Single): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValueString(SteamInterface: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; val: PChar): Boolean; cdecl; external STEAMLIB;
+function SteamAPI_ISteamNetworkingUtils_SetGlobalConfigValuePtr(SteamInterface: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; val: PChar): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueInt32(SteamInterface: ISteamNetworkingUtils; hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: int32): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueFloat(SteamInterface: ISteamNetworkingUtils; hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: Single): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingUtils_SetConnectionConfigValueString(SteamInterface: ISteamNetworkingUtils; hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: PChar): Boolean; cdecl; external STEAMLIB;
+function SteamAPI_ISteamNetworkingUtils_SetGlobalCallback_SteamNetConnectionStatusChanged(SteamInterface: ISteamNetworkingUtils; fnCallback: FnSteamNetConnectionStatusChanged): Boolean; cdecl; external STEAMLIB;
+function SteamAPI_ISteamNetworkingUtils_SetGlobalCallback_SteamNetAuthenticationStatusChanged(SteamInterface: ISteamNetworkingUtils; fnCallback: FnSteamNetAuthenticationStatusChanged): Boolean; cdecl; external STEAMLIB;
+function SteamAPI_ISteamNetworkingUtils_SetGlobalCallback_SteamRelayNetworkStatusChanged(SteamInterface: ISteamNetworkingUtils; fnCallback: FnSteamRelayNetworkStatusChanged): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingUtils_SetConfigValue(SteamInterface: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; eScopeType: ESteamNetworkingConfigScope; scopeObj: intptr; eDataType: ESteamNetworkingConfigDataType; pArg: Pointer): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingUtils_SetConfigValueStruct(SteamInterface: ISteamNetworkingUtils; opt: PSteamNetworkingConfigValue_t; eScopeType: ESteamNetworkingConfigScope; scopeObj: intptr): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingUtils_GetConfigValue(SteamInterface: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; eScopeType: ESteamNetworkingConfigScope; scopeObj: intptr; pOutDataType: pESteamNetworkingConfigDataType; var pResult; cbResult: pcsize_t): ESteamNetworkingGetConfigValueResult; cdecl; external STEAMLIB;
@@ -1434,8 +1438,8 @@ begin
     raise Exception.Create('SteamPipeHandle is null');
 
   UGC := TSteamUGC.Init(SteamAPI_SteamUGC_v014());
-  Utils := TSteamUtils.Init(SteamAPI_SteamUtils_v009());
-  User := TSteamUser.Init(SteamAPI_SteamUser_v020());
+  Utils := TSteamUtils.Init(SteamAPI_SteamUtils_v010());
+  User := TSteamUser.Init(SteamAPI_SteamUser_v021());
   Screenshots := TSteamScreenshots.Init(SteamAPI_SteamScreenshots_v003());
   Friends := TSteamFriends.Init(SteamAPI_SteamFriends_v017());
 end;
@@ -1448,7 +1452,7 @@ begin
   SteamPipeHandle := SteamGameServer_GetHSteamPipe();
 
   UGC := TSteamUGC.Init(SteamAPI_SteamGameServerUGC_v014());
-  Utils := TSteamUtils.Init(SteamAPI_SteamGameServerUtils_v009());
+  Utils := TSteamUtils.Init(SteamAPI_SteamGameServerUtils_v010());
   GameServer := TSteamGameServer.Init(SteamAPI_SteamGameServer_v013());
   GameServerStats := TSteamGameServerStats.Init(SteamAPI_SteamGameServerStats_v001());
 end;


### PR DESCRIPTION
This PR updates GameNetworkingSockets bindings to [v1.2.0](https://github.com/ValveSoftware/GameNetworkingSockets/releases/tag/v1.2.0) and also SteamSDK to v1.50 as it uses the same GNS interface.