### PR TITLE
Use uname -m if uname -p returns "unknown"

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -39,6 +39,9 @@ else
     endif
   endif
     UNAME_P := $(shell uname -p)
+    ifeq ($(UNAME_P),unknown)
+      ARCH = $(shell uname -m)
+    endif
     ifeq ($(UNAME_P),x86_64)
       ARCH = x86_64
     endif

--- a/server/Makefile
+++ b/server/Makefile
@@ -39,6 +39,9 @@ else
     endif
   endif
     UNAME_P := $(shell uname -p)
+    ifeq ($(UNAME_P),unknown)
+      ARCH = $(shell uname -m)
+    endif
     ifeq ($(UNAME_P),x86_64)
       ARCH = x86_64
     endif


### PR DESCRIPTION
Fix `server/Makefile` for Arch Linux.