### PR TITLE
Fix Mesa 20.1+

### DIFF
--- a/client/Gfx.pas
+++ b/client/Gfx.pas
@@ -482,7 +482,7 @@ begin
     begin
       glVertexAttribPointer(0, 2, GL_FLOAT, False, sizeof(TGfxVertex), Pointer(0));
       glVertexAttribPointer(1, 2, GL_FLOAT, False, sizeof(TGfxVertex), Pointer(8));
-      { Pass ByteBool(1) instead of True because Mesa developers are very clever. }
+      // Workaround for MESA 20.1+ breakage: Pass ByteBool(1) instead of True
       glVertexAttribPointer(2, 4, GL_UNSIGNED_BYTE, ByteBool(1), sizeof(TGfxVertex), Pointer(16));
     end
     else

--- a/client/Gfx.pas
+++ b/client/Gfx.pas
@@ -482,7 +482,8 @@ begin
     begin
       glVertexAttribPointer(0, 2, GL_FLOAT, False, sizeof(TGfxVertex), Pointer(0));
       glVertexAttribPointer(1, 2, GL_FLOAT, False, sizeof(TGfxVertex), Pointer(8));
-      glVertexAttribPointer(2, 4, GL_UNSIGNED_BYTE, True, sizeof(TGfxVertex), Pointer(16));
+      { Pass ByteBool(1) instead of True because Mesa developers are very clever. }
+      glVertexAttribPointer(2, 4, GL_UNSIGNED_BYTE, ByteBool(1), sizeof(TGfxVertex), Pointer(16));
     end
     else
     begin


### PR DESCRIPTION
This fixes Mesa 20.1+, and #18 .

I haven't traced down the exact source in the Mesa code but it has to do with booleans being treated as ints, and the nonsense with Pascal boolean true. Because the GLboolean type in dglOpenGL is a ByteBool, OpenGL/Mesa winds up with a value of 255. Somehow this breaks glVertexAttribPointer. To the Mesa developers' credit, they have an assert statement in varray.c which checks for this condition, and was how I was able to track down the bug.