### PR TITLE
feature: copy chat contents to clipboard

### DIFF
--- a/client/ControlGame.pas
+++ b/client/ControlGame.pas
@@ -81,6 +81,10 @@ begin
       ChatChanged := True;
       Result := True;
     end
+    else if ((KeyMods = KM_CTRL) and (KeyCode = SDLK_v)) then
+    begin
+      SDL_SetClipboardText(ChatText)
+    end
     else if (KeyMods = KM_CTRL) then
     begin
       Result := True;


### PR DESCRIPTION
This feature adds CTRL+C functionality when a chat is open. It copies chat content to the clipboard. 

With this feature people can actually share interesting links or messages between each other.