### PR TITLE
Chat input fixes & enhancements

### DIFF
--- a/client/ClientGame.pas
+++ b/client/ClientGame.pas
@@ -42,7 +42,7 @@ var
 
   // chat stuff
   ChatText, LastChatText, FireChatText: WideString;
-  ChatType: Byte;
+  ChatType, FireChatType: Byte;
   CompletionBase: String = '';
   CompletionBaseSeparator: Integer;
   CurrentTabCompletePlayer: Byte = 0;

--- a/client/ControlGame.pas
+++ b/client/ControlGame.pas
@@ -467,11 +467,12 @@ begin
   begin
     if ChatText = '' then
     begin
-      ChatText := '/';
       ChatType := MSGTYPE_CMD;
-      ChatChanged := True;
-      CursorPosition := 1;
+      ChatText := '/';
       VoteKickReasonType := False;
+
+      ChatChanged := True;
+      CursorPosition := Length(ChatText);
       SDL_StartTextInput;
     end;
   end
@@ -479,20 +480,21 @@ begin
   begin
     if ChatText = '' then
     begin
-      SDL_StartTextInput;
-      ChatChanged := True;
-      ChatText := ' ';
-      ChatType := MSGTYPE_PUB;
-
-      if Length(FireChatText) > 0 then
-        ChatText := FireChatText;
-
       // force spectator chat to teamchat in survival mode when Round hasn't ended
       if (sv_survivalmode.Value) and Sprite[MySprite].IsSpectator() and
          not SurvivalEndRound and (sv_survivalmode_antispy.Value) then
-        ChatType := MSGTYPE_TEAM;
+        ChatType := MSGTYPE_TEAM
+      else
+        ChatType := MSGTYPE_PUB;
 
+      if Length(FireChatText) > 0 then
+        ChatText := FireChatText
+      else
+        ChatText := ' ';
+
+      ChatChanged := True;
       CursorPosition := Length(ChatText);
+      SDL_StartTextInput;
     end;
   end
   else if Action = TAction.TeamChat then
@@ -500,11 +502,12 @@ begin
     if (ChatText = '') and (MySprite > 0) and
       (Sprite[MySprite].IsSpectator() or IsTeamGame()) then
     begin
-      SDL_StartTextInput;
-      ChatText := ' ';
       ChatType := MSGTYPE_TEAM;
+      ChatText := ' ';
+
       ChatChanged := True;
       CursorPosition := Length(ChatText);
+      SDL_StartTextInput;
     end;
   end
   else if Action = TAction.Snap then

--- a/client/ControlGame.pas
+++ b/client/ControlGame.pas
@@ -525,14 +525,18 @@ begin
       // force spectator chat to teamchat in survival mode when Round hasn't ended
       if (sv_survivalmode.Value) and Sprite[MySprite].IsSpectator() and
          not SurvivalEndRound and (sv_survivalmode_antispy.Value) then
-        ChatType := MSGTYPE_TEAM
-      else
-        ChatType := MSGTYPE_PUB;
-
-      if Length(FireChatText) > 0 then
-        ChatText := FireChatText
-      else
+      begin
+        ChatType := MSGTYPE_TEAM;
         ChatText := ' ';
+      end
+      else
+      begin
+        ChatType := MSGTYPE_PUB;
+        if Length(FireChatText) > 0 then
+          ChatText := FireChatText
+        else
+          ChatText := ' ';
+      end;
 
       ChatChanged := True;
       CursorPosition := Length(ChatText);

--- a/client/ControlGame.pas
+++ b/client/ControlGame.pas
@@ -48,7 +48,8 @@ begin
 
   if Length(ChatText) > 0 then
   begin
-    if (KeyMods = KM_CTRL) and (KeyCode = SDLK_v) then
+    if ((KeyMods = KM_CTRL) and (KeyCode = SDLK_v))
+      or ((KeyMods = KM_SHIFT) and (KeyCode = SDLK_INSERT)) then
     begin
       Str := FilterChatText(WideString(UTF8String(SDL_GetClipboardText)));
       Len := Length(ChatText);
@@ -66,6 +67,47 @@ begin
       CurrentTabCompletePlayer := 0;
       ChatChanged := True;
       Result := True;
+    end
+    else if (KeyMods = KM_CTRL) then
+    begin
+      Result := True;
+
+      case KeyCode of
+        SDLK_HOME: begin
+          ChatChanged := True;
+          CursorPosition := 1;
+        end;
+
+        SDLK_END: begin
+          ChatChanged := True;
+          CursorPosition := Length(ChatText);
+        end;
+
+        SDLK_RIGHT: begin
+          ChatChanged := True;
+          Len := Length(ChatText);
+          while (CursorPosition < Len) do
+          begin
+            Inc(CursorPosition);
+            if (ChatText[CursorPosition] = ' ')
+              and (ChatText[CursorPosition + 1] <> ' ') then
+              break;
+          end;
+        end;
+
+        SDLK_LEFT: begin
+          ChatChanged := True;
+          while (CursorPosition > 1) do
+          begin
+            Dec(CursorPosition);
+            if (ChatText[CursorPosition] = ' ')
+              and (ChatText[CursorPosition + 1] <> ' ') then
+              break;
+          end;
+        end;
+      else
+        Result := False;
+      end;
     end
     else if KeyMods = KM_NONE then
     begin

--- a/client/ControlGame.pas
+++ b/client/ControlGame.pas
@@ -89,6 +89,8 @@ begin
           while (CursorPosition < Len) do
           begin
             Inc(CursorPosition);
+            if (CursorPosition = Len) then
+              break;
             if (ChatText[CursorPosition] = ' ')
               and (ChatText[CursorPosition + 1] <> ' ') then
               break;
@@ -100,6 +102,8 @@ begin
           while (CursorPosition > 1) do
           begin
             Dec(CursorPosition);
+            if (CursorPosition = 0) then
+              break;
             if (ChatText[CursorPosition] = ' ')
               and (ChatText[CursorPosition + 1] <> ' ') then
               break;

--- a/client/ControlGame.pas
+++ b/client/ControlGame.pas
@@ -26,6 +26,20 @@ begin
   SDL_StopTextInput;
 end;
 
+procedure StartChat;
+begin
+  if (Length(FireChatText) > 0) and (FireChatType = ChatType) then
+    ChatText := FireChatText
+  else if ChatType = MSGTYPE_CMD then
+    ChatText := '/'
+  else
+    ChatText := ' ';
+
+  ChatChanged := True;
+  CursorPosition := Length(ChatText);
+  SDL_StartTextInput;
+end;
+
 function FilterChatText(Str: WideString): WideString;
 var
   i: Integer;
@@ -514,12 +528,8 @@ begin
     if ChatText = '' then
     begin
       ChatType := MSGTYPE_CMD;
-      ChatText := '/';
       VoteKickReasonType := False;
-
-      ChatChanged := True;
-      CursorPosition := Length(ChatText);
-      SDL_StartTextInput;
+      StartChat;
     end;
   end
   else if Action = TAction.Chat then
@@ -529,22 +539,11 @@ begin
       // force spectator chat to teamchat in survival mode when Round hasn't ended
       if (sv_survivalmode.Value) and Sprite[MySprite].IsSpectator() and
          not SurvivalEndRound and (sv_survivalmode_antispy.Value) then
-      begin
-        ChatType := MSGTYPE_TEAM;
-        ChatText := ' ';
-      end
+        ChatType := MSGTYPE_TEAM
       else
-      begin
         ChatType := MSGTYPE_PUB;
-        if Length(FireChatText) > 0 then
-          ChatText := FireChatText
-        else
-          ChatText := ' ';
-      end;
 
-      ChatChanged := True;
-      CursorPosition := Length(ChatText);
-      SDL_StartTextInput;
+      StartChat;
     end;
   end
   else if Action = TAction.TeamChat then
@@ -553,11 +552,7 @@ begin
       (Sprite[MySprite].IsSpectator() or IsTeamGame()) then
     begin
       ChatType := MSGTYPE_TEAM;
-      ChatText := ' ';
-
-      ChatChanged := True;
-      CursorPosition := Length(ChatText);
-      SDL_StartTextInput;
+      StartChat;
     end;
   end
   else if Action = TAction.Snap then

--- a/shared/mechanics/Control.pas
+++ b/shared/mechanics/Control.pas
@@ -205,8 +205,8 @@ begin
             if (Length(ChatText) > 0) and KeyStatus[301] then
             begin
               SDL_StopTextInput;
-              if (ChatType = MSGTYPE_PUB) then
-                FireChatText := ChatText;
+              FireChatType := ChatType;
+              FireChatText := ChatText;
               ChatText := '';
             end;
 

--- a/shared/mechanics/Control.pas
+++ b/shared/mechanics/Control.pas
@@ -205,7 +205,8 @@ begin
             if (Length(ChatText) > 0) and KeyStatus[301] then
             begin
               SDL_StopTextInput;
-              FireChatText := ChatText;
+              if (ChatType = MSGTYPE_PUB) then
+                FireChatText := ChatText;
               ChatText := '';
             end;
 


### PR DESCRIPTION
- Fix cursor render (position & size) in different types of chat input
  Its position was all over the place in both Command & Team chat modes. Plus there was an issue with determining its position after text with trailing space.
- Refactor `Cmd`/`Chat`/`TeamChat` actions
- Add more shortcuts for chat input cursor navigation
  `Ctrl`+`Left`/`Right`, `Ctrl`+`Home`/`End`, `Shift`+`Ins`
- Fix `FireChatText` to function only with public chat type
  To prevent leaking team messages and commands into public chat. In addition to that, after filling the `FireChatText` in Command chat mode it was "breaking" Chat & TeamChat by the first `/` in `ChatText`