### PR TITLE
Use cvars system for ScriptCore global configuration

### DIFF
--- a/server/Server.pas
+++ b/server/Server.pas
@@ -187,6 +187,10 @@ var
   sc_onscriptcrash: TStringCvar;
   sc_maxscripts: TIntegerCvar;
   sc_safemode: TBooleanCvar;
+  sc_allowdlls: TBooleanCvar;
+  sc_sandboxed: TIntegerCvar;
+  sc_defines: TStringCvar;
+  sc_searchpaths: TStringCvar;
 
   fileserver_enable: TBooleanCvar;
   fileserver_port: TIntegerCvar;

--- a/server/scriptcore/ScriptCore3.pas
+++ b/server/scriptcore/ScriptCore3.pas
@@ -156,9 +156,6 @@ type
     property API: TList read FApi;
   end;
 
-var
-  GlobalConfig: TScriptCore3Conf;
-
 function CheckFunction(Dir: string): TScriptCore3;
 
 implementation
@@ -218,14 +215,14 @@ begin
         Result := TScriptCore3.Create;
         Result.FName := Name;
         Result.FConfig.LoadConfig(IniFile, 'Config', 'SearchPaths', 'Defines');
-        if Result.FConfig.SandboxLevel < GlobalConfig.SandboxLevel then
+        if Result.FConfig.SandboxLevel < sc_sandboxed.Value then
         begin
           Result.WriteInfo('Script''s sandbox level denied by global config.');
           Result.Free;
           Result := nil;
           Exit;
         end;
-        if Result.FConfig.AllowDlls and not GlobalConfig.AllowDlls then
+        if Result.FConfig.AllowDlls and not sc_allowdlls.Value then
         begin
           Result.WriteInfo('AllowDlls denied by global config.');
           Result.Free;
@@ -240,8 +237,8 @@ begin
         Result.FDebug := IniFile.ReadBool('Config', 'Debug', False);
         if Result.FLegacyMode then
           Result.SetHybridMode;
-        Result.FConfig.Defines.AddStrings(GlobalConfig.Defines);
-        Result.FConfig.SearchPaths.AddStrings(GlobalConfig.SearchPaths);
+        Result.FConfig.Defines.CommaText := sc_defines.Value;
+        Result.FConfig.SearchPaths.CommaText := sc_searchpaths.Value;
       end
       else
         ScrptDispatcher.WriteInfo('[' + Dir + '] CONFIG section not found');
@@ -1220,11 +1217,5 @@ begin
     Self.Lock.Release;
   end;
 end;
-
-initialization
-  GlobalConfig.Create;
-
-finalization
-  GlobalConfig.Destroy;
 
 end.

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -944,10 +944,14 @@ begin
   bots_chat := TBooleanCvar.Add('bots_chat', 'Enables/disables bots chatting', True, True, [CVAR_SERVER], nil);
 
   // ScriptCore cvars
-  sc_enable := TBooleanCvar.Add('sc_enable', 'Enables/Disables scripting', True, True, [CVAR_SERVER], nil);
-  sc_onscriptcrash := TStringCvar.Add('sc_onscriptcrash', 'What action to take when a script crashes. Available parameters are recompile, shutdown, ignore and disable', 'ignore', 'ignore', [CVAR_SERVER], nil, 0, 10);
-  sc_maxscripts := TIntegerCvar.Add('sc_maxscripts', 'Set the maximum number of scripts which can be loaded by this server.', 0, 255, [CVAR_SERVER], nil, 0, 255);
-  sc_safemode := TBooleanCvar.Add('sc_safemode', 'Enables/Disables Safe Mode for Scripts', False, False, [CVAR_SERVER], nil);
+  sc_enable := TBooleanCvar.Add('sc_enable', 'Enables/Disables scripting', True, True, [CVAR_SERVER, CVAR_INITONLY], nil);
+  sc_onscriptcrash := TStringCvar.Add('sc_onscriptcrash', 'What action to take when a script crashes. Available parameters are recompile, shutdown, ignore and disable', 'ignore', 'ignore', [CVAR_SERVER, CVAR_INITONLY], nil, 0, 10);
+  sc_maxscripts := TIntegerCvar.Add('sc_maxscripts', 'Set the maximum number of scripts which can be loaded by this server.', 0, 255, [CVAR_SERVER, CVAR_INITONLY], nil, 0, 255);
+  sc_safemode := TBooleanCvar.Add('sc_safemode', 'Enables/Disables Safe Mode for Scripts', False, False, [CVAR_SERVER, CVAR_INITONLY], nil);
+  sc_allowdlls := TBooleanCvar.Add('sc_allowdlls', 'Enables/Disables loading external dlls', False, False, [CVAR_SERVER, CVAR_INITONLY], nil);
+  sc_sandboxed := TIntegerCvar.Add('sc_sandboxed', 'ScriptCore global sandbox level ', 2, 2, [CVAR_SERVER, CVAR_INITONLY], nil, 0, 2);
+  sc_defines := TStringCvar.Add('sc_defines', 'ScriptCore global defines (comma separated)', '', '', [CVAR_SERVER, CVAR_INITONLY], nil, 0, 255);
+  sc_searchpaths := TStringCvar.Add('sc_searchpaths', 'ScriptCore global search paths (comma separated)', '', '', [CVAR_SERVER, CVAR_INITONLY], nil, 0, 255);
 
   // Fileserver cvars
   fileserver_enable := TBooleanCvar.Add('fileserver_enable', 'Enables/Disables built-in fileserver', True, True, [CVAR_SERVER, CVAR_INITONLY], nil);


### PR DESCRIPTION
This change adds new cvars: `sc_allowdlls` `sc_sandboxed` `sc_defines` `sc_searchpaths` to set scriptcore global configuration (previously defined in removed server.ini). 