### PR TITLE
Fix arg parsing if dashes are contained within arguments

### DIFF
--- a/shared/Command.pas
+++ b/shared/Command.pas
@@ -472,34 +472,23 @@ end;
 
 procedure ParseCommandLine();
 var
-  CommandLine: AnsiString = '';
-  CommandLineNoDash: AnsiString = '';
+  CurrentCommand: AnsiString = '';
   i: Integer;
-  j: Integer;
-  commandBegin : Integer;
 begin
-  i := 0;
-  commandBegin := 0;
-  while i <= argc do
+  for i := 1 to argc do
   begin
-    if ((i > commandBegin) and (argv[i] <> '') and (argv[i][0] = '-')) or
-       (i = argc) then
+    if (argv[i] <> '') and (argv[i][0] <> '-') then
     begin
-      CommandLine := '';
-      for j:=commandBegin To i-1 do
-      begin
-        if CommandLine <> '' then
-          CommandLine := CommandLine + ' ';
-        CommandLine := CommandLine + argv[j];
-      end;
-
-      CommandLineNoDash := copy(CommandLine, 2, Length(CommandLine) - 1);
-
-      ParseInput(CommandLineNoDash);
-
-      commandBegin := i;
+      CurrentCommand := CurrentCommand + ' ' + argv[i];
+      continue;
     end;
-    i := i + 1;
+
+    if CurrentCommand <> '' then
+    begin
+      Writeln(copy(CurrentCommand, 2));
+    end;
+
+    CurrentCommand := argv[i];
   end;
 end;
 

--- a/shared/Command.pas
+++ b/shared/Command.pas
@@ -473,25 +473,33 @@ end;
 procedure ParseCommandLine();
 var
   CommandLine: AnsiString = '';
-  CommandLineParser: TStringList;
+  CommandLineNoDash: AnsiString = '';
   i: Integer;
+  j: Integer;
+  commandBegin : Integer;
 begin
-  for i:=1 to argc do
+  i := 0;
+  commandBegin := 0;
+  while i <= argc do
   begin
-    if CommandLine <> '' then
-      CommandLine := CommandLine + ' ';
-    CommandLine := CommandLine + argv[i];
-  end;
+    if ((i > commandBegin) and (argv[i] <> '') and (argv[i][0] = '-')) or
+       (i = argc) then
+    begin
+      CommandLine := '';
+      for j:=commandBegin To i-1 do
+      begin
+        if CommandLine <> '' then
+          CommandLine := CommandLine + ' ';
+        CommandLine := CommandLine + argv[j];
+      end;
 
-  CommandLineParser := TStringList.Create;
-  CommandLineParser.Delimiter := '-';
-  CommandLineParser.StrictDelimiter := True;
-  CommandLineParser.DelimitedText := CommandLine;
+      CommandLineNoDash := copy(CommandLine, 2, Length(CommandLine) - 1);
 
-  for i:=0 To CommandLineParser.Count-1 do
-  begin
-    if CommandLineParser[i] <> '' then
-      ParseInput(CommandLineParser[i]);
+      ParseInput(CommandLineNoDash);
+
+      commandBegin := i;
+    end;
+    i := i + 1;
   end;
 end;
 

--- a/shared/Command.pas
+++ b/shared/Command.pas
@@ -485,7 +485,7 @@ begin
 
     if CurrentCommand <> '' then
     begin
-      Writeln(copy(CurrentCommand, 2));
+      ParseInput(copy(CurrentCommand, 2));
     end;
 
     CurrentCommand := argv[i];


### PR DESCRIPTION
This is achieved by a new parsing approach: We collect argv entries
until we encounter one which starts with a dash and then concatenate
them and pass them to ParseInput. This is repeated until all arguments
are consumed.

Fixes an issue where `./soldatserver -fs_basepath /path-to/my-basepath`
would result in soldatserver parsing the arguments wrong because all dashes
were considered a delimiter.