### PR TITLE
Fix animated scenery.

### DIFF
--- a/client/Gfx.pas
+++ b/client/Gfx.pas
@@ -2325,12 +2325,19 @@ end;
 constructor TGfxImage.Create(Filename: string; ColorKey: TGfxColor);
 var
   FileBuffer: PHYSFS_Buffer;
+  i: Integer;
 begin
   FileBuffer := PhysFS_readBuffer(PChar(Filename));
   FDelays := Nil;
-  if Length(FileBuffer) > 0 then
-    FData := stbi_xload_mem(@FileBuffer[0], Length(FileBuffer), @FWidth, @FHeight, @FNumFrames, @FDelays)
-  else
+  if Length(FileBuffer) > 0 then begin
+    FData := stbi_xload_mem(@FileBuffer[0], Length(FileBuffer), @FWidth, @FHeight, @FNumFrames, @FDelays);
+
+    if FNumFrames > 1 then begin
+      for i := 0 to FNumFrames do begin
+        FDelays[i] := FDelays[i] div 10;
+      end;
+    end;
+  end else
     FData := nil;
 
   if FData <> nil then

--- a/client/Gfx.pas
+++ b/client/Gfx.pas
@@ -2333,7 +2333,7 @@ begin
     FData := stbi_xload_mem(@FileBuffer[0], Length(FileBuffer), @FWidth, @FHeight, @FNumFrames, @FDelays);
 
     if FNumFrames > 1 then begin
-      for i := 0 to FNumFrames do begin
+      for i := 0 to FNumFrames - 1 do begin
         FDelays[i] := FDelays[i] div 10;
       end;
     end;

--- a/client/libs/stb/src/stb.c
+++ b/client/libs/stb/src/stb.c
@@ -48,7 +48,7 @@ STBIDEF unsigned char *stbi_xload(stbi__context *s, int *x, int *y, int *frames,
 	int comp;
 	unsigned char *result = 0;
 
-	if ((result = stbi__gif_test(s)))
+	if (stbi__gif_test(s))
 		return stbi__load_gif_main(s, delays, x, y, frames, &comp, 4);
 
 	stbi__result_info ri;

--- a/client/libs/stb/src/stb.c
+++ b/client/libs/stb/src/stb.c
@@ -16,24 +16,18 @@
 extern "C" {
 #endif
 
-typedef struct gif_result_t {
-	int delay;
-	unsigned char *data;
-	struct gif_result_t *next;
-} gif_result;
+STBIDEF unsigned char *stbi_xload(stbi__context *s, int *x, int *y, int *frames, int **delays);
+STBIDEF unsigned char *stbi_xload_mem(unsigned char *buffer, int len, int *x, int *y, int *frames, int **delays);
+STBIDEF unsigned char *stbi_xload_file(char const *filename, int *x, int *y, int *frames, int **delays);
 
-STBIDEF unsigned char *stbi_xload(stbi__context *s, int *x, int *y, int *frames);
-STBIDEF unsigned char *stbi_xload_mem(unsigned char *buffer, int len, int *x, int *y, int *frames);
-STBIDEF unsigned char *stbi_xload_file(char const *filename, int *x, int *y, int *frames);
-
-STBIDEF unsigned char *stbi_xload_mem(unsigned char *buffer, int len, int *x, int *y, int *frames)
+STBIDEF unsigned char *stbi_xload_mem(unsigned char *buffer, int len, int *x, int *y, int *frames, int **delays)
 {
 	stbi__context s;
 	stbi__start_mem(&s, buffer, len);
-	return stbi_xload(&s, x, y, frames);
+	return stbi_xload(&s, x, y, frames, delays);
 }
 
-STBIDEF unsigned char *stbi_xload_file(char const *filename, int *x, int *y, int *frames)
+STBIDEF unsigned char *stbi_xload_file(char const *filename, int *x, int *y, int *frames, int **delays)
 {
 	FILE *f;
 	stbi__context s;
@@ -43,91 +37,28 @@ STBIDEF unsigned char *stbi_xload_file(char const *filename, int *x, int *y, int
 		return stbi__errpuc("can't fopen", "Unable to open file");
 
 	stbi__start_file(&s, f);
-	result = stbi_xload(&s, x, y, frames);
+	result = stbi_xload(&s, x, y, frames, delays);
 	fclose(f);
 
 	return result;
 }
 
-STBIDEF unsigned char *stbi_xload(stbi__context *s, int *x, int *y, int *frames)
+STBIDEF unsigned char *stbi_xload(stbi__context *s, int *x, int *y, int *frames, int **delays)
 {
+	int comp;
 	unsigned char *result = 0;
 
-	if (stbi__gif_test(s))
-	{
-		int c;
-		stbi__gif g;
-		gif_result head;
-		gif_result *prev = 0, *gr = &head;
+	if ((result = stbi__gif_test(s)))
+		return stbi__load_gif_main(s, delays, x, y, frames, &comp, 4);
 
-		memset(&g, 0, sizeof(g));
-		memset(&head, 0, sizeof(head));
+	stbi__result_info ri;
+	result = stbi__load_main(s, x, y, &comp, 4, &ri, 8);
+	*frames = !!result;
 
-		*frames = 0;
-
-		while (gr->data = stbi__gif_load_next(s, &g, &c, 4, 0))
-		{
-			if (gr->data == (unsigned char*)s)
-			{
-				gr->data = 0;
-				break;
-			}
-
-			if (prev) prev->next = gr;
-			gr->delay = g.delay;
-			prev = gr;
-			gr = (gif_result*) stbi__malloc(sizeof(gif_result));
-			memset(gr, 0, sizeof(gif_result));
-			++(*frames);
-		}
-
-		STBI_FREE(g.out);
-
-		if (gr != &head)
-			STBI_FREE(gr);
-
-		if (*frames > 0)
-		{
-			*x = g.w;
-			*y = g.h;
-		}
-
-		result = head.data;
-
-		if (*frames > 1)
-		{
-			unsigned int size = 4 * g.w * g.h;
-			unsigned char *p = 0;
-
-			result = (unsigned char*)stbi__malloc(*frames * (size + 2));
-			gr = &head;
-			p = result;
-
-			while (gr)
-			{
-				prev = gr;
-				memcpy(p, gr->data, size);
-				p += size;
-				*p++ = gr->delay & 0xFF;
-				*p++ = (gr->delay & 0xFF00) >> 8;
-				gr = gr->next;
-
-				STBI_FREE(prev->data);
-				if (prev != &head) STBI_FREE(prev);
-			}
-		}
-	}
-	else
-	{
-		stbi__result_info ri;
-		result = stbi__load_main(s, x, y, frames, 4, &ri, 8);
-		*frames = !!result;
-
-		if (ri.bits_per_channel != 8) {
-			STBI_ASSERT(ri.bits_per_channel == 16);
-			result = stbi__convert_16_to_8((stbi__uint16 *)result, *x, *y, 4);
-			ri.bits_per_channel = 8;
-		}
+	if (ri.bits_per_channel != 8) {
+		STBI_ASSERT(ri.bits_per_channel == 16);
+		result = stbi__convert_16_to_8((stbi__uint16 *)result, *x, *y, 4);
+		ri.bits_per_channel = 8;
 	}
 
 	return result;

--- a/client/libs/stb/stb.pas
+++ b/client/libs/stb/stb.pas
@@ -10,6 +10,9 @@ unit stb;
 
 interface
 
+type
+  PPInteger = ^PInteger;
+
 const
  {$IFDEF MSWINDOWS}
   STBLIB = 'stb.dll';
@@ -18,10 +21,10 @@ const
  {$ENDIF}
 
 // stb_image
-function stbi_xload_file(filename: PAnsiChar; w, h, f: PInteger): PByte;
+function stbi_xload_file(filename: PAnsiChar; w, h, f: PInteger; delays: PPInteger): PByte;
   cdecl; external STBLIB;
 
-function stbi_xload_mem(buffer: PByte; len: Integer; w, h, f: PInteger): PByte;
+function stbi_xload_mem(buffer: PByte; len: Integer; w, h, f: PInteger; delays: PPInteger): PByte;
   cdecl; external STBLIB;
 
 function stbi_load(filename: PAnsiChar; w, h, c: PInteger; req_comp: Integer): PByte;


### PR DESCRIPTION
This is done by switching to the new `stbi__load_gif_main` function in
stb_image which supports animated gifs. Animated scenery image data is
now in plain-old RGBA.

Animated scenery is broken right now. It seems like there is a version mismatch between stb.c and the stb libraries (stb.c is much older), which results in stb.c freeing the same pointer over and over again when loading animated gifs. I took this opportunity to update to the new `stbi__load_gif_main` function, which we already have in this repo.