### PR TITLE
Easy Anti-Cheat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ option(ADD_ASSETS "Include soldat.smod and font file" True)
 option(BUILD_CLIENT "Build client" True)
 option(BUILD_SERVER "Build server" True)
 option(BUILD_STEAM "Build steam version" False)
+option(BUILD_ANTICHEAT "Build easy anti-cheat" False)
 option(CROSS_LINUX_64 "Cross compile to Linux 64bit" False)
 option(CROSS_LINUX_32 "Cross compile to Linux 32bit" False)
 option(CROSS_WINDOWS_64 "Cross compile to Windows x86_64" False)
@@ -109,6 +110,8 @@ add_flag_prepend(CMAKE_Pascal_FLAGS
 add_flag_prepend(CMAKE_Pascal_FLAGS "-Fu${CMAKE_SOURCE_DIR}/shared/libs/PhysFS")
 add_flag_prepend(CMAKE_Pascal_FLAGS
                  "-Fu${CMAKE_SOURCE_DIR}/shared/libs/SteamWrapper")
+add_flag_prepend(CMAKE_Pascal_FLAGS
+                 "-Fu${CMAKE_SOURCE_DIR}/shared/libs/EOS")
 add_flag_prepend(CMAKE_Pascal_FLAGS "-Fu${CMAKE_SOURCE_DIR}/shared/mechanics")
 add_flag_prepend(CMAKE_Pascal_FLAGS "-Fu${CMAKE_SOURCE_DIR}/shared/network")
 
@@ -143,6 +146,10 @@ if(BUILD_STEAM)
   add_flag_prepend(CMAKE_Pascal_FLAGS "-dSTEAM")
 endif()
 
+if(BUILD_ANTICHEAT)
+  add_flag_prepend(CMAKE_Pascal_FLAGS "-dENABLE_EAC")
+endif()
+
 # Other dependencies shared between client and server.
 # Find PhysFS
 if(NOT PHYSFS_LIBRARY OR NOT PHYSFS_INCLUDE_DIR)
@@ -170,6 +177,10 @@ endif()
 
 if(BUILD_SERVER)
   add_subdirectory(server)
+endif()
+
+if(BUILD_ANTICHEAT)
+  add_subdirectory(shared/libs/EOS)
 endif()
 
 # Install step that does 3 things:

--- a/client/ClientGame.pas
+++ b/client/ClientGame.pas
@@ -270,7 +270,7 @@ begin
       Dec(MenuTimer);
 
     {$IFDEF STEAM}
-    SteamAPI_RunCallbacks();
+    RunManualCallbacks();
     {$ENDIF}
 
     // General game updating

--- a/client/Makefile
+++ b/client/Makefile
@@ -70,6 +70,10 @@ ifeq ($(steam),on)
   CFLAGS += -dSTEAM
 endif
 
+ifeq ($(anticheat),on)
+  CFLAGS += -dENABLE_EAC
+endif
+
 COMPILER = fpc -l -B -MDelphi -Scgi ${CFLAGS} \
 -Fi../shared \
 -Fl./libs \
@@ -80,6 +84,7 @@ COMPILER = fpc -l -B -MDelphi -Scgi ${CFLAGS} \
 -Fu../shared/libs/GameNetworkingSockets \
 -Fu../shared/libs/PhysFS \
 -Fu../shared/libs/SteamWrapper \
+-Fu../shared/libs/EOS \
 -Fu../shared/mechanics \
 -Fu../shared/network \
 -Fu../server \

--- a/client/Sound.pas
+++ b/client/Sound.pas
@@ -12,7 +12,7 @@ unit Sound;
 interface
 
 uses
-  SDL2, Vector, openal, PhysFS;
+  SDL2, Vector, openal, PhysFS {$IFDEF STEAM}, fgl{$ENDIF};
 
 type
   TSoundSample = record

--- a/client/UpdateFrame.pas
+++ b/client/UpdateFrame.pas
@@ -16,6 +16,7 @@ uses
   NetworkClientConnection, Constants,
   Polymap, Game, Client, Util, SysUtils, Calc, LogFile, WeatherEffects, Sparks
   {$IFDEF ENABLE_FAE}, FaeClient{$ENDIF}
+  {$IFDEF ENABLE_EAC}, EOS{$ENDIF}
   ;
 
 procedure Update_Frame;
@@ -39,6 +40,11 @@ begin
 
   {$IFDEF ENABLE_FAE}
   FaeOnTick;
+  {$ENDIF}
+
+  {$IFDEF ENABLE_EAC}
+  if Assigned(EACClient) then
+    EACClient.OnClockTick();
   {$ENDIF}
 
   CameraPrev.x := CameraX;

--- a/server/LobbyClient.pas
+++ b/server/LobbyClient.pas
@@ -53,7 +53,7 @@ begin
 
   Json := TJSONObject.Create;
 
-  Json.Add('AC', {$IFDEF ENABLE_FAE}ac_enable.Value{$ELSE}False{$ENDIF});
+  Json.Add('AC', {$IFDEF ENABLE_FAE OR $IFDEF ENABLE_EAC}ac_enable.Value{$ELSE}False{$ENDIF});
   Json.Add('AuthMode', 0);
   Json.Add('Advanced', sv_advancemode.Value);
   Json.Add('BonusFreq', sv_bonus_frequency.Value);

--- a/server/Makefile
+++ b/server/Makefile
@@ -70,6 +70,10 @@ ifeq ($(steam),on)
   CFLAGS += -dSTEAM
 endif
 
+ifeq ($(anticheat),on)
+  CFLAGS += -dENABLE_EAC
+endif
+
 COMPILER = fpc -l -B -MDelphi -Scgi ${CFLAGS} \
 -Fi../shared \
 -Fl./libs \
@@ -80,6 +84,7 @@ COMPILER = fpc -l -B -MDelphi -Scgi ${CFLAGS} \
 -Fu../shared/libs/GameNetworkingSockets \
 -Fu../shared/libs/PhysFS \
 -Fu../shared/libs/SteamWrapper \
+-Fu../shared/libs/EOS \
 -Fu../shared/mechanics \
 -Fu../shared/network \
 -Fu./scriptcore \

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -839,6 +839,7 @@ begin
   {$IFDEF STEAM}
   Debug('[Steam] Shutdown');
   SteamAPI.GameServer.Shutdown;
+  SteamAPI_Shutdown();
   {$ENDIF}
 
   {$IFNDEF STEAM}

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -36,6 +36,10 @@ uses
   Rcon,
   {$ENDIF}
 
+  {$IFDEF ENABLE_EAC}
+  EOS,
+  {$ENDIF}
+
   FileServer, LobbyClient,
 
   // soldat units
@@ -226,6 +230,12 @@ var
   ac_enable: TBooleanCvar;
   {$ENDIF}
 
+  {$IFDEF ENABLE_EAC}
+  ac_enable: TBooleanCvar;
+  ac_timeout: TIntegerCvar;
+  ac_loglevel: TIntegerCvar;
+  {$ENDIF}
+
   // config stuff
   ServerIP: string = '127.0.0.1';
   ServerPort: Integer = 23073;
@@ -295,6 +305,10 @@ var
   {$IFDEF STEAM}
   //SteamCallbacks: TSteamCallbacks;
   SteamAPI: TSteamGS;
+  {$ENDIF}
+
+  {$IFDEF ENABLE_EAC}
+  EACServer: TEpicOnlineServicesServer;
   {$ENDIF}
 
 implementation
@@ -685,6 +699,22 @@ begin
   end;
   {$ENDIF}
 
+  {$IFDEF ENABLE_EAC}
+  if ac_enable.Value then
+    begin
+    try
+      EACServer := TEpicOnlineServicesServer.Create(ac_loglevel.Value, sv_hostname.Value, ac_timeout.Value);
+    except
+      on E: Exception do
+      begin
+        WriteLn('Easy Anti-Cheat initialization has failed: ' + E.Message);
+        ProgReady := False;
+        Exit;
+      end;
+    end;
+  end;
+  {$ENDIF}
+
   ProgReady := True;
 
   {$IFNDEF SCRIPT}
@@ -844,6 +874,10 @@ begin
 
   {$IFNDEF STEAM}
   GameNetworkingSockets_Kill();
+  {$ENDIF}
+
+  {$IFDEF ENABLE_EAC}
+  FreeAndNil(EACServer);
   {$ENDIF}
 
   try

--- a/server/ServerLoop.pas
+++ b/server/ServerLoop.pas
@@ -11,6 +11,9 @@ uses
   {$IFDEF SCRIPT}
   ScriptDispatcher,
   {$ENDIF}
+  {$IFDEF ENABLE_EAC}
+  EOS,
+  {$ENDIF}
   {$IFDEF ENABLE_FAE}
   NetworkServerFae,
   {$ENDIF}
@@ -50,6 +53,11 @@ begin
 
     {$IFDEF SCRIPT}
     ScrptDispatcher.OnClockTick();
+    {$ENDIF}
+
+    {$IFDEF ENABLE_EAC}
+    if Assigned(EACServer) then
+      EACServer.OnClockTick();
     {$ENDIF}
 
     {$IFDEF STEAM}

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -721,6 +721,15 @@ begin
     {$IFDEF ENABLE_FAE}
   ac_enable := TBooleanCvar.Add('ac_enable', 'Enables/Disables anti-cheat checks via Fae', True, True, [CVAR_SERVER], nil);
     {$ENDIF}
+
+  {$ENDIF}
+
+  {$IFDEF ENABLE_EAC}
+  {$IFDEF SERVER}
+  ac_timeout := TIntegerCvar.Add('ac_timeout', 'Time in seconds to allow newly registered clients to complete anti-cheat authentication', 30, 30, [CVAR_SERVER, CVAR_INITONLY], nil, 10, 120);
+  {$ENDIF}
+  ac_enable := TBooleanCvar.Add('ac_enable', 'Enables/Disables easy anti-cheat', True, True, [CVAR_INITONLY], nil);
+  ac_loglevel := TIntegerCvar.Add('ac_loglevel', 'Verbosity level of EOS (Off = 0, Fatal = 100, Error = 200, Warning = 300, Info = 400, Verbose = 500, VeryVerbose = 600', 300, 300, [CVAR_INITONLY], nil, 0, 600);
   {$ENDIF}
 
   fs_localmount := TBooleanCvar.Add('fs_localmount', 'Mount game directory as game mod', False, False, [CVAR_CLIENT, CVAR_INITONLY], nil);

--- a/shared/Demo.pas
+++ b/shared/Demo.pas
@@ -14,6 +14,7 @@ uses
   {$IFNDEF SERVER}
   GameStrings, ClientGame,
   {$ENDIF}
+  {$IFDEF STEAM}Steam,{$ENDIF}
   SysUtils, Classes, Vector, Sprites,
   {$IFNDEF SERVER}GameNetworkingSockets,{$ENDIF}
   Net;

--- a/shared/libs/EOS/CMakeLists.txt
+++ b/shared/libs/EOS/CMakeLists.txt
@@ -1,0 +1,67 @@
+set(EOS_SDK_DIR "Location of EOS SDK" CACHE STRING "")
+set(EOS_ANTICHEAT_TOOLS_DIR "Location of EAC Anti-cheat tools" CACHE STRING "")
+set(EOS_CERTS "Location of EAC certs" CACHE STRING "")
+set(EOS_DEPLOYMENT_ID "EOS Deployment ID" CACHE STRING "")
+set(EOS_PRODUCT_ID "EOS Product ID" CACHE STRING "")
+set(EOS_SANDBOX_ID "EOS Sandbox ID" CACHE STRING "")
+set(EOS_CLIENT_ID "EOS Client ID for soldat" CACHE STRING "")
+set(EOS_CLIENT_SECRET "EOS Client secret for soldat" CACHE STRING "")
+set(EOS_SERVER_ID "EOS Client ID for soldatserver" CACHE STRING "")
+set(EOS_SERVER_SECRET "EOS Client secret for soldat" CACHE STRING "")
+
+if (UNIX)
+  set(EOS_LIBRARY_NAME "libEOSSDK-Linux-Shipping.so")
+  set(EOS_EXE_NAME "soldat")
+endif()
+
+if(WIN32)
+  set(EOS_LIBRARY_NAME "EOSSDK-Win64-Shipping.dll")
+  set(EOS_EXE_NAME "soldat_x64.exe")
+endif()
+
+if(APPLE)
+  set(EOS_LIBRARY_NAME "libEOSSDK-Mac-Shipping.dylib")
+  set(EOS_EXE_NAME "soldat_x64")
+endif()
+
+configure_file(${CMAKE_SOURCE_DIR}/shared/libs/EOS/utils/Settings.json ${EXECUTABLE_OUTPUT_PATH}/EasyAntiCheat/Settings.json.compiled @ONLY)
+
+add_custom_target(copy_eos_sdk
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+  "${EOS_SDK_DIR}/SDK/Bin/${EOS_LIBRARY_NAME}"
+  ${EXECUTABLE_OUTPUT_PATH}
+)
+
+add_dependencies(soldat copy_eos_sdk)
+
+add_custom_target(copy_anticheat_bootstrapper
+  COMMAND ${CMAKE_COMMAND} -E copy_directory "${EOS_ANTICHEAT_TOOLS_DIR}/dist" ${EXECUTABLE_OUTPUT_PATH}
+  COMMAND ${CMAKE_COMMAND} -E copy ${EXECUTABLE_OUTPUT_PATH}/EasyAntiCheat/Settings.json.compiled ${EXECUTABLE_OUTPUT_PATH}/EasyAntiCheat/Settings.json
+)
+
+add_dependencies(soldat copy_anticheat_bootstrapper)
+
+if(WIN32)
+  file(WRITE ${EXECUTABLE_OUTPUT_PATH}/EAC_install.bat "%~dp0EasyAntiCheat\\EasyAntiCheat_EOS_Setup.exe install -productid ${EOS_PRODUCT_ID}\n")
+  file(WRITE ${EXECUTABLE_OUTPUT_PATH}/EAC_uinstall.bat "%~dp0EasyAntiCheat\\EasyAntiCheat_EOS_Setup.exe uninstall -productid ${EOS_PRODUCT_ID}\n")
+endif()
+
+add_custom_target(integrity_tool ALL
+  COMMAND "${EOS_ANTICHEAT_TOOLS_DIR}/devtools/anticheat_integritytool${CMAKE_EXECUTABLE_SUFFIX}" -inkey "${EOS_CERTS}/base_private.key" -incert "${EOS_CERTS}/base_public.cer" -productid "${EOS_PRODUCT_ID}" -target_game_dir "${EXECUTABLE_OUTPUT_PATH}" "${CMAKE_SOURCE_DIR}/shared/libs/EOS/utils/anticheat_integritytool.cfg"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMENT "Hashing game files with anticheat_integritytool"
+)
+
+install(
+  DIRECTORY ${EXECUTABLE_OUTPUT_PATH}/EasyAntiCheat
+  DESTINATION ${target_full_binary_install_dir}
+  PATTERN "*.bat"
+)
+
+if(WIN32)
+  install(
+    DIRECTORY ${EXECUTABLE_OUTPUT_PATH}/
+    DESTINATION ${target_full_binary_install_dir}
+    PATTERN "*.bat"
+  )
+endif()

--- a/shared/libs/EOS/eos.pas
+++ b/shared/libs/EOS/eos.pas
@@ -1,0 +1,671 @@
+{*******************************************************}
+{                                                       }
+{       EOS Unit for SOLDAT                             }
+{                                                       }
+{       Copyright (c) 2021 Soldat Team                  }
+{                                                       }
+{       For use with EOS SDK  v1.14.1                   }
+{                                                       }
+{*******************************************************}
+
+unit EOS;
+{$IFDEF UNIX}
+{$PACKRECORDS 4}
+{$PACKENUM 4}
+{$ELSE}
+{$PACKRECORDS 8}
+{$ENDIF}
+interface
+
+uses
+  ctypes, SysUtils, Classes, 
+  GameNetworkingSockets, Net, Version, NetworkUtils, Constants, TraceLog
+  {$IFDEF SERVER}{$IFDEF STEAM}, SteamTypes{$ENDIF}, NetworkServerConnection{$ENDIF};
+
+const
+  {$IFDEF WINDOWS}
+  EOSLIB = 'EOSSDK-Win64-Shipping.dll';
+  {$ENDIF}
+  {$IFDEF LINUX}
+  EOSLIB = 'libEOSSDK-Linux-Shipping.so';
+  {$ENDIF}
+  {$IFDEF DARWIN}
+  EOSLIB = 'libEOSSDK-Mac-Shipping.dylib';
+  {$ENDIF}
+
+  EOS_PRODUCT_ID = {$INCLUDE %EOS_PRODUCT_ID%};
+  EOS_SANDBOX_ID = {$INCLUDE %EOS_SANDBOX_ID%};
+  EOS_DEPLOYMENT_ID = {$INCLUDE %EOS_DEPLOYMENT_ID%};
+
+  {$IFDEF SERVER}
+  EOS_SERVER_ID = {$INCLUDE %EOS_SERVER_ID%};
+  EOS_SERVER_SECRET = {$INCLUDE %EOS_SERVER_SECRET%};
+  {$ELSE}
+  EOS_CLIENT_ID = {$INCLUDE %EOS_CLIENT_ID%};
+  EOS_CLIENT_SECRET = {$INCLUDE %EOS_CLIENT_SECRET%};
+  {$ENDIF}
+
+{$PACKRECORDS 8}
+{$PACKENUM 4}
+{$include eos_base.pas}
+{$include eos_logging.pas}
+{$include eos_types.pas}
+{$include eos_init.pas}
+{$include eos_connect_types.pas}
+{$include eos_connect.pas}
+{$include eos_anticheatcommon_types.pas}
+{$include eos_anticheatserver_types.pas}
+{$include eos_anticheatserver.pas}
+{$include eos_anticheatclient_types.pas}
+{$include eos_anticheatclient.pas}
+{$include eos_sdk.pas}
+{$include eos_windows.pas}
+
+{$IFDEF SERVER}
+procedure ServerHandleEACMessage(NetMessage: PSteamNetworkingMessage_t);
+{$ELSE}
+procedure ClientHandleEACMessage(NetMessage: PSteamNetworkingMessage_t);
+{$ENDIF}
+
+type
+  TEpicOnlineServices = class
+  private
+    FPlatformHandle: EOS_HPlatform;
+  public
+    constructor Create(LogLevel: Integer);
+    destructor Destroy; override;
+    procedure OnClockTick();
+  end;
+
+  {$IFNDEF SERVER}
+  TEpicOnlineServicesClient = class(TEpicOnlineServices)
+  private
+    FAntiCheatHandle: EOS_HAntiCheatClient;
+    FAddNotifyMessageToServerId: EOS_NotificationId;
+    FConnectHandle: EOS_HConnect;
+    FLocalUser: EOS_ProductUserId;
+    FPollStatusOptions: EOS_AntiCheatClient_PollStatusOptions;
+    procedure OnMessageToServer(Data: PEOS_AntiCheatClient_OnMessageToServerCallbackInfo); stdcall;
+    procedure OnCreateUser(Data: PEOS_Connect_CreateUserCallbackInfo);
+    procedure OnLoginConnect(Data: PEOS_Connect_LoginCallbackInfo); stdcall;
+  public
+    constructor Create(LogLevel: Integer);
+    destructor Destroy; override;
+    procedure OnClockTick();
+    {$IFDEF STEAM}
+    procedure OnSteamAuth();
+    {$ENDIF}
+    procedure OpenIDLogin();
+    procedure BeginSession();
+    procedure EndSession();
+    property AntiCheatHandle: EOS_HAntiCheatClient read FAntiCheatHandle;
+  end;
+  {$ELSE}
+
+  TEpicOnlineServicesServer = class(TEpicOnlineServices)
+  private
+    FAntiCheatHandle: EOS_HAntiCheatServer;
+    FAddNotifyMessageToClientId: EOS_NotificationId;
+    FAddNotifyClientActionRequiredId: EOS_NotificationId;
+    FAddNotifyClientAuthStatusChangedId: EOS_NotificationId;
+    procedure OnMessageToClient(Data: PEOS_AntiCheatCommon_OnMessageToClientCallbackInfo); stdcall;
+    procedure OnClientActionRequired(Data: PEOS_AntiCheatCommon_OnClientActionRequiredCallbackInfo); stdcall;
+    procedure OnClientAuthStatusChanged(Data: PEOS_AntiCheatCommon_OnClientAuthStatusChangedCallbackInfo); stdcall;
+  public
+    constructor Create(LogLevel: Integer; ServerName: String; Timeout: Integer);
+    destructor Destroy; override;
+    procedure RegisterClient(Peer: Pointer);
+    procedure UnregisterClient(Peer: Pointer);
+    property AntiCheatHandle: EOS_HAntiCheatClient read FAntiCheatHandle;
+  end;
+  {$ENDIF}
+
+  {$IFDEF SERVER}
+  procedure OnMessageToClientCallback(Data: PEOS_AntiCheatCommon_OnMessageToClientCallbackInfo); stdcall;
+  procedure OnClientActionRequiredCallback(Data: PEOS_AntiCheatCommon_OnClientActionRequiredCallbackInfo); stdcall;
+  procedure OnClientAuthStatusChangedCallback(Data: PEOS_AntiCheatCommon_OnClientAuthStatusChangedCallbackInfo); stdcall;
+  {$ELSE}
+  procedure OnMessageToServerCallback(Data: PEOS_AntiCheatClient_OnMessageToServerCallbackInfo); stdcall;
+  procedure OnCreateUserCallback(Data: PEOS_Connect_CreateUserCallbackInfo);
+  procedure OnLoginConnectCallback(Data: PEOS_Connect_LoginCallbackInfo); stdcall;
+  {$ENDIF}
+  procedure EOS_LogHandler(var Message: EOS_LogMessage); stdcall;
+
+implementation
+
+{$IFDEF SERVER}
+uses Server;
+{$ELSE}
+uses Client;
+{$ENDIF}
+
+constructor TEpicOnlineServices.Create(LogLevel: Integer);
+var
+  InitializeOptions: EOS_InitializeOptions;
+  PlatformOptions: EOS_Platform_Options;
+  EOSResult: EOS_EResult;
+{$IFDEF WINDOWS}
+  RtcOptions: EOS_Platform_RTCOptions;
+  WindowsRTC: EOS_Windows_RTCOptions;
+{$ENDIF}
+begin
+  InitializeOptions := Default(EOS_InitializeOptions);
+  InitializeOptions.ApiVersion := EOS_INITIALIZE_API_LATEST;
+  InitializeOptions.AllocateMemoryFunction := nil;
+  InitializeOptions.ReallocateMemoryFunction := nil;
+  InitializeOptions.ReleaseMemoryFunction := nil;
+  InitializeOptions.ProductName := PChar('Soldat');
+  InitializeOptions.ProductVersion := PChar(SOLDAT_VERSION);
+  InitializeOptions.Reserved := nil;
+  InitializeOptions.SystemInitializeOptions := nil;
+  InitializeOptions.OverrideThreadAffinity := nil;
+
+  EOSResult := EOS_Initialize(@InitializeOptions);
+
+  if EOSResult <> EOS_SUCCESS then
+    raise Exception.Create('EOS_Initialize has failed: ' + EOS_EResult_ToString(EOSResult));
+
+  EOSResult := EOS_Logging_SetLogLevel(EOS_LC_ALL_CATEGORIES, EOS_ELogLevel(LogLevel));
+
+  if EOSResult <> EOS_SUCCESS then
+    raise Exception.Create('EOS_Logging_SetLogLevel has failed: ' + EOS_EResult_ToString(EOSResult));
+
+  EOSResult := EOS_Logging_SetCallback(@EOS_LogHandler);
+
+  if EOSResult <> EOS_SUCCESS then
+    raise Exception.Create('EOS_Logging_SetCallback has failed: ' + EOS_EResult_ToString(EOSResult));
+
+  PlatformOptions := Default(EOS_Platform_Options);
+
+  PlatformOptions.ApiVersion := EOS_PLATFORM_OPTIONS_API_LATEST;
+  PlatformOptions.bIsServer := {$IFDEF SERVER}EOS_TRUE{$ELSE}EOS_FALSE{$ENDIF};
+  PlatformOptions.EncryptionKey := PChar('abcd');
+  PlatformOptions.OverrideCountryCode := nil;
+  PlatformOptions.OverrideLocaleCode := nil;
+  PlatformOptions.Flags := EOS_PF_DISABLE_OVERLAY;
+  PlatformOptions.CacheDirectory := PChar(GetTempDir());
+
+  PlatformOptions.ProductId := EOS_PRODUCT_ID;
+  PlatformOptions.SandboxId := EOS_SANDBOX_ID;
+  PlatformOptions.DeploymentId := EOS_DEPLOYMENT_ID;
+
+  {$IFNDEF SERVER}
+  PlatformOptions.ClientCredentials.ClientId := EOS_CLIENT_ID;
+  PlatformOptions.ClientCredentials.ClientSecret := EOS_CLIENT_SECRET;
+  {$ELSE}
+  PlatformOptions.ClientCredentials.ClientId := EOS_SERVER_ID;
+  PlatformOptions.ClientCredentials.ClientSecret := EOS_SERVER_SECRET;
+  {$ENDIF}
+
+  // A budget, measured in milliseconds, for EOS_Platform_Tick to do its work.
+  PlatformOptions.TickBudgetInMilliseconds := 10;
+  PlatformOptions.Reserved := nil;
+
+  {$IFDEF WINDOWS}
+  WindowsRTC.ApiVersion := EOS_WINDOWS_RTCOPTIONS_API_LATEST;
+  WindowsRTC.XAudio29DllPath := PChar(GetCurrentDir + '/xaudio2_9redist.dll');
+
+  RtcOptions.ApiVersion := EOS_PLATFORM_RTCOPTIONS_API_LATEST;
+  RtcOptions.PlatformSpecificOptions := @WindowsRTC;
+
+  PlatformOptions.RTCOptions := @RtcOptions;
+  {$ELSE}
+  PlatformOptions.RTCOptions := nil;
+  {$ENDIF}
+
+  FPlatformHandle := EOS_Platform_Create(@PlatformOptions);
+
+  if FPlatformHandle = nil then
+    raise Exception.Create('EOS_Platform_Create is nil');
+end;
+
+destructor TEpicOnlineServices.Destroy();
+begin
+  if FPlatformHandle <> nil then
+    EOS_Platform_Release(FPlatformHandle);
+
+  FPlatformHandle := nil;
+
+  EOS_Shutdown();
+end;
+
+procedure TEpicOnlineServices.OnClockTick();
+begin
+  if FPlatformHandle <> nil then
+    EOS_Platform_Tick(FPlatformHandle);
+end;
+
+{$IFNDEF SERVER}
+constructor TEpicOnlineServicesClient.Create(LogLevel: Integer);
+var
+  AddNotifyMessageToServerOptions: EOS_AntiCheatClient_AddNotifyMessageToServerOptions;
+begin
+  inherited Create(LogLevel);
+
+  FAntiCheatHandle := EOS_Platform_GetAntiCheatClientInterface(FPlatformHandle);
+
+  if FAntiCheatHandle = nil then
+    raise Exception.Create('[EOS] Failed to initialize Anti-Cheat');
+
+  FPollStatusOptions.ApiVersion := EOS_ANTICHEATCLIENT_POLLSTATUS_API_LATEST;
+  FPollStatusOptions.OutMessageLength := 1024;
+
+  AddNotifyMessageToServerOptions.ApiVersion := EOS_ANTICHEATCLIENT_ADDNOTIFYMESSAGETOSERVER_API_LATEST;
+  FAddNotifyMessageToServerId := EOS_AntiCheatClient_AddNotifyMessageToServer(FAntiCheatHandle, @AddNotifyMessageToServerOptions, Self, @OnMessageToServerCallback);
+end;
+
+destructor TEpicOnlineServicesClient.Destroy;
+begin
+  EndSession();
+  EOS_AntiCheatClient_RemoveNotifyMessageToServer(FAntiCheatHandle, FAddNotifyMessageToServerId);
+
+  inherited;
+end;
+
+procedure TEpicOnlineServicesClient.BeginSession();
+var
+  SessionOptions: EOS_AntiCheatClient_BeginSessionOptions;
+  EOSResult: EOS_EResult;
+begin
+  if FLocalUser <> nil then
+  begin
+    SessionOptions.ApiVersion := EOS_ANTICHEATCLIENT_BEGINSESSION_API_LATEST;
+    SessionOptions.LocalUserId := FLocalUser;
+    SessionOptions.Mode := EOS_ACCM_ClientServer;
+
+    EOSResult := EOS_AntiCheatClient_BeginSession(FAntiCheatHandle, @SessionOptions);
+    if EOSResult <> EOS_SUCCESS then
+      Debug('[EOS] EOS_AntiCheatClient_BeginSession failed: ' + EOS_EResult_ToString(EOSResult));
+  end else
+  begin
+    {$IFDEF STEAM}
+    SteamAPI.User.RequestEncryptedAppTicket(nil, 0);
+    {$ELSE}
+    OpenIDLogin();
+    {$ENDIF}
+  end;
+end;
+
+procedure TEpicOnlineServicesClient.EndSession();
+var
+  Options: EOS_AntiCheatClient_EndSessionOptions;
+  EOSResult: EOS_EResult;
+begin
+  Options.ApiVersion := EOS_ANTICHEATCLIENT_ENDSESSION_API_LATEST;
+
+  if FAntiCheatHandle <> nil then
+  begin
+    EOSResult := EOS_AntiCheatClient_EndSession(FAntiCheatHandle, @Options);
+    if EOSResult <> EOS_SUCCESS then
+      Debug('[EOS] EOS_AntiCheatClient_EndSession failed: ' + EOS_EResult_ToString(EOSResult));
+  end;
+end;
+{$IFDEF STEAM}
+procedure TEpicOnlineServicesClient.OnSteamAuth();
+var
+  AppTicket: array[0..1024] of Byte;
+  AppTicketSize: LongWord;
+  EOSTicket: TCharArray;
+  EOSTicketSize: LongWord;
+  ConnectCredentials: EOS_Connect_Credentials;
+  LoginOptions: EOS_Connect_LoginOptions;
+begin
+  Debug('[EOS] OnSteamAuth');
+  EOSTicket := Default(TCharArray);
+
+  if SteamAPI.User.GetEncryptedAppTicket(@AppTicket, 1024, @AppTicketSize) then
+  begin
+    EOSTicketSize := (AppTicketSize * 2) + 1;
+    SetLength(EOSTicket, EOSTicketSize);
+    if EOS_ByteArray_ToString(@AppTicket[0], AppTicketSize, @EOSTicket[0], @EOSTicketSize) <> EOS_Success then
+    begin
+      Debug('[EOS] EOS_ByteArray_ToString failed');
+      Exit;
+    end;
+
+    FConnectHandle := EOS_Platform_GetConnectInterface(FPlatformHandle);
+
+    ConnectCredentials.ApiVersion := EOS_CONNECT_CREDENTIALS_API_LATEST;
+    ConnectCredentials.Token := @EOSTicket[0];
+    ConnectCredentials._Type := EOS_ECT_STEAM_APP_TICKET;
+
+    LoginOptions.ApiVersion := EOS_CONNECT_LOGIN_API_LATEST;
+    LoginOptions.UserLoginInfo := nil;
+    LoginOptions.Credentials := @ConnectCredentials;
+
+    EOS_Connect_Login(FConnectHandle, @LoginOptions, Self, @OnLoginConnectCallback);
+  end else
+    Debug('[EOS] GetEncryptedAppTicket failed');
+end;
+{$ENDIF}
+
+procedure TEpicOnlineServicesClient.OpenIDLogin();
+var
+  ConnectCredentials: EOS_Connect_Credentials;
+  LoginOptions: EOS_Connect_LoginOptions;
+begin
+  Debug('[EOS] OpenIDLogin');
+  FConnectHandle := EOS_Platform_GetConnectInterface(FPlatformHandle);
+
+  ConnectCredentials.ApiVersion := EOS_CONNECT_CREDENTIALS_API_LATEST;
+  ConnectCredentials.Token := PChar(HWID);
+  ConnectCredentials._Type := EOS_ECT_OPENID_ACCESS_TOKEN;
+
+  LoginOptions.ApiVersion := EOS_CONNECT_LOGIN_API_LATEST;
+  LoginOptions.UserLoginInfo := nil;
+  LoginOptions.Credentials := @ConnectCredentials;
+
+  EOS_Connect_Login(FConnectHandle, @LoginOptions, Self, @OnLoginConnectCallback);
+end;
+
+procedure TEpicOnlineServicesClient.OnMessageToServer(Data: PEOS_AntiCheatClient_OnMessageToServerCallbackInfo); stdcall;
+var
+  EACMsg: PMsg_EACMessage;
+  Size: Integer;
+  SendBuffer: TCharArray;
+begin
+  Debug('[EOS] OnMessageToServer');
+  SendBuffer := Default(TCharArray);
+
+  Size := SizeOf(TMsg_EACMessage) + Data.MessageDataSizeBytes;
+  SetLength(SendBuffer, Size);
+
+  EACMsg := PMsg_EACMessage(SendBuffer);
+  EACMsg.Header.ID := MsgID_EACMessage;
+
+  Move(Data.MessageData^, EACMsg.Data, Data.MessageDataSizeBytes);
+
+  UDP.SendData(EACMsg^, Size, k_nSteamNetworkingSend_Reliable);
+end;
+
+procedure TEpicOnlineServicesClient.OnCreateUser(Data: PEOS_Connect_CreateUserCallbackInfo);
+begin
+  Debug('[EOS] OnCreateUser');
+  if Data.ResultCode = EOS_Success then
+    FLocalUser := Data.LocalUserId;
+end;
+
+procedure TEpicOnlineServicesClient.OnLoginConnect(Data: PEOS_Connect_LoginCallbackInfo); stdcall;
+var
+  CreateUserOptions: EOS_Connect_CreateUserOptions;
+begin
+  Debug('[EOS] OnLoginConnect');
+  if Data.ResultCode = EOS_InvalidUser then
+  begin
+    CreateUserOptions.ApiVersion := EOS_CONNECT_CREATEUSER_API_LATEST;
+    CreateUserOptions.ContinuanceToken := Data.ContinuanceToken;
+    EOS_Connect_CreateUser(FConnectHandle, @CreateUserOptions, Self, @OnCreateUserCallback);
+  end
+  else if Data.ResultCode = EOS_Success then
+  begin
+    FLocalUser := Data.LocalUserId;
+    Self.BeginSession();
+  end else
+    Debug('[EOS] Unhandled OnLoginConnect event');
+end;
+
+procedure TEpicOnlineServicesClient.OnClockTick();
+var
+  PollStatusMessage: array[0..1024] of Char;
+  ViolationType: EOS_EAntiCheatClientViolationType;
+begin
+  inherited;
+
+  if EOS_AntiCheatClient_PollStatus(FAntiCheatHandle, @FPollStatusOptions, @ViolationType, @PollStatusMessage) = EOS_Success then
+  begin
+    ShowMessage('Anti-cheat violation: ' + StrPas(PollStatusMessage));
+    ShutDown;
+  end;
+end;
+{$ELSE}
+
+constructor TEpicOnlineServicesServer.Create(LogLevel: Integer; ServerName: String; Timeout: Integer);
+var
+  SessionOptions: EOS_AntiCheatServer_BeginSessionOptions;
+  FAddNotifyMessageToClientOptions: EOS_AntiCheatServer_AddNotifyMessageToClientOptions;
+  FAddNotifyClientActionRequiredOptions: EOS_AntiCheatServer_AddNotifyClientActionRequiredOptions;
+  FAddNotifyClientAuthStatusChangedOptions: EOS_AntiCheatServer_AddNotifyClientAuthStatusChangedOptions;
+  EOSResult: EOS_EResult;
+begin
+  inherited Create(LogLevel);
+
+  Self.FAntiCheatHandle := EOS_Platform_GetAntiCheatServerInterface(FPlatformHandle);
+
+  if FAntiCheatHandle = nil then
+    raise Exception.Create('[EOS] EOS_Platform_GetAntiCheatServerInterface is nil');
+
+  FAddNotifyMessageToClientOptions.ApiVersion := EOS_ANTICHEATSERVER_ADDNOTIFYMESSAGETOCLIENT_API_LATEST;
+  FAddNotifyMessageToClientId := EOS_AntiCheatServer_AddNotifyMessageToClient(FAntiCheatHandle, @FAddNotifyMessageToClientOptions, Self, @OnMessageToClientCallback);
+
+  if FAddNotifyMessageToClientId = EOS_INVALID_NOTIFICATIONID then
+    raise Exception.Create('[EOS] EOS_AntiCheatServer_AddNotifyMessageToClient returned invalid id');
+
+  FAddNotifyClientActionRequiredOptions.ApiVersion := EOS_ANTICHEATSERVER_ADDNOTIFYCLIENTACTIONREQUIRED_API_LATEST;
+  FAddNotifyClientActionRequiredId := EOS_AntiCheatServer_AddNotifyClientActionRequired(FAntiCheatHandle, @FAddNotifyClientActionRequiredOptions, Self, @OnClientActionRequiredCallback);
+
+  if FAddNotifyClientActionRequiredId = EOS_INVALID_NOTIFICATIONID then
+    raise Exception.Create('[EOS] EOS_AntiCheatServer_AddNotifyClientActionRequired returned invalid id');
+
+  FAddNotifyClientAuthStatusChangedOptions.ApiVersion := EOS_ANTICHEATSERVER_ADDNOTIFYCLIENTAUTHSTATUSCHANGED_API_LATEST;
+  FAddNotifyClientAuthStatusChangedId := EOS_AntiCheatServer_AddNotifyClientAuthStatusChanged(FAntiCheatHandle, @FAddNotifyClientAuthStatusChangedOptions, Self, @OnClientAuthStatusChangedCallback);
+
+  if FAddNotifyClientAuthStatusChangedId = EOS_INVALID_NOTIFICATIONID then
+    raise Exception.Create('[EOS] EOS_AntiCheatServer_AddNotifyClientAuthStatusChanged returned invalid id');
+
+  SessionOptions.ApiVersion := EOS_ANTICHEATSERVER_BEGINSESSION_API_LATEST;
+  SessionOptions.RegisterTimeoutSeconds := Timeout;
+  SessionOptions.ServerName := PChar(ServerName);
+  SessionOptions.bEnableGameplayData := EOS_FALSE;
+  SessionOptions.LocalUserId := nil;
+
+  EOSResult := EOS_AntiCheatServer_BeginSession(FAntiCheatHandle, @SessionOptions);
+  if EOSResult <> EOS_SUCCESS then
+    raise Exception.Create('[EOS] EOS_AntiCheatServer_BeginSession failed: ' + EOS_EResult_ToString(EOSResult));
+end;
+
+destructor TEpicOnlineServicesServer.Destroy;
+var
+  Options: EOS_AntiCheatServer_EndSessionOptions;
+begin
+  EOS_AntiCheatServer_RemoveNotifyMessageToClient(FAntiCheatHandle, FAddNotifyMessageToClientId);
+  EOS_AntiCheatServer_RemoveNotifyClientActionRequired(FAntiCheatHandle, FAddNotifyClientActionRequiredId);
+  EOS_AntiCheatServer_RemoveNotifyClientAuthStatusChanged(FAntiCheatHandle, FAddNotifyClientAuthStatusChangedId);
+
+  Options.ApiVersion := EOS_ANTICHEATSERVER_ENDSESSION_API_LATEST;
+  EOS_AntiCheatServer_EndSession(FAntiCheatHandle, @Options);
+
+  inherited;
+end;
+
+procedure TEpicOnlineServicesServer.RegisterClient(Peer: Pointer);
+var
+  Options: EOS_AntiCheatServer_RegisterClientOptions;
+  {$IFDEF STEAM}
+  SteamID: TSteamID;
+  {$ENDIF}
+  EOSResult: EOS_EResult;
+begin
+  Options.ApiVersion := EOS_ANTICHEATSERVER_REGISTERCLIENT_API_LATEST;
+  Options.ClientHandle := Peer;
+  Options.ClientType := EOS_ACCCT_ProtectedClient;
+  // TODO: Set a proper platform based on ... not sure what
+  Options.ClientPlatform := EOS_ACCCP_Unknown;
+  {$IFDEF STEAM}
+  SteamID := TPlayer(Peer).SteamID;
+  Options.AccountID := PChar(SteamID.GetAsString);
+  {$ELSE}
+  Options.AccountID := PChar(TPlayer(Peer).HWID);
+  {$ENDIF}
+  Options.IpAddress := PChar(TPlayer(Peer).IP);
+
+  EOSResult := EOS_AntiCheatServer_RegisterClient(FAntiCheatHandle, @Options);
+  if EOSResult <> EOS_SUCCESS then
+    Debug('[EOS] Failed to register player' + TPlayer(Peer).Name);
+end;
+
+procedure TEpicOnlineServicesServer.UnregisterClient(Peer: Pointer);
+var
+  Options: EOS_AntiCheatServer_UnregisterClientOptions;
+  EOSResult: EOS_EResult;
+begin
+  Options.ApiVersion := EOS_ANTICHEATSERVER_UNREGISTERCLIENT_API_LATEST;
+  Options.ClientHandle := Peer;
+
+  EOSResult := EOS_AntiCheatServer_UnregisterClient(FAntiCheatHandle, @Options);
+  if EOSResult <> EOS_SUCCESS then
+    Debug('[EOS] Failed to unregister player: ' + TPlayer(Peer).Name);
+end;
+
+
+procedure TEpicOnlineServicesServer.OnMessageToClient(Data: PEOS_AntiCheatCommon_OnMessageToClientCallbackInfo); stdcall;
+var
+  Player: TPlayer;
+  EACMsg: PMsg_EACMessage;
+  Size: Integer;
+  SendBuffer: TCharArray;
+begin
+  SendBuffer := Default(TCharArray);
+
+  if Data.ClientHandle = nil then
+  begin
+    Debug('[EOS] OnMessageToClientCallback: ClientHandle is nil');
+    Exit;
+  end;
+
+  Player := TPlayer(Data.ClientHandle);
+
+  Size := SizeOf(TMsg_EACMessage) + Data.MessageDataSizeBytes;
+  SetLength(SendBuffer, Size);
+
+  EACMsg := PMsg_EACMessage(SendBuffer);
+  EACMsg.Header.ID := MsgID_EACMessage;
+
+  Move(Data.MessageData^, EACMsg.Data, Data.MessageDataSizeBytes);
+
+  UDP.SendData(EACMsg^, Size, Player.Peer, k_nSteamNetworkingSend_Reliable);
+end;
+
+
+procedure TEpicOnlineServicesServer.OnClientActionRequired(Data: PEOS_AntiCheatCommon_OnClientActionRequiredCallbackInfo); stdcall;
+var
+  Player: TPlayer;
+begin
+  if Data.ClientAction = EOS_ACCCA_RemovePlayer then
+  begin
+    Player := TPlayer(Data.ClientHandle);
+    MainConsole.Console(Format('[EAC] Violation detected - name: %s(%s) reason: %s', [Player.Name, Player.IP, Data.ActionReasonDetailsString]), WARNING_MESSAGE_COLOR);
+
+    if Player.SpriteNum <> 0 then
+      KickPlayer(Player.SpriteNum, False, KICK_AC, 0, 'Anti-Cheat violation: ' + Data.ActionReasonDetailsString)
+    else
+      ServerSendUnAccepted(Player.Peer, ANTICHEAT_REJECTED, Data.ActionReasonDetailsString);
+
+    Self.UnregisterClient(Data.ClientHandle);
+  end;
+end;
+
+procedure TEpicOnlineServicesServer.OnClientAuthStatusChanged(Data: PEOS_AntiCheatCommon_OnClientAuthStatusChangedCallbackInfo); stdcall;
+var
+  Status: String;
+begin
+  WriteStr(Status, Data.ClientAuthStatus);
+  Debug('[EOS] OnClientAuthStatusChanged ' + TPlayer(Data.ClientHandle).Name + ' set to ' + Status);
+end;
+{$ENDIF}
+
+{$IFDEF SERVER}
+procedure ServerHandleEACMessage(NetMessage: PSteamNetworkingMessage_t);
+var
+  EACMsg: PMsg_EACMessage;
+  Player: TPlayer;
+  Options: EOS_AntiCheatServer_ReceiveMessageFromClientOptions;
+  EOSResult: EOS_EResult;
+begin
+  if not Assigned(EACServer) then
+    Exit;
+
+  if not VerifyPacketLargerOrEqual(sizeof(EACMsg), NetMessage^.m_cbSize, MsgID_EACMessage) then
+    Exit;
+
+  Player := TPlayer(NetMessage^.m_nConnUserData);
+
+  EACMsg := PMsg_EACMessage(NetMessage^.m_pData);
+
+  Options.ApiVersion := EOS_ANTICHEATSERVER_RECEIVEMESSAGEFROMCLIENT_API_LATEST;
+  Options.ClientHandle := Player;
+  Options.DataLengthBytes := NetMessage^.m_cbSize - SizeOf(TMsg_EACMessage);
+  Options.Data := @EACMsg^.Data;
+
+  EOSResult := EOS_AntiCheatServer_ReceiveMessageFromClient(EACServer.AntiCheatHandle, @Options);
+  if EOSResult <> EOS_SUCCESS then
+    Debug('[EOS] EOS_AntiCheatServer_ReceiveMessageFromClient failed: ' + EOS_EResult_ToString(EOSResult));
+end;
+{$ELSE}
+procedure ClientHandleEACMessage(NetMessage: PSteamNetworkingMessage_t);
+var
+  EACMsg: PMsg_EACMessage;
+  Options: EOS_AntiCheatClient_ReceiveMessageFromServerOptions;
+  EOSResult: EOS_EResult;
+begin
+  if not Assigned(EACClient) then
+    Exit;
+
+  if not VerifyPacketLargerOrEqual(sizeof(EACMsg), NetMessage^.m_cbSize, MsgID_EACMessage) then
+    Exit;
+
+  EACMsg := PMsg_EACMessage(NetMessage^.m_pData);
+
+  Options.ApiVersion := EOS_ANTICHEATCLIENT_RECEIVEMESSAGEFROMSERVER_API_LATEST;
+  Options.DataLengthBytes := NetMessage^.m_cbSize - SizeOf(TMsg_EACMessage);
+  Options.Data := @EACMsg^.Data[0];
+
+  EOSResult := EOS_AntiCheatClient_ReceiveMessageFromServer(EACClient.AntiCheatHandle, @Options);
+  if EOSResult <> EOS_SUCCESS then
+    Debug('[EOS] EOS_AntiCheatClient_ReceiveMessageFromServer failed: ' + EOS_EResult_ToString(EOSResult));
+end;
+{$ENDIF}
+
+{$IFDEF SERVER}
+procedure OnMessageToClientCallback(Data: PEOS_AntiCheatCommon_OnMessageToClientCallbackInfo); stdcall;
+begin
+  if Data.ClientData <> nil then
+    TEpicOnlineServicesServer(Data.ClientData).OnMessageToClient(Data);
+end;
+
+procedure OnClientActionRequiredCallback(Data: PEOS_AntiCheatCommon_OnClientActionRequiredCallbackInfo); stdcall;
+begin
+  if Data.ClientData <> nil then
+    TEpicOnlineServicesServer(Data.ClientData).OnClientActionRequired(Data);
+end;
+
+procedure OnClientAuthStatusChangedCallback(Data: PEOS_AntiCheatCommon_OnClientAuthStatusChangedCallbackInfo); stdcall;
+begin
+  if Data.ClientData <> nil then
+    TEpicOnlineServicesServer(Data.ClientData).OnClientAuthStatusChanged(Data);
+end;
+{$ELSE}
+procedure OnMessageToServerCallback(Data: PEOS_AntiCheatClient_OnMessageToServerCallbackInfo); stdcall;
+begin
+  if Data.ClientData <> nil then
+    TEpicOnlineServicesClient(Data.ClientData).OnMessageToServer(Data);
+end;
+
+procedure OnCreateUserCallback(Data: PEOS_Connect_CreateUserCallbackInfo);
+begin
+  if Data.ClientData <> nil then
+    TEpicOnlineServicesClient(Data.ClientData).OnCreateUser(Data);
+end;
+
+procedure OnLoginConnectCallback(Data: PEOS_Connect_LoginCallbackInfo); stdcall;
+begin
+  if Data.ClientData <> nil then
+    TEpicOnlineServicesClient(Data.ClientData).OnLoginConnect(Data);
+end;
+{$ENDIF}
+
+procedure EOS_LogHandler(var Message: EOS_LogMessage); stdcall;
+begin
+  MainConsole.Console(Format('[EOS] %s', [Message.Message]), DEBUG_MESSAGE_COLOR);
+end;
+
+end.

--- a/shared/libs/EOS/eos_anticheatclient.pas
+++ b/shared/libs/EOS/eos_anticheatclient.pas
@@ -1,0 +1,244 @@
+{
+ * Add a callback issued when a new message must be dispatched to the game server. The bound function will only be called
+ * between a successful call to EOS_AntiCheatClient_BeginSession and the matching EOS_AntiCheatClient_EndSession call in mode EOS_ACCM_ClientServer.
+ * Mode: EOS_ACCM_ClientServer.
+ *
+ * @param Options Structure containing input data
+ * @param ClientData This value is returned to the caller when NotificationFn is invoked
+ * @param NotificationFn The callback to be fired
+ * @return A valid notification ID if successfully bound, or EOS_INVALID_NOTIFICATIONID otherwise
+ }
+function EOS_AntiCheatClient_AddNotifyMessageToServer(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_AddNotifyMessageToServerOptions; ClientData: Pointer; NotificationFn: EOS_AntiCheatClient_OnMessageToServerCallback): EOS_NotificationId; cdecl; external EOSLIB;
+
+{
+ * Remove a previously bound EOS_AntiCheatClient_AddNotifyMessageToServer handler.
+ * Mode: Any.
+ *
+ * @param NotificationId The previously bound notification ID
+ }
+procedure EOS_AntiCheatClient_RemoveNotifyMessageToServer(Handle: EOS_HAntiCheatClient; NotificationId: EOS_NotificationId); cdecl; external EOSLIB;
+
+{
+ * Add a callback issued when a new message must be dispatched to a connected peer. The bound function will only be called
+ * between a successful call to EOS_AntiCheatClient_BeginSession and the matching EOS_AntiCheatClient_EndSession call in mode EOS_ACCM_PeerToPeer.
+ * Mode: EOS_ACCM_PeerToPeer.
+ *
+ * @param Options Structure containing input data
+ * @param ClientData This value is returned to the caller when NotificationFn is invoked
+ * @param NotificationFn The callback to be fired
+ * @return A valid notification ID if successfully bound, or EOS_INVALID_NOTIFICATIONID otherwise
+ }
+function EOS_AntiCheatClient_AddNotifyMessageToPeer(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_AddNotifyMessageToPeerOptions; ClientData: Pointer; NotificationFn: EOS_AntiCheatClient_OnMessageToPeerCallback): EOS_NotificationId; cdecl; external EOSLIB;
+
+{
+ * Remove a previously bound EOS_AntiCheatClient_AddNotifyMessageToPeer handler.
+ * Mode: Any.
+ *
+ * @param NotificationId The previously bound notification ID
+ }
+procedure EOS_AntiCheatClient_RemoveNotifyMessageToPeer(Handle: EOS_HAntiCheatClient; NotificationId: EOS_NotificationId); cdecl; external EOSLIB;
+
+{
+ * Add a callback issued when an action must be applied to a connected client. The bound function will only be called
+ * between a successful call to EOS_AntiCheatClient_BeginSession and the matching EOS_AntiCheatClient_EndSession call in mode EOS_ACCM_PeerToPeer.
+ * Mode: EOS_ACCM_PeerToPeer.
+ *
+ * @param Options Structure containing input data
+ * @param ClientData This value is returned to the caller when NotificationFn is invoked
+ * @param NotificationFn The callback to be fired
+ * @return A valid notification ID if successfully bound, or EOS_INVALID_NOTIFICATIONID otherwise
+ }
+function EOS_AntiCheatClient_AddNotifyPeerActionRequired(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_AddNotifyPeerActionRequiredOptions; ClientData: Pointer; NotificationFn: EOS_AntiCheatClient_OnPeerActionRequiredCallback): EOS_NotificationId; cdecl; external EOSLIB;
+
+{
+ * Remove a previously bound EOS_AntiCheatClient_AddNotifyPeerActionRequired handler.
+ * Mode: Any.
+ *
+ * @param NotificationId The previously bound notification ID
+ }
+procedure EOS_AntiCheatClient_RemoveNotifyPeerActionRequired(Handle: EOS_HAntiCheatClient; NotificationId: EOS_NotificationId); cdecl; external EOSLIB;
+
+{
+ * Add an optional callback issued when a connected peer's authentication status changes. The bound function will only be called
+ * between a successful call to EOS_AntiCheatClient_BeginSession and the matching EOS_AntiCheatClient_EndSession call in mode EOS_ACCM_PeerToPeer.
+ * Mode: EOS_ACCM_PeerToPeer.
+ *
+ * @param Options Structure containing input data
+ * @param ClientData This value is returned to the caller when NotificationFn is invoked
+ * @param NotificationFn The callback to be fired
+ * @return A valid notification ID if successfully bound, or EOS_INVALID_NOTIFICATIONID otherwise
+ }
+function EOS_AntiCheatClient_AddNotifyPeerAuthStatusChanged(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_AddNotifyPeerAuthStatusChangedOptions; ClientData: Pointer; NotificationFn: EOS_AntiCheatClient_OnPeerAuthStatusChangedCallback): EOS_NotificationId; cdecl; external EOSLIB;
+
+{
+ * Remove a previously bound EOS_AntiCheatClient_AddNotifyPeerAuthStatusChanged handler.
+ * Mode: Any.
+ *
+ * @param NotificationId The previously bound notification ID
+ }
+procedure EOS_AntiCheatClient_RemoveNotifyPeerAuthStatusChanged(Handle: EOS_HAntiCheatClient; NotificationId: EOS_NotificationId); cdecl; external EOSLIB;
+
+{
+ * Begins a multiplayer game session. After this call returns successfully, the client is ready to exchange
+ * anti-cheat messages with a game server or peer(s). When leaving one game session and connecting to a
+ * different one, a new anti-cheat session must be created by calling EOS_AntiCheatClient_EndSession and EOS_AntiCheatClient_BeginSession again.
+ * Mode: All
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the session was started successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ *         EOS_AntiCheat_InvalidMode - If the current mode does not support this function
+ }
+function EOS_AntiCheatClient_BeginSession(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_BeginSessionOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Ends a multiplayer game session, either by leaving an ongoing session or shutting it down entirely.
+ * Mode: All
+ *
+ * Must be called when the multiplayer session ends, or when the local user leaves a session in progress.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the session was ended normally
+ *         EOS_InvalidParameters - If input data was invalid
+ *         EOS_AntiCheat_InvalidMode - If the current mode does not support this function
+ }
+function EOS_AntiCheatClient_EndSession(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_EndSessionOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Polls for changes in client integrity status.
+ * Mode: All
+ *
+ * The purpose of this function is to allow the game to display information
+ * about anti-cheat integrity problems to the user. These are often the result of a
+ * corrupt game installation rather than cheating attempts. This function does not
+ * check for violations, it only provides information about violations which have
+ * automatically been discovered by the anti-cheat client. Such a violation may occur
+ * at any time and afterwards the user will be unable to join any protected multiplayer
+ * session until after restarting the game. Note that this function returns EOS_NotFound
+ * when everything is normal and there is no violation to display.
+ *
+ * @param Options Structure containing input data.
+ * @param OutViolationType On success, receives a code describing the violation that occurred.
+ * @param OutMessage On success, receives a string describing the violation which should be displayed to the user.
+ *
+ * @return EOS_Success - If violation information was returned successfully
+ *		   EOS_LimitExceeded - If OutMessage is too small to receive the message string. Call again with a larger OutMessage.
+ *         EOS_NotFound - If no violation has occurred since the last call
+ }
+function EOS_AntiCheatClient_PollStatus(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_PollStatusOptions; OutViolationType: PEOS_EAntiCheatClientViolationType; OutMessage: Pointer): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional. Adds an integrity catalog and certificate pair from outside the game directory,
+ * for example to support mods that load from elsewhere.
+ * Mode: All
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the integrity catalog was added successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatClient_AddExternalIntegrityCatalog(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_AddExternalIntegrityCatalogOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Call when an anti-cheat message is received from the game server.
+ * Mode: EOS_ACCM_ClientServer.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the message was processed successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ *         EOS_AntiCheat_InvalidMode - If the current mode does not support this function
+ }
+function EOS_AntiCheatClient_ReceiveMessageFromServer(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_ReceiveMessageFromServerOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional NetProtect feature for game message encryption.
+ * Calculates the required decrypted buffer size for a given input data length.
+ * This will not change for a given SDK version, and allows one time allocation of reusable buffers.
+ * Mode: EOS_ACCM_ClientServer.
+ *
+ * @param Options Structure containing input data.
+ * @param OutBufferLengthBytes On success, the OutBuffer length in bytes that is required to call ProtectMessage on the given input size.
+ *
+ * @return EOS_Success - If the output length was calculated successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ *         EOS_AntiCheat_InvalidMode - If the current mode does not support this function
+ }
+function EOS_AntiCheatClient_GetProtectMessageOutputLength(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_GetProtectMessageOutputLengthOptions; OutBufferSizeBytes: pcuint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional NetProtect feature for game message encryption.
+ * Encrypts an arbitrary message that will be sent to the game server and decrypted on the other side.
+ * Mode: EOS_ACCM_ClientServer.
+ *
+ * Options.Data and OutBuffer may refer to the same buffer to encrypt in place.
+ *
+ * @param Options Structure containing input data.
+ * @param OutBuffer On success, buffer where encrypted message data will be written.
+ * @param OutBytesWritten On success, the number of bytes that were written to OutBuffer.
+ *
+ * @return EOS_Success - If the message was protected successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ *         EOS_AntiCheat_InvalidMode - If the current mode does not support this function
+ }
+function EOS_AntiCheatClient_ProtectMessage(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_ProtectMessageOptions; OutBuffer: Pointer; OutBytesWritten: pcuint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional NetProtect feature for game message encryption.
+ * Decrypts an encrypted message received from the game server.
+ * Mode: EOS_ACCM_ClientServer.
+ *
+ * Options.Data and OutBuffer may refer to the same buffer to decrypt in place.
+ *
+ * @param Options Structure containing input data.
+ * @param OutBuffer On success, buffer where encrypted message data will be written.
+ * @param OutBytesWritten On success, the number of bytes that were written to OutBuffer.
+ *
+ * @return EOS_Success - If the message was unprotected successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ *         EOS_AntiCheat_InvalidMode - If the current mode does not support this function
+ }
+function EOS_AntiCheatClient_UnprotectMessage(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_UnprotectMessageOptions; OutBuffer: Pointer; OutBytesWritten: pcuint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Registers a connected peer-to-peer client.
+ * Mode: EOS_ACCM_PeerToPeer.
+ *
+ * Must be paired with a call to EOS_AntiCheatClient_UnregisterPeer if this user leaves the session
+ * in progress, or EOS_AntiCheatClient_EndSession if the entire session is ending.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the player was registered successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ *         EOS_AntiCheat_InvalidMode - If the current mode does not support this function
+ }
+function EOS_AntiCheatClient_RegisterPeer(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_RegisterPeerOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Unregisters a disconnected peer-to-peer client.
+ * Mode: EOS_ACCM_PeerToPeer.
+ *
+ * Must be called when a user leaves a session in progress.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the player was unregistered successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ *         EOS_AntiCheat_InvalidMode - If the current mode does not support this function
+ }
+function EOS_AntiCheatClient_UnregisterPeer(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_UnregisterPeerOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Call when an anti-cheat message is received from a peer.
+ * Mode: EOS_ACCM_PeerToPeer.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the message was processed successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ *         EOS_AntiCheat_InvalidMode - If the current mode does not support this function
+ }
+function EOS_AntiCheatClient_ReceiveMessageFromPeer(Handle: EOS_HAntiCheatClient; Options: PEOS_AntiCheatClient_ReceiveMessageFromPeerOptions): EOS_EResult; cdecl; external EOSLIB;

--- a/shared/libs/EOS/eos_anticheatclient_types.pas
+++ b/shared/libs/EOS/eos_anticheatclient_types.pas
@@ -1,0 +1,248 @@
+type EOS_HAntiCheatClient = Pointer;
+
+{ Operating modes }
+EOS_EAntiCheatClientMode = (
+    { Not used }
+    EOS_ACCM_Invalid = 0,
+    { Dedicated or listen server mode }
+    EOS_ACCM_ClientServer = 1,
+    { Full mesh peer-to-peer mode }
+    EOS_ACCM_PeerToPeer = 2
+);
+
+{ Anti-cheat integrity violation types }
+EOS_EAntiCheatClientViolationType = (
+    { Not used }
+    EOS_ACCVT_Invalid = 0,
+    { An anti-cheat asset integrity catalog file could not be found }
+    EOS_ACCVT_IntegrityCatalogNotFound = 1,
+    { An anti-cheat asset integrity catalog file is corrupt or invalid }
+    EOS_ACCVT_IntegrityCatalogError = 2,
+    { An anti-cheat asset integrity catalog file's certificate has been revoked. }
+    EOS_ACCVT_IntegrityCatalogCertificateRevoked = 3,
+    {
+     * The primary anti-cheat asset integrity catalog does not include an entry for the game's
+     * main executable, which is required.
+     }
+    EOS_ACCVT_IntegrityCatalogMissingMainExecutable = 4,
+    { A disallowed game file modification was detected }
+    EOS_ACCVT_GameFileMismatch = 5,
+    { A disallowed game file removal was detected }
+    EOS_ACCVT_RequiredGameFileNotFound = 6,
+    { A disallowed game file addition was detected }
+    EOS_ACCVT_UnknownGameFileForbidden = 7,
+    { A system file failed an integrity check }
+    EOS_ACCVT_SystemFileUntrusted = 8,
+    { A disallowed code module was loaded into the game process }
+    EOS_ACCVT_ForbiddenModuleLoaded = 9,
+    { A disallowed game process memory modification was detected }
+    EOS_ACCVT_CorruptedMemory = 10,
+    { A disallowed tool was detected running in the system }
+    EOS_ACCVT_ForbiddenToolDetected = 11,
+    { An internal anti-cheat integrity check failed }
+    EOS_ACCVT_InternalAntiCheatViolation = 12,
+    { Integrity checks on messages between the game client and game server failed }
+    EOS_ACCVT_CorruptedNetworkMessageFlow = 13,
+    { The game is running inside a disallowed virtual machine }
+    EOS_ACCVT_VirtualMachineNotAllowed = 14,
+    { A forbidden operating system configuration was detected }
+    EOS_ACCVT_ForbiddenSystemConfiguration = 15
+);
+PEOS_EAntiCheatClientViolationType = ^EOS_EAntiCheatClientViolationType;
+
+{
+ * Structure containing details about a new message that must be dispatched to the game server.
+ }
+type EOS_AntiCheatClient_OnMessageToServerCallbackInfo = record
+    { Caller-specified context data }
+    ClientData: Pointer;
+    { The message data that must be sent to the server }
+    MessageData: Pointer;
+    { The size in bytes of MessageData }
+    MessageDataSizeBytes: cuint32;
+end;
+
+type PEOS_AntiCheatClient_OnMessageToServerCallbackInfo = ^EOS_AntiCheatClient_OnMessageToServerCallbackInfo;
+
+{
+ * Callback issued when a new message must be dispatched to the game server.
+ *
+ * Messages contain opaque binary data of up to 256 bytes and must be transmitted
+ * to the game server using the game's own networking layer, then delivered
+ * to the server anti-cheat instance using the EOS_AntiCheatServer_ReceiveMessageFromClient function.
+ *
+ * This callback is always issued from within EOS_Platform_Tick on its calling thread.
+ }
+type EOS_AntiCheatClient_OnMessageToServerCallback = procedure(Data: PEOS_AntiCheatClient_OnMessageToServerCallbackInfo);
+{
+ * Callback issued when a new message must be dispatched to a connected peer.
+ *
+ * Messages contain opaque binary data of up to 256 bytes and must be transmitted
+ * to the correct peer using the game's own networking layer, then delivered
+ * to the client anti-cheat instance using the EOS_AntiCheatClient_ReceiveMessageFromPeer function.
+ *
+ * This callback is always issued from within EOS_Platform_Tick on its calling thread.
+ }
+type EOS_AntiCheatClient_OnMessageToPeerCallback = procedure(Data: PEOS_AntiCheatCommon_OnMessageToClientCallbackInfo);
+{
+ * Callback issued when an action must be applied to a connected peer.
+ * This callback is always issued from within EOS_Platform_Tick on its calling thread.
+ }
+type EOS_AntiCheatClient_OnPeerActionRequiredCallback = procedure(Data: PEOS_AntiCheatCommon_OnClientActionRequiredCallbackInfo);
+{
+ * Optional callback issued when a connected peer's authentication status has changed.
+ * This callback is always issued from within EOS_Platform_Tick on its calling thread.
+ }
+type EOS_AntiCheatClient_OnPeerAuthStatusChangedCallback = procedure(Data: PEOS_AntiCheatCommon_OnClientAuthStatusChangedCallbackInfo);
+const EOS_ANTICHEATCLIENT_ADDNOTIFYMESSAGETOSERVER_API_LATEST = 1;
+type EOS_AntiCheatClient_AddNotifyMessageToServerOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_ADDNOTIFYMESSAGETOSERVER_API_LATEST. }
+    ApiVersion: cint32;
+end;
+type PEOS_AntiCheatClient_AddNotifyMessageToServerOptions = ^EOS_AntiCheatClient_AddNotifyMessageToServerOptions;
+const EOS_ANTICHEATCLIENT_ADDNOTIFYMESSAGETOPEER_API_LATEST = 1;
+type EOS_AntiCheatClient_AddNotifyMessageToPeerOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_ADDNOTIFYMESSAGETOPEER_API_LATEST. }
+    ApiVersion: cint32;
+end;
+type PEOS_AntiCheatClient_AddNotifyMessageToPeerOptions = ^EOS_AntiCheatClient_AddNotifyMessageToPeerOptions;
+const EOS_ANTICHEATCLIENT_ADDNOTIFYPEERACTIONREQUIRED_API_LATEST = 1;
+type EOS_AntiCheatClient_AddNotifyPeerActionRequiredOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_ADDNOTIFYPEERACTIONREQUIRED_API_LATEST. }
+    ApiVersion: cint32;
+end;
+type PEOS_AntiCheatClient_AddNotifyPeerActionRequiredOptions = ^EOS_AntiCheatClient_AddNotifyPeerActionRequiredOptions;
+const EOS_ANTICHEATCLIENT_ADDNOTIFYPEERAUTHSTATUSCHANGED_API_LATEST = 1;
+type EOS_AntiCheatClient_AddNotifyPeerAuthStatusChangedOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_ADDNOTIFYPEERAUTHSTATUSCHANGED_API_LATEST. }
+    ApiVersion: cint32;
+end;
+type PEOS_AntiCheatClient_AddNotifyPeerAuthStatusChangedOptions = ^EOS_AntiCheatClient_AddNotifyPeerAuthStatusChangedOptions;
+const EOS_ANTICHEATCLIENT_BEGINSESSION_API_LATEST = 3;
+type EOS_AntiCheatClient_BeginSessionOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_BEGINSESSION_API_LATEST. }
+    ApiVersion: cint32;
+    { Logged in user identifier from earlier call to EOS_Connect_Login family of functions }
+    LocalUserId: EOS_ProductUserId;
+    { Operating mode }
+    Mode: EOS_EAntiCheatClientMode;
+end;
+type PEOS_AntiCheatClient_BeginSessionOptions = ^EOS_AntiCheatClient_BeginSessionOptions;
+const EOS_ANTICHEATCLIENT_ENDSESSION_API_LATEST = 1;
+type EOS_AntiCheatClient_EndSessionOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_ENDSESSION_API_LATEST. }
+    ApiVersion: cint32;
+end;
+type PEOS_AntiCheatClient_EndSessionOptions = ^EOS_AntiCheatClient_EndSessionOptions;
+const EOS_ANTICHEATCLIENT_POLLSTATUS_API_LATEST = 1;
+type EOS_AntiCheatClient_PollStatusOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_POLLSTATUS_API_LATEST. }
+    ApiVersion: cint32;
+    { The size of OutMessage in bytes. Recommended size is 256 bytes. }
+    OutMessageLength: cuint32;
+end;
+type PEOS_AntiCheatClient_PollStatusOptions = ^EOS_AntiCheatClient_PollStatusOptions;
+const EOS_ANTICHEATCLIENT_ADDEXTERNALINTEGRITYCATALOG_API_LATEST = 1;
+type EOS_AntiCheatClient_AddExternalIntegrityCatalogOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_ADDEXTERNALINTEGRITYCATALOG_API_LATEST. }
+    ApiVersion: cint32;
+    { UTF-8 path to the .bin catalog file to add }
+    PathToBinFile: PChar;
+end;
+type PEOS_AntiCheatClient_AddExternalIntegrityCatalogOptions = ^EOS_AntiCheatClient_AddExternalIntegrityCatalogOptions;
+const EOS_ANTICHEATCLIENT_RECEIVEMESSAGEFROMSERVER_API_LATEST = 1;
+type EOS_AntiCheatClient_ReceiveMessageFromServerOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_RECEIVEMESSAGEFROMSERVER_API_LATEST. }
+    ApiVersion: cint32;
+    { The size of the data received }
+    DataLengthBytes: cuint32;
+    { The data received }
+    Data: Pointer;
+end;
+type PEOS_AntiCheatClient_ReceiveMessageFromServerOptions = ^EOS_AntiCheatClient_ReceiveMessageFromServerOptions;
+const EOS_ANTICHEATCLIENT_GETPROTECTMESSAGEOUTPUTLENGTH_API_LATEST = 1;
+type EOS_AntiCheatClient_GetProtectMessageOutputLengthOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_GETPROTECTMESSAGEOUTPUTLENGTH_API_LATEST. }
+    ApiVersion: cint32;
+    { Length in bytes of input }
+    DataLengthBytes: cuint32;
+end;
+type PEOS_AntiCheatClient_GetProtectMessageOutputLengthOptions = ^EOS_AntiCheatClient_GetProtectMessageOutputLengthOptions;
+const EOS_ANTICHEATCLIENT_PROTECTMESSAGE_API_LATEST = 1;
+type EOS_AntiCheatClient_ProtectMessageOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_PROTECTMESSAGE_API_LATEST. }
+    ApiVersion: cint32;
+    { Length in bytes of input }
+    DataLengthBytes: cuint32;
+    { The data to encrypt }
+    Data: Pointer;
+    { The size in bytes of OutBuffer }
+    OutBufferSizeBytes: cuint32;
+end;
+type PEOS_AntiCheatClient_ProtectMessageOptions = ^EOS_AntiCheatClient_ProtectMessageOptions;
+const EOS_ANTICHEATCLIENT_UNPROTECTMESSAGE_API_LATEST = 1;
+type EOS_AntiCheatClient_UnprotectMessageOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_UNPROTECTMESSAGE_API_LATEST. }
+    ApiVersion: cint32;
+    { Length in bytes of input }
+    DataLengthBytes: cuint32;
+    { The data to decrypt }
+    Data: Pointer;
+    { The size in bytes of OutBuffer }
+    OutBufferSizeBytes: cuint32;
+end;
+type PEOS_AntiCheatClient_UnprotectMessageOptions = ^EOS_AntiCheatClient_UnprotectMessageOptions;
+{
+ * A special peer handle that represents the client itself.
+ * It does not need to be registered or unregistered and is
+ * used in OnPeerActionRequiredCallback to quickly signal to the user
+ * that they will not be able to join online play.
+ }
+const EOS_ANTICHEATCLIENT_PEER_SELF = (-1);
+
+const EOS_ANTICHEATCLIENT_REGISTERPEER_API_LATEST = 1;
+type EOS_AntiCheatClient_RegisterPeerOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_REGISTERPEER_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value describing the remote user (e.g. a player object pointer) }
+    PeerHandle: EOS_AntiCheatCommon_ClientHandle;
+    { Type of remote user being registered }
+    ClientType: EOS_EAntiCheatCommonClientType;
+    { Remote user's platform, if known }
+    ClientPlatform: EOS_EAntiCheatCommonClientPlatform;
+    { 
+     * Identifier for the remote user. This is typically a string representation of an
+     * account ID, but it can be any string which is both unique (two different users will never
+     * have the same string) and consistent (if the same user connects to this game session
+     * twice, the same string will be used) in the scope of a single protected game session.
+     }
+    AccountId: PChar;
+    { 
+     * Optional IP address for the remote user. May be null if not available.
+     * IPv4 format: "0.0.0.0"
+     * IPv6 format: "0:0:0:0:0:0:0:0"
+     }
+    IpAddress: PChar;
+end;
+type PEOS_AntiCheatClient_RegisterPeerOptions = ^EOS_AntiCheatClient_RegisterPeerOptions;
+const EOS_ANTICHEATCLIENT_UNREGISTERPEER_API_LATEST = 1;
+type EOS_AntiCheatClient_UnregisterPeerOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_UNREGISTERPEER_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value describing the remote user, as previously passed to EOS_AntiCheatClient_RegisterPeer }
+    PeerHandle: EOS_AntiCheatCommon_ClientHandle;
+end;
+type PEOS_AntiCheatClient_UnregisterPeerOptions = ^EOS_AntiCheatClient_UnregisterPeerOptions;
+
+const EOS_ANTICHEATCLIENT_RECEIVEMESSAGEFROMPEER_API_LATEST = 1;
+type EOS_AntiCheatClient_ReceiveMessageFromPeerOptions = record
+    { API Version: Set this to EOS_ANTICHEATCLIENT_RECEIVEMESSAGEFROMPEER_API_LATEST. }
+    ApiVersion: cint32;
+    { The handle describing the sender of this message }
+    PeerHandle: EOS_AntiCheatCommon_ClientHandle;
+    { The size of the data received }
+    DataLengthBytes: cuint32;
+    { The data received }
+    Data: Pointer;
+end;
+type PEOS_AntiCheatClient_ReceiveMessageFromPeerOptions = ^EOS_AntiCheatClient_ReceiveMessageFromPeerOptions;

--- a/shared/libs/EOS/eos_anticheatcommon_types.pas
+++ b/shared/libs/EOS/eos_anticheatcommon_types.pas
@@ -1,0 +1,510 @@
+{ 
+  * Arbitrary data that is a unique local identifier for
+  * a single remote client or peer.
+  *
+  * Typically this is a pointer to an object describing the
+  * player, but it can be anything that is locally unique.
+  }
+type EOS_AntiCheatCommon_ClientHandle = Pointer;
+
+{ Flags describing the type of a remote client }
+EOS_EAntiCheatCommonClientType = (
+    { An ordinary player that requires anti-cheat client protection to play }
+    EOS_ACCCT_ProtectedClient = 0,
+    { The player does not need the anti-cheat client to play because of their platform or other factors }
+    EOS_ACCCT_UnprotectedClient = 1,
+    { The client is an AI bot, not an actual human }
+    EOS_ACCCT_AIBot = 2
+);
+
+{ Flags describing the platform of a remote client, if known }
+EOS_EAntiCheatCommonClientPlatform = (
+    { Unknown platform }
+    EOS_ACCCP_Unknown = 0,
+    { The client is playing on Windows }
+    EOS_ACCCP_Windows = 1,
+    { The client is playing on Mac }
+    EOS_ACCCP_Mac = 2,
+    { The client is playing on Linux }
+    EOS_ACCCP_Linux = 3,
+    { The client is playing on an Xbox device }
+    EOS_ACCCP_Xbox = 4,
+    { The client is playing on a PlayStation device }
+    EOS_ACCCP_PlayStation = 5,
+    { The client is playing on a Nintendo device }
+    EOS_ACCCP_Nintendo = 6,
+    { The client is playing on iOS }
+    EOS_ACCCP_iOS = 7,
+    { The client is playing on Android }
+    EOS_ACCCP_Android = 8
+);
+
+{ Anti-cheat action values. Applicable to both clients and remote peers. }
+EOS_EAntiCheatCommonClientAction = (
+    { Not used }
+    EOS_ACCCA_Invalid = 0,
+    { The client/peer must be removed from the current game session }
+    EOS_ACCCA_RemovePlayer = 1
+);
+
+{ Anti-cheat action reasons. Applicable to both clients and remote peers. }
+EOS_EAntiCheatCommonClientActionReason = (
+    { Not used }
+    EOS_ACCCAR_Invalid = 0,
+    { An internal error occurred }
+    EOS_ACCCAR_InternalError = 1,
+    { An anti-cheat message received from the client/peer was corrupt or invalid }
+    EOS_ACCCAR_InvalidMessage = 2,
+    { The client/peer's anti-cheat authentication failed }
+    EOS_ACCCAR_AuthenticationFailed = 3,
+    { The client/peer failed to load the anti-cheat module at startup }
+    EOS_ACCCAR_NullClient = 4,
+    { The client/peer's anti-cheat heartbeat was not received }
+    EOS_ACCCAR_HeartbeatTimeout = 5,
+    { The client/peer failed an anti-cheat client runtime check }
+    EOS_ACCCAR_ClientViolation = 6,
+    { The client/peer failed an anti-cheat backend runtime check }
+    EOS_ACCCAR_BackendViolation = 7,
+    { The client/peer is temporarily blocked from playing on this game server }
+    EOS_ACCCAR_TemporaryCooldown = 8,
+    { The client/peer is temporarily banned }
+    EOS_ACCCAR_TemporaryBanned = 9,
+    { The client/peer is permanently banned }
+    EOS_ACCCAR_PermanentBanned = 10
+);
+
+{ The client/peer's anti-cheat authentication status }
+EOS_EAntiCheatCommonClientAuthStatus = (
+    { Not used }
+    EOS_ACCCAS_Invalid = 0,
+    { The client/peer's anti-cheat functionality has been validated by this game server }
+    EOS_ACCCAS_LocalAuthComplete = 1,
+    { The client/peer's anti-cheat functionality has been validated by the anti-cheat backend service }
+    EOS_ACCCAS_RemoteAuthComplete = 2
+);
+
+{ Flags describing a remote client. These can be updated during a play session }
+EOS_EAntiCheatCommonClientFlags = (
+    { No particular flags relevant for this client }
+    EOS_ACCCF_None = 0,
+    { The client has admin privileges on the game server }
+    EOS_ACCCF_Admin = (1 shl 0)
+);
+//EOS_ENUM_BOOLEAN_OPERATORS(EOS_EAntiCheatCommonClientFlags);
+
+{ Flags describing the input device used by a remote client, if known. These can be updated during a play session. }
+EOS_EAntiCheatCommonClientInput = (
+    { Unknown input device }
+    EOS_ACCCI_Unknown = 0,
+    { The client is using mouse and keyboard }
+    EOS_ACCCI_MouseKeyboard = 1,
+    { The client is using a gamepad or game controller }
+    EOS_ACCCI_Gamepad = 2,
+    { The client is using a touch input device (e.g. phone/tablet screen) }
+    EOS_ACCCI_TouchInput = 3
+);
+
+{
+ * Types supported for custom gameplay behavior events.
+ * These have a considerable impact on performance
+ }
+EOS_EAntiCheatCommonEventType = (
+    { Not used }
+    EOS_ACCET_Invalid = 0,
+    {
+     * A general game event that is not specific to any individual player.
+     * Low memory use which is constant with respect to the number of players.
+     }
+    EOS_ACCET_GameEvent = 1,
+    {
+     * An event that is logically associated with a specific player. Events logged in
+     * this category require a specific ClientHandle to which they will be attached.
+     * Higher memory use which scales according to the number of players.
+     }
+    EOS_ACCET_PlayerEvent = 2
+);
+
+{ Types supported for custom gameplay behavior event parameters }
+EOS_EAntiCheatCommonEventParamType = (
+    { Not used }
+    EOS_ACCEPT_Invalid = 0,
+    { EOS_AntiCheatCommon_ClientHandle }
+    EOS_ACCEPT_ClientHandle = 1,
+    { const char* }
+    EOS_ACCEPT_String = 2,
+    { uint32_t }
+    EOS_ACCEPT_UInt32 = 3,
+    { int32_t }
+    EOS_ACCEPT_Int32 = 4,
+    { uint64_t }
+    EOS_ACCEPT_UInt64 = 5,
+    { int64_t }
+    EOS_ACCEPT_Int64 = 6,
+    { EOS_AntiCheatCommon_Vec3f }
+    EOS_ACCEPT_Vector3f = 7,
+    { EOS_AntiCheatCommon_Quat }
+    EOS_ACCEPT_Quat = 8
+);
+
+{ Details of a player's movement state }
+EOS_EAntiCheatCommonPlayerMovementState = (
+    { No particular state applies }
+    EOS_ACCPMS_None = 0,
+    { Player is crouching }
+    EOS_ACCPMS_Crouching = 1,
+    { Player is prone }
+    EOS_ACCPMS_Prone = 2,
+    { Player is mounted in a vehicle or similar }
+    EOS_ACCPMS_Mounted = 3,
+    { Player is swimming in a fluid volume }
+    EOS_ACCPMS_Swimming = 4,
+    { Player is falling under the effects of gravity, such as when jumping or walking off the edge of a surface }
+    EOS_ACCPMS_Falling = 5,
+    { Player is flying, ignoring the effects of gravity }
+    EOS_ACCPMS_Flying = 6,
+    { Player is on a ladder }
+    EOS_ACCPMS_OnLadder = 7
+);
+
+{ The source of a damage event }
+EOS_EAntiCheatCommonPlayerTakeDamageSource = (
+    { No particular source relevant }
+    EOS_ACCPTDS_None = 0,
+    { Damage caused by a player controlled character }
+    EOS_ACCPTDS_Player = 1,
+    { Damage caused by a non-player character such as an AI enemy }
+    EOS_ACCPTDS_NonPlayerCharacter = 2,
+    { Damage caused by the world (falling off level, into lava, etc) }
+    EOS_ACCPTDS_World = 3
+);
+
+{ Type of damage applied in a damage event }
+EOS_EAntiCheatCommonPlayerTakeDamageType = (
+    { No particular type relevant }
+    EOS_ACCPTDT_None = 0,
+    { Damage caused by a point source such as a bullet or melee attack }
+    EOS_ACCPTDT_PointDamage = 1,
+    { Damage caused by a radial source such as an explosion }
+    EOS_ACCPTDT_RadialDamage = 2,
+    { Damage over time such as bleeding, poison, etc }
+    EOS_ACCPTDT_DamageOverTime = 3
+);
+
+{ The result of a damage event, if any }
+EOS_EAntiCheatCommonPlayerTakeDamageResult = (
+    { No direct state change consequence for the victim }
+    EOS_ACCPTDR_None = 0,
+    { Player character is temporarily incapacitated and requires assistance to recover }
+    EOS_ACCPTDR_Downed = 1,
+    { Player character is permanently incapacitated and cannot recover (e.g. dead) }
+    EOS_ACCPTDR_Eliminated = 2
+);
+
+{ Vector using left-handed coordinate system (as in Unreal Engine) }
+type EOS_AntiCheatCommon_Vec3f = record
+    { X axis coordinate - forward direction }
+    x: Single;
+    { Y axis coordinate - right direction }
+    y: Single;
+    { Z axis coordinate - up direction }
+    z: Single;
+end;
+
+{ Quaternion using left-handed coordinate system (as in Unreal Engine) }
+type EOS_AntiCheatCommon_Quat = record
+    { W component - scalar part }
+    w: Single;
+    { X component - forward direction }
+    x: Single;
+    { Y component - right direction }
+    y: Single;
+    { Z component - up direction }
+    z: Single;
+end;
+
+{
+ * Structure containing details about a new message that must be dispatched to a connected client/peer.
+ }
+type EOS_AntiCheatCommon_OnMessageToClientCallbackInfo = record
+    { Caller-specified context data }
+    ClientData: Pointer;
+    { The identifier of the client/peer that this message must be delivered to. See the RegisterClient and RegisterPeer functions. }
+    ClientHandle: EOS_AntiCheatCommon_ClientHandle;
+    { The message data that must be sent to the client }
+    MessageData: Pointer;
+    { The size in bytes of MessageData }
+    MessageDataSizeBytes: cuint32;
+end;
+
+type PEOS_AntiCheatCommon_OnMessageToClientCallbackInfo = ^EOS_AntiCheatCommon_OnMessageToClientCallbackInfo;
+
+{ Structure containing details about a required client/peer action }
+type EOS_AntiCheatCommon_OnClientActionRequiredCallbackInfo = record
+    { Caller-specified context data }
+    ClientData: Pointer;
+    { The identifier of the client/peer that this action applies to. See the RegisterClient and RegisterPeer functions. }
+    ClientHandle: EOS_AntiCheatCommon_ClientHandle;
+    { The action that must be applied to the specified client/peer }
+    ClientAction: EOS_EAntiCheatCommonClientAction;
+    { Code indicating the reason for the action. This can be displayed to the affected player. }
+    ActionReasonCode: EOS_EAntiCheatCommonClientActionReason;
+    { String containing details about the action reason. This can be displayed to the affected player. }
+    ActionReasonDetailsString: PChar;
+end;
+
+type PEOS_AntiCheatCommon_OnClientActionRequiredCallbackInfo = ^EOS_AntiCheatCommon_OnClientActionRequiredCallbackInfo;
+
+{ Structure containing details about a client/peer authentication status change }
+type EOS_AntiCheatCommon_OnClientAuthStatusChangedCallbackInfo = record
+    { Caller-specified context data }
+    ClientData: Pointer;
+    { The identifier of the client/peer that this status change applies to. See the RegisterClient and RegisterPeer functions. }
+    ClientHandle: EOS_AntiCheatCommon_ClientHandle;
+    { The client/peer's new authentication status }
+    ClientAuthStatus: EOS_EAntiCheatCommonClientAuthStatus;
+end;
+
+type PEOS_AntiCheatCommon_OnClientAuthStatusChangedCallbackInfo = ^EOS_AntiCheatCommon_OnClientAuthStatusChangedCallbackInfo;
+
+const EOS_ANTICHEATCOMMON_SETCLIENTDETAILS_API_LATEST = 1;
+type EOS_AntiCheatCommon_SetClientDetailsOptions = record
+    { API Version: Set this to EOS_ANTICHEATCOMMON_SETCLIENTDETAILS_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value used in RegisterClient/RegisterPeer }
+    ClientHandle: EOS_AntiCheatCommon_ClientHandle;
+    { General flags associated with this client, if any }
+    ClientFlags: EOS_EAntiCheatCommonClientFlags;
+    { Input device being used by this client, if known }
+    ClientInputMethod: EOS_EAntiCheatCommonClientInput;
+end;
+
+type PEOS_AntiCheatCommon_SetClientDetailsOptions = ^EOS_AntiCheatCommon_SetClientDetailsOptions;
+
+const EOS_ANTICHEATCOMMON_SETGAMESESSIONID_API_LATEST = 1;
+type EOS_AntiCheatCommon_SetGameSessionIdOptions = record
+    { API Version: Set this to EOS_ANTICHEATCOMMON_SETGAMESESSIONID_API_LATEST. }
+    ApiVersion: cint32;
+    { Game session identifier }
+    GameSessionId: PChar;
+end;
+
+type PEOS_AntiCheatCommon_SetGameSessionIdOptions = ^EOS_AntiCheatCommon_SetGameSessionIdOptions;
+
+const EOS_ANTICHEATCOMMON_REGISTEREVENT_API_LATEST = 1;
+const EOS_ANTICHEATCOMMON_REGISTEREVENT_CUSTOMEVENTBASE = $10000000;
+const EOS_ANTICHEATCOMMON_REGISTEREVENT_MAX_PARAMDEFSCOUNT = 12;
+type EOS_AntiCheatCommon_RegisterEventParamDef = record
+    { Parameter name. Allowed characters are 0-9, A-Z, a-z, '_', '-' }
+    ParamName: PChar;
+    { Parameter type }
+    ParamType: EOS_EAntiCheatCommonEventParamType;
+end;
+type PEOS_AntiCheatCommon_RegisterEventParamDef = ^EOS_AntiCheatCommon_RegisterEventParamDef;
+type EOS_AntiCheatCommon_RegisterEventOptions = record
+    { API Version: Set this to EOS_ANTICHEATCOMMON_REGISTEREVENT_API_LATEST. }
+    ApiVersion: cint32;
+    { Unique event identifier. Must be >= EOS_ANTICHEATCOMMON_REGISTEREVENT_CUSTOMEVENTBASE. }
+    EventId: cuint32;
+    { Name of the custom event. Allowed characters are 0-9, A-Z, a-z, '_', '-' }
+    EventName: PChar;
+    { Type of the custom event }
+    EventType: EOS_EAntiCheatCommonEventType;
+    { Number of parameters described in ParamDefs. Must be <= EOS_ANTICHEATCOMMON_REGISTEREVENT_MAX_PARAMDEFSCOUNT. }
+    ParamDefsCount: cuint32;
+    { Pointer to an array of EOS_AntiCheatCommon_RegisterEventParamDef with ParamDefsCount elements }
+    ParamDefs: ^EOS_AntiCheatCommon_RegisterEventParamDef;
+end;
+
+type PEOS_AntiCheatCommon_RegisterEventOptions = ^EOS_AntiCheatCommon_RegisterEventOptions;
+
+const EOS_ANTICHEATCOMMON_LOGEVENT_API_LATEST = 1;
+const EOS_ANTICHEATCOMMON_LOGEVENT_STRING_MAX_LENGTH = 39;
+type EOS_AntiCheatCommon_LogEventParamPair = record
+    { Parameter type }
+    ParamValueType: EOS_EAntiCheatCommonEventParamType;
+    { Parameter value }
+    {union
+    
+        EOS_AntiCheatCommon_ClientHandle ClientHandle;
+        const char* String; // Will be truncated if longer than EOS_ANTICHEATCOMMON_LOGEVENT_STRING_MAX_LENGTH bytes.
+        uint32_t UInt32;
+        int32_t Int32;
+        uint64_t UInt64;
+        int64_t Int64;
+        EOS_AntiCheatCommon_Vec3f Vec3f;
+        EOS_AntiCheatCommon_Quat Quat;
+     ParamValue;}
+end;
+type PEOS_AntiCheatCommon_LogEventParamPair = ^EOS_AntiCheatCommon_LogEventParamPair;
+type EOS_AntiCheatCommon_LogEventOptions = record
+    { API Version: Set this to EOS_ANTICHEATCOMMON_LOGEVENT_API_LATEST. }
+    ApiVersion: cint32;
+    { Optional client who this event is primarily associated with. If not applicable, use 0. }
+    ClientHandle: EOS_AntiCheatCommon_ClientHandle;
+    { Unique event identifier previously configured in RegisterEvent }
+    EventId: cuint32;
+    { Number of parameters described in Params }
+    ParamsCount: cuint32;
+    { Set of parameter types previously configured in RegisterEvent, and their values }
+    Params: ^EOS_AntiCheatCommon_LogEventParamPair;
+end;
+type PEOS_AntiCheatCommon_LogEventOptions = ^EOS_AntiCheatCommon_LogEventOptions;
+const EOS_ANTICHEATCOMMON_LOGGAMEROUNDSTART_API_LATEST = 1;
+type EOS_AntiCheatCommon_LogGameRoundStartOptions = record
+    { API Version: Set this to EOS_ANTICHEATCOMMON_LOGGAMEROUNDSTART_API_LATEST. }
+    ApiVersion: cint32;
+    { Optional game session or match identifier useful for some backend API integrations }
+    SessionIdentifier: PChar;
+    { Optional name of the map being played }
+    LevelName: PChar;
+    { Optional name of the game mode being played }
+    ModeName: PChar;
+    { Optional length of the game round to be played, in seconds. If none, use 0. }
+    RoundTimeSeconds: cuint32;
+end;
+type PEOS_AntiCheatCommon_LogGameRoundStartOptions = ^EOS_AntiCheatCommon_LogGameRoundStartOptions;
+const EOS_ANTICHEATCOMMON_LOGGAMEROUNDEND_API_LATEST = 1;
+type EOS_AntiCheatCommon_LogGameRoundEndOptions = record
+    { API Version: Set this to EOS_ANTICHEATCOMMON_LOGGAMEROUNDEND_API_LATEST. }
+    ApiVersion: cint32;
+    { Optional identifier for the winning team }
+    WinningTeamId: cuint32;
+end;
+type PEOS_AntiCheatCommon_LogGameRoundEndOptions = ^EOS_AntiCheatCommon_LogGameRoundEndOptions;
+const EOS_ANTICHEATCOMMON_LOGPLAYERSPAWN_API_LATEST = 1;
+type EOS_AntiCheatCommon_LogPlayerSpawnOptions = record
+    { API Version: Set this to EOS_ANTICHEATCOMMON_LOGPLAYERSPAWN_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value used in RegisterClient/RegisterPeer }
+    SpawnedPlayerHandle: EOS_AntiCheatCommon_ClientHandle;
+    { Optional identifier for the player's team. If none, use 0. }
+    TeamId: cuint32;
+    { Optional identifier for the player's character. If none, use 0. }
+    CharacterId: cuint32;
+end;
+type PEOS_AntiCheatCommon_LogPlayerSpawnOptions = ^EOS_AntiCheatCommon_LogPlayerSpawnOptions;
+const EOS_ANTICHEATCOMMON_LOGPLAYERDESPAWN_API_LATEST = 1;
+type EOS_AntiCheatCommon_LogPlayerDespawnOptions = record
+    { API Version: Set this to EOS_ANTICHEATCOMMON_LOGPLAYERDESPAWN_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value used in RegisterClient/RegisterPeer }
+    DespawnedPlayerHandle: EOS_AntiCheatCommon_ClientHandle;
+end;
+type PEOS_AntiCheatCommon_LogPlayerDespawnOptions = ^EOS_AntiCheatCommon_LogPlayerDespawnOptions;
+const EOS_ANTICHEATCOMMON_LOGPLAYERREVIVE_API_LATEST = 1;
+type EOS_AntiCheatCommon_LogPlayerReviveOptions = record
+    { API Version: Set this to EOS_ANTICHEATCOMMON_LOGPLAYERREVIVE_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value used in RegisterClient/RegisterPeer }
+    RevivedPlayerHandle: EOS_AntiCheatCommon_ClientHandle;
+    { Locally unique value used in RegisterClient/RegisterPeer }
+    ReviverPlayerHandle: EOS_AntiCheatCommon_ClientHandle;
+end;
+type PEOS_AntiCheatCommon_LogPlayerReviveOptions = ^EOS_AntiCheatCommon_LogPlayerReviveOptions;
+const EOS_ANTICHEATCOMMON_LOGPLAYERTICK_API_LATEST = 2;
+type EOS_AntiCheatCommon_LogPlayerTickOptions = record
+    { API Version: Set this to EOS_ANTICHEATCOMMON_LOGPLAYERTICK_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value used in RegisterClient/RegisterPeer }
+    PlayerHandle: EOS_AntiCheatCommon_ClientHandle;
+    { Attack origin world position as a 3D vector }
+    PlayerPosition: ^EOS_AntiCheatCommon_Vec3f;
+    { Attack direction as a quaternion }
+    PlayerViewRotation: ^EOS_AntiCheatCommon_Quat;
+    { True if the player's view is zoomed (e.g. using a sniper rifle), otherwise false }
+    bIsPlayerViewZoomed: EOS_Bool;
+    { Player's current health value }
+    PlayerHealth: Single;
+    { Any movement state applicable }
+    PlayerMovementState: EOS_EAntiCheatCommonPlayerMovementState;
+end;
+type PEOS_AntiCheatCommon_LogPlayerTickOptions = ^EOS_AntiCheatCommon_LogPlayerTickOptions;
+const EOS_ANTICHEATCOMMON_LOGPLAYERUSEWEAPON_API_LATEST = 2;
+const EOS_ANTICHEATCOMMON_LOGPLAYERUSEWEAPON_WEAPONNAME_MAX_LENGTH = 16;
+type EOS_AntiCheatCommon_LogPlayerUseWeaponData = record
+    { Locally unique value used in RegisterClient/RegisterPeer }
+    PlayerHandle: EOS_AntiCheatCommon_ClientHandle;
+    { Player's current world position as a 3D vector }
+    PlayerPosition: ^EOS_AntiCheatCommon_Vec3f;
+    { Player's view rotation as a quaternion }
+    PlayerViewRotation: ^EOS_AntiCheatCommon_Quat;
+    { True if the player's view is zoomed (e.g. using a sniper rifle), otherwise false }
+    bIsPlayerViewZoomed: EOS_Bool;
+    { Set to true if the player is using a melee attack, otherwise false }
+    bIsMeleeAttack: EOS_Bool;
+    { Name of the weapon used. Will be truncated to EOS_ANTICHEATCOMMON_LOGPLAYERUSEWEAPON_WEAPONNAME_MAX_LENGTH bytes if longer. }
+    WeaponName: PChar;
+end;
+type PEOS_AntiCheatCommon_LogPlayerUseWeaponData = ^EOS_AntiCheatCommon_LogPlayerUseWeaponData;
+type EOS_AntiCheatCommon_LogPlayerUseWeaponOptions = record
+    { API Version: Set this to EOS_ANTICHEATCOMMON_LOGPLAYERUSEWEAPON_API_LATEST. }
+    ApiVersion: cint32;
+    { Struct containing detailed information about a weapon use event }
+    UseWeaponData: ^EOS_AntiCheatCommon_LogPlayerUseWeaponData;
+end;
+type PEOS_AntiCheatCommon_LogPlayerUseWeaponOptions = ^EOS_AntiCheatCommon_LogPlayerUseWeaponOptions;
+const EOS_ANTICHEATCOMMON_LOGPLAYERUSEABILITY_API_LATEST = 1;
+type EOS_AntiCheatCommon_LogPlayerUseAbilityOptions = record
+    { API Version: Set this to EOS_ANTICHEATCOMMON_LOGPLAYERUSEABILITY_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value used in RegisterClient/RegisterPeer }
+    PlayerHandle: EOS_AntiCheatCommon_ClientHandle;
+    { Game defined unique identifier for the ability being used }
+    AbilityId: cuint32;
+    { Duration of the ability effect in milliseconds. If not applicable, use 0. }
+    AbilityDurationMs: cuint32;
+    { Cooldown until the ability can be used again in milliseconds. If not applicable, use 0. }
+    AbilityCooldownMs: cuint32;
+end;
+type PEOS_AntiCheatCommon_LogPlayerUseAbilityOptions = ^EOS_AntiCheatCommon_LogPlayerUseAbilityOptions;
+const EOS_ANTICHEATCOMMON_LOGPLAYERTAKEDAMAGE_API_LATEST = 2;
+type EOS_AntiCheatCommon_LogPlayerTakeDamageOptions = record
+    { API Version: Set this to EOS_ANTICHEATCOMMON_LOGPLAYERTAKEDAMAGE_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value used in RegisterClient/RegisterPeer }
+    VictimPlayerHandle: EOS_AntiCheatCommon_ClientHandle;
+    { Victim player's current world position as a 3D vector }
+    VictimPlayerPosition: ^EOS_AntiCheatCommon_Vec3f;
+    { Victim player's view rotation as a quaternion }
+    VictimPlayerViewRotation: ^EOS_AntiCheatCommon_Quat;
+    { Locally unique value used in RegisterClient/RegisterPeer }
+    AttackerPlayerHandle: EOS_AntiCheatCommon_ClientHandle;
+    { Attacker player's current world position as a 3D vector }
+    AttackerPlayerPosition: ^EOS_AntiCheatCommon_Vec3f;
+    { Attacker player's view rotation as a quaternion }
+    AttackerPlayerViewRotation: ^EOS_AntiCheatCommon_Quat;
+    {
+     * True if the damage was applied instantly at the time of attack from the game
+     * simulation's perspective, otherwise false (simulated ballistics, arrow, etc).
+     }
+    bIsHitscanAttack: EOS_Bool;
+    {
+     * True if there is a visible line of sight between the attacker and the victim at the time
+     * that damage is being applied, false if there is an obstacle like a wall or terrain in
+     * the way. For some situations like melee or hitscan weapons this is trivially
+     * true, for others like projectiles with simulated physics it may not be e.g. a player
+     * could fire a slow moving projectile and then move behind cover before it strikes.
+     }
+    bHasLineOfSight: EOS_Bool;
+    { True if this was a critical hit that causes extra damage (e.g. headshot) }
+    bIsCriticalHit: EOS_Bool;
+    { Identifier of the victim bone hit in this damage event }
+    HitBoneId_DEPRECATED: cuint32;
+    { Number of health points that the victim lost due to this damage event }
+    DamageTaken: Single;
+    { Number of health points that the victim has remaining after this damage event }
+    HealthRemaining: Single;
+    { Source of the damage event }
+    DamageSource: EOS_EAntiCheatCommonPlayerTakeDamageSource;
+    { Type of the damage being applied }
+    DamageType: EOS_EAntiCheatCommonPlayerTakeDamageType;
+    { Result of the damage for the victim, if any }
+    DamageResult: EOS_EAntiCheatCommonPlayerTakeDamageResult;
+    { PlayerUseWeaponData associated with this damage event if available, otherwise NULL }
+    PlayerUseWeaponData: ^EOS_AntiCheatCommon_LogPlayerUseWeaponData;
+    { Time in milliseconds since the PlayerUseWeaponData event occurred if available, otherwise 0 }
+    TimeSincePlayerUseWeaponMs: cuint32;
+    { World position where damage hit the victim as a 3D vector if available, otherwise NULL *}
+    DamagePosition: ^EOS_AntiCheatCommon_Vec3f;
+end;
+type PEOS_AntiCheatCommon_LogPlayerTakeDamageOptions = ^EOS_AntiCheatCommon_LogPlayerTakeDamageOptions;

--- a/shared/libs/EOS/eos_anticheatserver.pas
+++ b/shared/libs/EOS/eos_anticheatserver.pas
@@ -1,0 +1,357 @@
+{
+ * Add a callback issued when a new message must be dispatched to a connected client. The bound function
+ * will only be called between a successful call to EOS_AntiCheatServer_BeginSession and the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data
+ * @param ClientData This value is returned to the caller when NotificationFn is invoked
+ * @param NotificationFn The callback to be fired
+ * @return A valid notification ID if successfully bound, or EOS_INVALID_NOTIFICATIONID otherwise
+ }
+function EOS_AntiCheatServer_AddNotifyMessageToClient(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatServer_AddNotifyMessageToClientOptions; ClientData: Pointer; NotificationFn: EOS_AntiCheatServer_OnMessageToClientCallback): EOS_NotificationId; cdecl; external EOSLIB;
+
+{
+ * Remove a previously bound EOS_AntiCheatServer_AddNotifyMessageToClient handler.
+ *
+ * @param NotificationId The previously bound notification ID
+ }
+procedure EOS_AntiCheatServer_RemoveNotifyMessageToClient(Handle: EOS_HAntiCheatServer; NotificationId: EOS_NotificationId); cdecl; external EOSLIB;
+
+{
+ * Add a callback issued when an action must be applied to a connected client. The bound function
+ * will only be called between a successful call to EOS_AntiCheatServer_BeginSession and the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data
+ * @param ClientData This value is returned to the caller when NotificationFn is invoked
+ * @param NotificationFn The callback to be fired
+ * @return A valid notification ID if successfully bound, or EOS_INVALID_NOTIFICATIONID otherwise
+ }
+function EOS_AntiCheatServer_AddNotifyClientActionRequired(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatServer_AddNotifyClientActionRequiredOptions; ClientData: Pointer; NotificationFn: EOS_AntiCheatServer_OnClientActionRequiredCallback): EOS_NotificationId; cdecl; external EOSLIB;
+
+{
+ * Remove a previously bound EOS_AntiCheatServer_AddNotifyClientActionRequired handler.
+ *
+ * @param NotificationId The previously bound notification ID
+ }
+procedure EOS_AntiCheatServer_RemoveNotifyClientActionRequired(Handle: EOS_HAntiCheatServer; NotificationId: EOS_NotificationId); cdecl; external EOSLIB;
+
+{
+ * Add an optional callback issued when a connected client's authentication status changes. The bound function
+ * will only be called between a successful call to EOS_AntiCheatServer_BeginSession and the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data
+ * @param ClientData This value is returned to the caller when NotificationFn is invoked
+ * @param NotificationFn The callback to be fired
+ * @return A valid notification ID if successfully bound, or EOS_INVALID_NOTIFICATIONID otherwise
+ }
+function EOS_AntiCheatServer_AddNotifyClientAuthStatusChanged(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatServer_AddNotifyClientAuthStatusChangedOptions; ClientData: Pointer; NotificationFn: EOS_AntiCheatServer_OnClientAuthStatusChangedCallback): EOS_NotificationId; cdecl; external EOSLIB;
+
+{
+ * Remove a previously bound EOS_AntiCheatServer_AddNotifyClientAuthStatusChanged handler.
+ *
+ * @param NotificationId The previously bound notification ID
+ }
+procedure EOS_AntiCheatServer_RemoveNotifyClientAuthStatusChanged(Handle: EOS_HAntiCheatServer; NotificationId: EOS_NotificationId); cdecl; external EOSLIB;
+
+{
+ * Begin the gameplay session. Event callbacks must be configured with EOS_AntiCheatServer_AddNotifyMessageToClient
+ * and EOS_AntiCheatServer_AddNotifyClientActionRequired before calling this function.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the initialization succeeded
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_BeginSession(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatServer_BeginSessionOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * End the gameplay session. Should be called when the server is shutting down or entering an idle state.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the initialization succeeded
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_EndSession(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatServer_EndSessionOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Register a connected client. Must be paired with a call to UnregisterClient.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the player was registered successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_RegisterClient(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatServer_RegisterClientOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Unregister a disconnected client.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the player was unregistered successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_UnregisterClient(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatServer_UnregisterClientOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Call when an anti-cheat message is received from a client.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the message was processed successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_ReceiveMessageFromClient(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatServer_ReceiveMessageFromClientOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional. Sets or updates client details including input device and admin status.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the flags were updated successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_SetClientDetails(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatCommon_SetClientDetailsOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional. Sets or updates a game session identifier which can be attached to other data for reference.
+ * The identifier can be updated at any time for currently and subsequently registered clients.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the game session identifier was set successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_SetGameSessionId(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatCommon_SetGameSessionIdOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional. Can be used to indicate that a client is legitimately known to be
+ * temporarily unable to communicate, for example as a result of loading a new level.
+ *
+ * The bIsNetworkActive flag must be set back to true when users enter normal
+ * gameplay, otherwise anti-cheat enforcement will not work correctly.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the network state was updated successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_SetClientNetworkState(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatServer_SetClientNetworkStateOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional NetProtect feature for game message encryption.
+ * Calculates the required decrypted buffer size for a given input data length.
+ * This will not change for a given SDK version, and allows one time allocation of reusable buffers.
+ *
+ * @param Options Structure containing input data.
+ * @param OutBufferLengthBytes On success, the OutBuffer length in bytes that is required to call ProtectMessage on the given input size.
+ *
+ * @return EOS_Success - If the output length was calculated successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_GetProtectMessageOutputLength(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatServer_GetProtectMessageOutputLengthOptions; OutBufferSizeBytes: pcuint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional NetProtect feature for game message encryption.
+ * Encrypts an arbitrary message that will be sent to a game client and decrypted on the other side.
+ *
+ * Options.Data and OutBuffer may refer to the same buffer to encrypt in place.
+ *
+ * @param Options Structure containing input data.
+ * @param OutBuffer On success, buffer where encrypted message data will be written.
+ * @param OutBytesWritten On success, the number of bytes that were written to OutBuffer.
+ *
+ * @return EOS_Success - If the message was protected successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ *         EOS_InvalidUser - If the specified ClientHandle was invalid or not currently registered. See RegisterClient.
+ }
+function EOS_AntiCheatServer_ProtectMessage(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatServer_ProtectMessageOptions; OutBuffer: Pointer; OutBytesWritten: pcuint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional NetProtect feature for game message encryption.
+ * Decrypts an encrypted message received from a game client.
+ *
+ * Options.Data and OutBuffer may refer to the same buffer to decrypt in place.
+ *
+ * @param Options Structure containing input data.
+ * @param OutBuffer On success, buffer where encrypted message data will be written.
+ * @param OutBytesWritten On success, the number of bytes that were written to OutBuffer.
+ *
+ * @return EOS_Success - If the message was unprotected successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_UnprotectMessage(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatServer_UnprotectMessageOptions; OutBuffer: Pointer; OutBytesWritten: pcuint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional Cerberus feature for gameplay data collection.
+ * Registers a custom gameplay event.
+ *
+ * All custom game events must be registered before EOS_AntiCheatServer_BeginSession is called for the first time.
+ * After the first call to EOS_AntiCheatServer_BeginSession, this function cannot be called any longer.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the event was registered successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_RegisterEvent(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatCommon_RegisterEventOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional Cerberus feature for gameplay data collection.
+ * Logs a custom gameplay event.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the event was logged successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_LogEvent(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatCommon_LogEventOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional Cerberus feature for gameplay data collection.
+ * Logs a new game round start.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the event was logged successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_LogGameRoundStart(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatCommon_LogGameRoundStartOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional Cerberus feature for gameplay data collection.
+ * Logs a game round's end and outcome.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the event was logged successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_LogGameRoundEnd(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatCommon_LogGameRoundEndOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional Cerberus feature for gameplay data collection.
+ * Logs a player spawning into the game.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the event was logged successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_LogPlayerSpawn(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatCommon_LogPlayerSpawnOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional Cerberus feature for gameplay data collection.
+ * Logs a player despawning in the game, for example as a result of the character's death,
+ * switching to spectator mode, etc.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the event was logged successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_LogPlayerDespawn(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatCommon_LogPlayerDespawnOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional Cerberus feature for gameplay data collection.
+ * Logs a player being revived after being downed (see EOS_AntiCheatServer_LogPlayerTakeDamage options).
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the event was logged successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_LogPlayerRevive(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatCommon_LogPlayerReviveOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional Cerberus feature for gameplay data collection.
+ * Logs a player's general state including position and view direction.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the event was logged successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_LogPlayerTick(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatCommon_LogPlayerTickOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional Cerberus feature for gameplay data collection.
+ * Logs that a player has used a weapon, for example firing one bullet or making one melee attack.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the event was logged successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_LogPlayerUseWeapon(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatCommon_LogPlayerUseWeaponOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional Cerberus feature for gameplay data collection.
+ * Logs that a player has used a special ability or item which affects their character's capabilities,
+ * for example temporarily increasing their speed or allowing them to see nearby players behind walls.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the event was logged successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_LogPlayerUseAbility(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatCommon_LogPlayerUseAbilityOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Optional Cerberus feature for gameplay data collection.
+ * Logs that a player has taken damage.
+ *
+ * This function may only be called between a successful call to EOS_AntiCheatServer_BeginSession and
+ * the matching EOS_AntiCheatServer_EndSession call.
+ *
+ * @param Options Structure containing input data.
+ *
+ * @return EOS_Success - If the event was logged successfully
+ *         EOS_InvalidParameters - If input data was invalid
+ }
+function EOS_AntiCheatServer_LogPlayerTakeDamage(Handle: EOS_HAntiCheatServer; Options: PEOS_AntiCheatCommon_LogPlayerTakeDamageOptions): EOS_EResult; cdecl; external EOSLIB;

--- a/shared/libs/EOS/eos_anticheatserver_types.pas
+++ b/shared/libs/EOS/eos_anticheatserver_types.pas
@@ -1,0 +1,181 @@
+type EOS_HAntiCheatServer = Pointer;
+
+{
+ * Callback issued when a new message must be dispatched to a connected client.
+ *
+ * Messages contain opaque binary data of up to 256 bytes and must be transmitted
+ * to the correct client using the game's own networking layer, then delivered
+ * to the client anti-cheat instance using the EOS_AntiCheatClient_ReceiveMessageFromServer function.
+ *
+ * This callback is always issued from within EOS_Platform_Tick on its calling thread.
+ }
+type EOS_AntiCheatServer_OnMessageToClientCallback = procedure(Data: PEOS_AntiCheatCommon_OnMessageToClientCallbackInfo); stdcall;
+
+{
+ * Callback issued when an action must be applied to a connected client.
+ * This callback is always issued from within EOS_Platform_Tick on its calling thread.
+ }
+type EOS_AntiCheatServer_OnClientActionRequiredCallback = procedure(Data: PEOS_AntiCheatCommon_OnClientActionRequiredCallbackInfo); stdcall;
+
+{
+ * Optional callback issued when a connected client's authentication status has changed.
+ * This callback is always issued from within EOS_Platform_Tick on its calling thread.
+ }
+type EOS_AntiCheatServer_OnClientAuthStatusChangedCallback = procedure(Data: PEOS_AntiCheatCommon_OnClientAuthStatusChangedCallbackInfo); stdcall;
+
+const EOS_ANTICHEATSERVER_ADDNOTIFYMESSAGETOCLIENT_API_LATEST = 1;
+type EOS_AntiCheatServer_AddNotifyMessageToClientOptions = record
+    { API Version: Set this to EOS_ANTICHEATSERVER_ADDNOTIFYMESSAGETOCLIENT_API_LATEST. }
+    ApiVersion: cint32;
+end;
+
+type PEOS_AntiCheatServer_AddNotifyMessageToClientOptions = ^EOS_AntiCheatServer_AddNotifyMessageToClientOptions;
+
+const EOS_ANTICHEATSERVER_ADDNOTIFYCLIENTACTIONREQUIRED_API_LATEST = 1;
+type EOS_AntiCheatServer_AddNotifyClientActionRequiredOptions = record
+    { API Version: Set this to EOS_ANTICHEATSERVER_ADDNOTIFYCLIENTACTIONREQUIRED_API_LATEST. }
+    ApiVersion: cint32;
+end;
+
+type PEOS_AntiCheatServer_AddNotifyClientActionRequiredOptions = ^EOS_AntiCheatServer_AddNotifyClientActionRequiredOptions;
+
+const EOS_ANTICHEATSERVER_ADDNOTIFYCLIENTAUTHSTATUSCHANGED_API_LATEST = 1;
+type EOS_AntiCheatServer_AddNotifyClientAuthStatusChangedOptions = record
+    { API Version: Set this to EOS_ANTICHEATSERVER_ADDNOTIFYCLIENTAUTHSTATUSCHANGED_API_LATEST. }
+    ApiVersion: cint32;
+end;
+
+type PEOS_AntiCheatServer_AddNotifyClientAuthStatusChangedOptions = ^EOS_AntiCheatServer_AddNotifyClientAuthStatusChangedOptions;
+
+{ Limits on RegisterTimeoutSeconds parameter }
+const EOS_ANTICHEATSERVER_BEGINSESSION_MIN_REGISTERTIMEOUT = 10;
+const EOS_ANTICHEATSERVER_BEGINSESSION_MAX_REGISTERTIMEOUT = 120;
+const EOS_ANTICHEATSERVER_BEGINSESSION_API_LATEST = 3;
+type EOS_AntiCheatServer_BeginSessionOptions = record
+    { API Version: Set this to EOS_ANTICHEATSERVER_BEGINSESSION_API_LATEST. }
+    ApiVersion: cint32;
+    {
+     * Time in seconds to allow newly registered clients to complete anti-cheat authentication.
+     * Recommended value: 60
+     }
+    RegisterTimeoutSeconds: cuint32;
+    { Optional name of this game server }
+    ServerName: PChar;
+    {
+     * Gameplay data collection APIs such as LogPlayerTick will be enabled if set to true.
+     * If you do not use these APIs, it is more efficient to set this value to false.
+     }
+    bEnableGameplayData: EOS_Bool;
+    { The Product User ID of the local user who is associated with this session. Dedicated servers should set this to null. }
+    LocalUserId: EOS_ProductUserId;
+end;
+
+type PEOS_AntiCheatServer_BeginSessionOptions = ^EOS_AntiCheatServer_BeginSessionOptions;
+
+const EOS_ANTICHEATSERVER_ENDSESSION_API_LATEST = 1;
+type EOS_AntiCheatServer_EndSessionOptions = record
+    { API Version: Set this to EOS_ANTICHEATSERVER_ENDSESSION_API_LATEST. }
+    ApiVersion: cint32;
+end;
+
+type PEOS_AntiCheatServer_EndSessionOptions = ^EOS_AntiCheatServer_EndSessionOptions;
+
+const EOS_ANTICHEATSERVER_REGISTERCLIENT_API_LATEST = 1;
+type EOS_AntiCheatServer_RegisterClientOptions = record
+    { API Version: Set this to EOS_ANTICHEATSERVER_REGISTERCLIENT_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value describing the remote user (e.g. a player object pointer) }
+    ClientHandle: EOS_AntiCheatCommon_ClientHandle;
+    { Type of remote user being registered }
+    ClientType: EOS_EAntiCheatCommonClientType;
+    { Remote user's platform, if known }
+    ClientPlatform: EOS_EAntiCheatCommonClientPlatform;
+    {
+     * Identifier for the remote user. This is typically a string representation of an
+     * account ID, but it can be any string which is both unique (two different users will never
+     * have the same string) and consistent (if the same user connects to this game session
+     * twice, the same string will be used) in the scope of a single protected game session.
+     }
+    AccountId: PChar;
+    {
+     * Optional IP address for the remote user. May be null if not available.
+     * IPv4 format: "0.0.0.0"
+     * IPv6 format: "0:0:0:0:0:0:0:0"
+     }
+    IpAddress: PChar;
+end;
+
+type PEOS_AntiCheatServer_RegisterClientOptions = ^EOS_AntiCheatServer_RegisterClientOptions;
+
+const EOS_ANTICHEATSERVER_UNREGISTERCLIENT_API_LATEST = 1;
+type EOS_AntiCheatServer_UnregisterClientOptions = record
+    { API Version: Set this to EOS_ANTICHEATSERVER_UNREGISTERCLIENT_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value describing the remote user, as previously passed to RegisterClient }
+    ClientHandle: EOS_AntiCheatCommon_ClientHandle;
+end;
+
+type PEOS_AntiCheatServer_UnregisterClientOptions = ^EOS_AntiCheatServer_UnregisterClientOptions;
+
+const EOS_ANTICHEATSERVER_RECEIVEMESSAGEFROMCLIENT_API_LATEST = 1;
+type EOS_AntiCheatServer_ReceiveMessageFromClientOptions = record
+    { API Version: Set this to EOS_ANTICHEATSERVER_RECEIVEMESSAGEFROMCLIENT_API_LATEST. }
+    ApiVersion: cint32;
+    { Optional value, if non-null then only messages addressed to this specific client will be returned }
+    ClientHandle: EOS_AntiCheatCommon_ClientHandle;
+    { The size of the data received }
+    DataLengthBytes: cuint32;
+    { The data received }
+    Data: Pointer;
+end;
+
+type PEOS_AntiCheatServer_ReceiveMessageFromClientOptions = ^EOS_AntiCheatServer_ReceiveMessageFromClientOptions;
+
+const EOS_ANTICHEATSERVER_SETCLIENTNETWORKSTATE_API_LATEST = 1;
+type EOS_AntiCheatServer_SetClientNetworkStateOptions = record
+    { API Version: Set this to EOS_ANTICHEATSERVER_SETCLIENTNETWORKSTATE_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value describing the remote user (e.g. a player object pointer) }
+    ClientHandle: EOS_AntiCheatCommon_ClientHandle;
+    { True if the network is functioning normally, false if temporarily interrupted }
+    bIsNetworkActive: EOS_Bool;
+end;
+type PEOS_AntiCheatServer_SetClientNetworkStateOptions = ^EOS_AntiCheatServer_SetClientNetworkStateOptions;
+const EOS_ANTICHEATSERVER_GETPROTECTMESSAGEOUTPUTLENGTH_API_LATEST = 1;
+type EOS_AntiCheatServer_GetProtectMessageOutputLengthOptions = record
+    { API Version: Set this to EOS_ANTICHEATSERVER_GETPROTECTMESSAGEOUTPUTLENGTH_API_LATEST. }
+    ApiVersion: cint32;
+    { Length in bytes of input }
+    DataLengthBytes: cuint32;
+end;
+type PEOS_AntiCheatServer_GetProtectMessageOutputLengthOptions = ^EOS_AntiCheatServer_GetProtectMessageOutputLengthOptions;
+
+const EOS_ANTICHEATSERVER_PROTECTMESSAGE_API_LATEST = 1;
+type EOS_AntiCheatServer_ProtectMessageOptions = record
+    { API Version: Set this to EOS_ANTICHEATSERVER_PROTECTMESSAGE_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value describing the remote user to whom the message will be sent }
+    ClientHandle: EOS_AntiCheatCommon_ClientHandle;
+    { Length in bytes of input }
+    DataLengthBytes: cuint32;
+    { The data to encrypt }
+    Data: Pointer;
+    { The size in bytes of OutBuffer }
+    OutBufferSizeBytes: cuint32;
+end;
+type PEOS_AntiCheatServer_ProtectMessageOptions = ^EOS_AntiCheatServer_ProtectMessageOptions;
+
+const EOS_ANTICHEATSERVER_UNPROTECTMESSAGE_API_LATEST = 1;
+type EOS_AntiCheatServer_UnprotectMessageOptions = record
+    { API Version: Set this to EOS_ANTICHEATSERVER_UNPROTECTMESSAGE_API_LATEST. }
+    ApiVersion: cint32;
+    { Locally unique value describing the remote user from whom the message was received }
+    ClientHandle: EOS_AntiCheatCommon_ClientHandle;
+    { Length in bytes of input }
+    DataLengthBytes: cuint32;
+    { The data to decrypt }
+    Data: Pointer;
+    { The size in bytes of OutBuffer }
+    OutBufferSizeBytes: cuint32;
+end;
+type PEOS_AntiCheatServer_UnprotectMessageOptions = ^EOS_AntiCheatServer_UnprotectMessageOptions;

--- a/shared/libs/EOS/eos_base.pas
+++ b/shared/libs/EOS/eos_base.pas
@@ -1,0 +1,489 @@
+{$include eos_result.pas}
+
+type 
+  EOS_Bool = cuint32;
+const EOS_TRUE = 1;
+const EOS_FALSE = 0;
+{
+ * Returns a string representation of an EOS_EResult. 
+ * The return value is never null.
+ * The return value must not be freed.
+ *
+ * Example: EOS_EResult_ToString(EOS_Success) returns "EOS_Success"
+ }
+function EOS_EResult_ToString(Result: EOS_EResult): PChar; cdecl; external EOSLIB;
+
+{
+ * Returns whether a result is to be considered the final result, or false if the callback that returned this result
+ * will be called again either after some time or from another action.
+ *
+ * @param Result The result to check against being a final result for an operation
+ * @return True if this result means the operation is complete, false otherwise
+ }
+function EOS_EResult_IsOperationComplete(Result: EOS_EResult): EOS_Bool; cdecl; external EOSLIB;
+{
+ * Encode a byte array into hex encoded string
+ *
+ * @return An EOS_EResult that indicates whether the byte array was converted and copied into the OutBuffer.
+ *         EOS_Success if the encoding was successful and passed out in OutBuffer
+ *         EOS_InvalidParameters if you pass a null pointer on invalid length for any of the parameters
+ *         EOS_LimitExceeded - The OutBuffer is not large enough to receive the encoding. InOutBufferLength contains the required minimum length to perform the operation successfully.
+ }
+function EOS_ByteArray_ToString(ByteArray: pcuint8; Length: cuint32; OutBuffer: pcchar; InOutBufferLength: pcuint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * A handle to a user's Epic Online Services Account ID
+ * This ID is associated with a specific login associated with Epic Account Services
+ *
+ * @see EOS_Auth_Login
+ }
+type
+  EOS_EpicAccountId = Pointer;
+
+{ 
+ * Check whether or not the given Epic Online Services Account ID is considered valid
+ * NOTE: This will return true for any EOS_EpicAccountId created with EOS_EpicAccountId_FromString as there is no validation
+ * 
+ * @param AccountId The Epic Online Services Account ID to check for validity
+ * @return EOS_TRUE if the EOS_EpicAccountId is valid, otherwise EOS_FALSE
+ }
+function EOS_EpicAccountId_IsValid(AccountId: EOS_EpicAccountId): EOS_Bool; cdecl; external EOSLIB;
+
+{
+ * Retrieve a null-terminated stringified Epic Online Services Account ID from an EOS_EpicAccountId. This is useful for replication of Epic Online Services Account IDs in multiplayer games.
+ * This string will be no larger than EOS_EPICACCOUNTID_MAX_LENGTH + 1 and will only contain UTF8-encoded printable characters (excluding the null-terminator).
+ *
+ * @param AccountId The Epic Online Services Account ID for which to retrieve the stringified version.
+ * @param OutBuffer The buffer into which the character data should be written
+ * @param InOutBufferLength The size of the OutBuffer in characters.
+ *                          The input buffer should include enough space to be null-terminated.
+ *                          When the function returns, this parameter will be filled with the length of the string copied into OutBuffer including the null termination character.
+ *
+ * @return An EOS_EResult that indicates whether the Epic Online Services Account ID string was copied into the OutBuffer.
+ *         EOS_Success - The OutBuffer was filled, and InOutBufferLength contains the number of characters copied into OutBuffer including the null terminator.
+ *         EOS_InvalidParameters - Either OutBuffer or InOutBufferLength were passed as NULL parameters.
+ *         EOS_InvalidUser - The AccountId is invalid and cannot be stringified.
+ *         EOS_LimitExceeded - The OutBuffer is not large enough to receive the Epic Online Services Account ID string. InOutBufferLength contains the required minimum length to perform the operation successfully.
+ }
+function EOS_EpicAccountId_ToString(AccountId: EOS_EpicAccountId; OutBuffer: pcchar; InOutBufferLength: pcuint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Retrieve an EOS_EpicAccountId from a raw string representing an Epic Online Services Account ID. The input string must be null-terminated.
+ * NOTE: There is no validation on the string format, this should only be used with values serialized from legitimate sources such as EOS_EpicAccountId_ToString
+ *
+ * @param AccountIdString The stringified account ID for which to retrieve the Epic Online Services Account ID
+ * @return The EOS_EpicAccountId that corresponds to the AccountIdString
+ }
+function EOS_EpicAccountId_FromString(AccountIdString: PChar): EOS_EpicAccountId; cdecl; external EOSLIB;
+
+{ 
+ * A character buffer of this size is large enough to fit a successful output of EOS_EpicAccountId_ToString. This length does not include the null-terminator.
+ * The EpicAccountId data structure is opaque in nature and no assumptions of its structure should be inferred
+ }
+const EOS_EPICACCOUNTID_MAX_LENGTH = 32;
+
+{ 
+ * A handle to a user's Product User ID (game services related ecosystem)
+ * This ID is associated with any of the external account providers (of which Epic Account Services is one)
+ * 
+ * @see EOS_Connect_Login
+ * @see EOS_EExternalCredentialType 
+ }
+type
+  EOS_ProductUserId = Pointer; 
+
+{
+ * Check whether or not the given account unique ID is considered valid
+ * NOTE: This will return true for any EOS_ProductUserId created with EOS_ProductUserId_FromString as there is no validation
+ *
+ * @param AccountId The Product User ID to check for validity
+ * @return EOS_TRUE if the EOS_ProductUserId is valid, otherwise EOS_FALSE
+ }
+function EOS_ProductUserId_IsValid(AccountId: EOS_ProductUserId): EOS_Bool; cdecl; external EOSLIB;
+
+{
+ * Retrieve a null-terminated stringified Product User ID from an EOS_ProductUserId. This is useful for replication of Product User IDs in multiplayer games.
+ * This string will be no larger than EOS_PRODUCTUSERID_MAX_LENGTH + 1 and will only contain UTF8-encoded printable characters (excluding the null-terminator).
+ *
+ * @param AccountId The Product User ID for which to retrieve the stringified version.
+ * @param OutBuffer The buffer into which the character data should be written
+ * @param InOutBufferLength The size of the OutBuffer in characters.
+ *                          The input buffer should include enough space to be null-terminated.
+ *                          When the function returns, this parameter will be filled with the length of the string copied into OutBuffer including the null termination character.
+ *
+ * @return An EOS_EResult that indicates whether the Product User ID string was copied into the OutBuffer.
+ *         EOS_Success - The OutBuffer was filled, and InOutBufferLength contains the number of characters copied into OutBuffer including the null terminator.
+ *         EOS_InvalidParameters - Either OutBuffer or InOutBufferLength were passed as NULL parameters.
+ *         EOS_InvalidUser - The AccountId is invalid and cannot be stringified.
+ *         EOS_LimitExceeded - The OutBuffer is not large enough to receive the Product User ID string. InOutBufferLength contains the required minimum length to perform the operation successfully.
+ }
+function EOS_ProductUserId_ToString(AccountId: EOS_ProductUserId; OutBuffer: pcchar; InOutBufferLength: pcuint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Retrieve an EOS_ProductUserId from a raw string representing an Epic Online Services Product User ID. The input string must be null-terminated.
+ * NOTE: There is no validation on the string format, this should only be used with values serialized from legitimate sources such as EOS_ProductUserId_ToString
+ *
+ * @param ProductUserIdString The stringified product user ID for which to retrieve the Epic Online Services Product User ID
+ * @return The EOS_ProductUserId that corresponds to the ProductUserIdString
+ }
+function EOS_ProductUserId_FromString(ProductUserIdString: PChar): EOS_ProductUserId; cdecl; external EOSLIB;
+
+{ A character buffer of this size is large enough to fit a successful output of EOS_ProductUserId_ToString. This length does not include the null-terminator. }
+const EOS_PRODUCTUSERID_MAX_LENGTH = 128;
+
+{ Handle to an existing registered notification (0 is an invalid handle) }
+type
+  EOS_NotificationId = cuint64;
+
+{ An invalid notification ID }
+const
+  EOS_INVALID_NOTIFICATIONID = 0;
+
+{ A handle to a continuance token @see eos_connect.h }
+type 
+  EOS_ContinuanceToken = Pointer;
+
+{
+ * Retrieve a null-terminated stringified continuance token from an EOS_ContinuanceToken.
+ *
+ * To get the required buffer size, call once with OutBuffer set to NULL, InOutBufferLength will contain the buffer size needed.
+ * Call again with valid params to get the stringified continuance token which will only contain UTF8-encoded printable characters (excluding the null-terminator).
+ *
+ * @param ContinuanceToken The continuance token for which to retrieve the stringified version.
+ * @param OutBuffer The buffer into which the character data should be written
+ * @param InOutBufferLength The size of the OutBuffer in characters.
+ *                          The input buffer should include enough space to be null-terminated.
+ *                          When the function returns, this parameter will be filled with the length of the string copied into OutBuffer including the null termination character.
+ *
+ * @return An EOS_EResult that indicates whether the continuance token string was copied into the OutBuffer.
+ *         EOS_Success - The OutBuffer was filled, and InOutBufferLength contains the number of characters copied into OutBuffer including the null terminator.
+ *         EOS_InvalidParameters - Either OutBuffer or InOutBufferLength were passed as NULL parameters.
+ *         EOS_InvalidUser - The AccountId is invalid and cannot be stringified.
+ *         EOS_LimitExceeded - The OutBuffer is not large enough to receive the continuance token string. InOutBufferLength contains the required minimum length to perform the operation successfully.
+ }
+function EOS_ContinuanceToken_ToString(ContinuanceToken: EOS_ContinuanceToken; OutBuffer: Pointer; InOutBufferLength: pcint32): EOS_EResult; cdecl; external EOSLIB;
+
+{ The most recent version of the EOS_PageQuery structs. }
+const EOS_PAGEQUERY_API_LATEST = 1;
+
+{ DEPRECATED! Use EOS_PAGEQUERY_API_LATEST instead. }
+const EOS_PAGINATION_API_LATEST = EOS_PAGEQUERY_API_LATEST;
+
+{ The default MaxCount used for a EOS_PageQuery when the API allows the EOS_PageQuery to be omitted. }
+const EOS_PAGEQUERY_MAXCOUNT_DEFAULT = 10;
+
+{ The maximum MaxCount used for a EOS_PageQuery. }
+const EOS_PAGEQUERY_MAXCOUNT_MAXIMUM = 100;
+
+{
+ * A page query is part of query options. It is used to allow pagination of query results.
+ }
+type
+EOS_PageQuery = record
+    { API Version: Set this to EOS_PAGEQUERY_API_LATEST. }
+    ApiVersion: cint32;
+    { The index into the ordered query results to start the page at. }
+    StartIndex: cint32;
+    { The maximum number of results to have in the page. }
+    MaxCount: cint32;
+end;
+
+{
+ * A page result is part of query callback info. It is used to provide pagination details of query results.
+ }
+EOS_PageResult = record
+    { The index into the ordered query results to start the page at. }
+    StartIndex: cint32;
+    { The number of results in the current page. }
+    Count: cint32;
+    { The number of results associated with they original query options. }
+    TotalCount: cint32;
+end;
+
+{
+ * All possible states of a local user
+ *
+ * @see EOS_Auth_AddNotifyLoginStatusChanged
+ * @see EOS_Auth_GetLoginStatus
+ * @see EOS_Auth_Login
+ * @see EOS_Connect_AddNotifyLoginStatusChanged
+ * @see EOS_Connect_GetLoginStatus
+ * @see EOS_Connect_Login
+ }
+EOS_ELoginStatus = (
+    { Player has not logged in or chosen a local profile }
+    EOS_LS_NotLoggedIn = 0,
+    { Player is using a local profile but is not logged in }
+    EOS_LS_UsingLocalProfile = 1,
+    { Player has been validated by the platform specific authentication service }
+    EOS_LS_LoggedIn = 2
+);
+
+{
+ * Supported types of data that can be stored with inside an attribute (used by sessions/lobbies/etc)
+ *
+ * @see EOS_LobbySearch_SetParameter
+ * @see EOS_SessionSearch_SetParameter
+ }
+EOS_EAttributeType = (
+    { Boolean value (true/false) }
+    EOS_AT_BOOLEAN = 0,
+    { 64 bit integers }
+    EOS_AT_INT64 = 1,
+    { Double/floating point precision }
+    EOS_AT_DOUBLE = 2,
+    { UTF8 Strings }
+    EOS_AT_STRING = 3
+);
+
+//typedef EOS_EAttributeType EOS_ESessionAttributeType;
+//typedef EOS_EAttributeType EOS_ELobbyAttributeType;
+
+{
+ * All comparison operators associated with parameters in a search query
+ *
+ * @see EOS_LobbySearch_SetParameter
+ * @see EOS_SessionSearch_SetParameter
+ }
+EOS_EComparisonOp = (
+    { Value must equal the one stored on the lobby/session }
+    EOS_CO_EQUAL = 0,
+    { Value must not equal the one stored on the lobby/session }
+    EOS_CO_NOTEQUAL = 1,
+    { Value must be strictly greater than the one stored on the lobby/session }
+    EOS_CO_GREATERTHAN = 2,
+    { Value must be greater than or equal to the one stored on the lobby/session }
+    EOS_CO_GREATERTHANOREQUAL = 3,
+    { Value must be strictly less than the one stored on the lobby/session }
+    EOS_CO_LESSTHAN = 4,
+    { Value must be less than or equal to the one stored on the lobby/session }
+    EOS_CO_LESSTHANOREQUAL = 5,
+    { Prefer values nearest the one specified ie. abs(SearchValue-SessionValue) closest to 0 }
+    EOS_CO_DISTANCE = 6,
+    { Value stored on the lobby/session may be any from a specified list }
+    EOS_CO_ANYOF = 7,
+    { Value stored on the lobby/session may NOT be any from a specified list }
+    EOS_CO_NOTANYOF = 8,
+    { This one value is a part of a collection }
+    EOS_CO_ONEOF = 9,
+    { This one value is NOT part of a collection }
+    EOS_CO_NOTONEOF = 10,
+    { This value is a CASE SENSITIVE substring of an attribute stored on the lobby/session }
+    EOS_CO_CONTAINS = 11
+);
+
+//typedef EOS_EComparisonOp EOS_EOnlineComparisonOp;
+
+{
+ * All supported external account providers
+ *
+ * @see EOS_Connect_QueryExternalAccountMappings
+ }
+EOS_EExternalAccountType = (
+    { External account is associated with Epic Games }
+    EOS_EAT_EPIC = 0,
+    { External account is associated with Steam }
+    EOS_EAT_STEAM = 1,
+    { External account is associated with PlayStation(TM)Network }
+    EOS_EAT_PSN = 2,
+    {
+     * External account is associated with Xbox Live
+     *
+     * With EOS Connect API, the associated account type is Partner XUID (PXUID).
+     * With EOS UserInfo API, the associated account type is Xbox Live ID (XUID).
+     }
+    EOS_EAT_XBL = 3,
+    { External account is associated with Discord }
+    EOS_EAT_DISCORD = 4,
+    { External account is associated with GOG }
+    EOS_EAT_GOG = 5,
+    {
+     * External account is associated with Nintendo
+     *
+     * With both EOS Connect and EOS UserInfo APIs, the associated account type is Nintendo Service Account ID.
+     * Local user authentication is possible using Nintendo Account ID, while the account type does not get exposed to the SDK in queries related to linked accounts information.
+     }
+    EOS_EAT_NINTENDO = 6,
+    { External account is associated with Uplay }
+    EOS_EAT_UPLAY = 7,
+    { External account is associated with an OpenID Provider }
+    EOS_EAT_OPENID = 8,
+    { External account is associated with Apple }
+    EOS_EAT_APPLE = 9,
+    { External account is associated with Google }
+    EOS_EAT_GOOGLE = 10,
+    { External account is associated with Oculus }
+    EOS_EAT_OCULUS = 11,
+    { External account is associated with itch.io }
+    EOS_EAT_ITCHIO = 12
+);
+
+{
+ * List of the supported identity providers to authenticate a user.
+ *
+ * The type of authentication token is specific to each provider.
+ * Tokens in string format should be passed as-is to the function.
+ * Tokens retrieved as raw byte arrays should be converted into a hex-encoded UTF-8 string (e.g. "FA87097A..") before being passed to the function.
+ * EOS_ByteArray_ToString can be used for this conversion.
+ *
+ * @see EOS_Auth_Login
+ * @see EOS_Connect_Login
+ }
+EOS_EExternalCredentialType = (
+    {
+     * Epic Games User Token
+     *
+     * Acquired using EOS_Auth_CopyUserAuthToken that returns EOS_Auth_Token::AccessToken.
+     *
+     * Supported with EOS_Connect_Login.
+     }
+    EOS_ECT_EPIC = 0,
+    {
+     * Steam Encrypted App Ticket
+     *
+     * Generated using the ISteamUser::RequestEncryptedAppTicket API of Steamworks SDK.
+     * For ticket generation parameters, use pDataToInclude(NULL) and cbDataToInclude(0).
+     *
+     * The retrieved App Ticket byte buffer needs to be converted into a hex-encoded UTF-8 string (e.g. "FA87097A..") before passing it to the EOS_Auth_Login or EOS_Connect_Login APIs.
+     * EOS_ByteArray_ToString can be used for this conversion.
+     *
+     * Supported with EOS_Auth_Login, EOS_Connect_Login.
+     }
+    EOS_ECT_STEAM_APP_TICKET = 1,
+    {
+     * PlayStation(TM)Network ID Token
+     *
+     * Retrieved from the PlayStation(R) SDK. Please see first-party documentation for additional information.
+     *
+     * Supported with EOS_Auth_Login, EOS_Connect_Login.
+     }
+    EOS_ECT_PSN_ID_TOKEN = 2,
+    {
+     * Xbox Live XSTS Token
+     *
+     * Retrieved from the GDK and XDK. Please see first-party documentation for additional information.
+     *
+     * Supported with EOS_Auth_Login, EOS_Connect_Login.
+     }
+    EOS_ECT_XBL_XSTS_TOKEN = 3,
+    {
+     * Discord Access Token
+     *
+     * Retrieved using the ApplicationManager::GetOAuth2Token API of Discord SDK.
+     *
+     * Supported with EOS_Connect_Login.
+     }
+    EOS_ECT_DISCORD_ACCESS_TOKEN = 4,
+    {
+     * GOG Galaxy Encrypted App Ticket
+     *
+     * Generated using the IUser::RequestEncryptedAppTicket API of GOG Galaxy SDK.
+     * For ticket generation parameters, use data(NULL) and dataSize(0).
+     *
+     * The retrieved App Ticket byte buffer needs to be converted into a hex-encoded UTF-8 string (e.g. "FA87097A..") before passing it to the EOS_Connect_Login API.
+     * For C/C++ API integration, use the EOS_ByteArray_ToString API for the conversion.
+     * For C# integration, you can use <see cref="Helper.ToHexString" /> for the conversion.
+     *
+     * Supported with EOS_Connect_Login.
+     }
+    EOS_ECT_GOG_SESSION_TICKET = 5,
+    {
+     * Nintendo Account ID Token
+     *
+     * Identifies a Nintendo user account and is acquired through web flow authentication where the local user logs in using their email address/sign-in ID and password.
+     * This is the common Nintendo account that users login with outside the Nintendo Switch device.
+     *
+     * Supported with EOS_Auth_Login, EOS_Connect_Login.
+     }
+    EOS_ECT_NINTENDO_ID_TOKEN = 6,
+    {
+     * Nintendo Service Account ID Token (NSA ID)
+     *
+     * The NSA ID identifies uniquely the local Nintendo Switch device. The authentication token is acquired locally without explicit user credentials.
+     * As such, it is the primary authentication method for seamless login on Nintendo Switch.
+     *
+     * The NSA ID is not exposed directly to the user and does not provide any means for login outside the local device.
+     * Because of this, Nintendo Switch users will need to link their Nintendo Account or another external user account
+     * to their Product User ID in order to share their game progression across other platforms. Otherwise, the user will
+     * not be able to login to their existing Product User ID on another platform due to missing login credentials to use.
+     * It is recommended that the game explicitly communicates this restriction to the user so that they will know to add
+     * the first linked external account on the Nintendo Switch device and then proceed with login on another platform.
+     *
+     * In addition to sharing cross-platform game progression, linking the Nintendo Account or another external account
+     * will allow preserving the game progression permanently. Otherwise, the game progression will be tied only to the
+     * local device. In case the user loses access to their local device, they will not be able to recover the game
+     * progression if it is only associated with this account type.
+     *
+     * Supported with EOS_Auth_Login, EOS_Connect_Login.
+     }
+    EOS_ECT_NINTENDO_NSA_ID_TOKEN = 7,
+    {
+     * Uplay Access Token
+     }
+    EOS_ECT_UPLAY_ACCESS_TOKEN = 8,
+    {
+     * OpenID Provider Access Token
+     *
+     * Supported with EOS_Connect_Login.
+     }
+    EOS_ECT_OPENID_ACCESS_TOKEN = 9,
+    {
+     * Device ID access token that identifies the current locally logged in user profile on the local device.
+     * The local user profile here refers to the operating system user login, for example the user's Windows Account
+     * or on a mobile device the default active user profile.
+     *
+     * This credential type is used to automatically login the local user using the EOS Connect Device ID feature.
+     *
+     * The intended use of the Device ID feature is to allow automatically logging in the user on a mobile device
+     * and to allow playing the game without requiring the user to necessarily login using a real user account at all.
+     * This makes a seamless first-time experience possible and allows linking the local device with a real external
+     * user account at a later time, sharing the same EOS_ProductUserId that is being used with the Device ID feature.
+     *
+     * Supported with EOS_Connect_Login.
+     *
+     * @see EOS_Connect_CreateDeviceId
+     }
+    EOS_ECT_DEVICEID_ACCESS_TOKEN = 10,
+    {
+     * Apple ID Token
+     *
+     * Supported with EOS_Connect_Login.
+     }
+    EOS_ECT_APPLE_ID_TOKEN = 11,
+    {
+     * Google ID Token
+     *
+     * Supported with EOS_Connect_Login.
+     }
+    EOS_ECT_GOOGLE_ID_TOKEN = 12,
+    {
+     * Oculus User ID and Nonce
+     *
+     * Call ovr_User_GetUserProof(), or Platform.User.GetUserProof() if you are using Unity, to retrieve the nonce.
+     * Then pass the local User ID and the Nonce as a  formatted string for the EOS_Connect_Login Token parameter.
+     *
+     * Note that in order to successfully retrieve a valid non-zero id for the local user using ovr_User_GetUser(),
+     * your Oculus App needs to be configured in the Oculus Developer Dashboard to have the User ID feature enabled.
+     *
+     * Supported with EOS_Connect_Login.
+     }
+    EOS_ECT_OCULUS_USERID_NONCE = 13,
+    {
+     * itch.io JWT Access Token
+     *
+     * Use the itch.io app manifest to receive a JWT access token for the local user via the ITCHIO_API_KEY process environment variable.
+     * The itch.io access token is valid for 7 days after which the game needs to be restarted by the user as otherwise EOS Connect
+     * authentication session can no longer be refreshed.
+     *
+     * Supported with EOS_Connect_Login.
+     }
+    EOS_ECT_ITCHIO_JWT = 14,
+    {
+     * itch.io Key Access Token
+     *
+     * This access token type is retrieved through the OAuth 2.0 authentication flow for the itch.io application.
+     *
+     * Supported with EOS_Connect_Login.
+     }
+    EOS_ECT_ITCHIO_KEY = 15
+);

--- a/shared/libs/EOS/eos_connect.pas
+++ b/shared/libs/EOS/eos_connect.pas
@@ -1,0 +1,397 @@
+{
+ * The Connect Interface is used to manage local user permissions and access to backend services through the verification of various forms of credentials.
+ * It creates an association between third party providers and an internal mapping that allows Epic Online Services to represent a user agnostically.
+ * All Connect Interface calls take a handle of type EOS_HConnect as the first parameter.
+ * This handle can be retrieved from a EOS_HPlatform handle by using the EOS_Platform_GetConnectInterface function.
+ *
+ * @see EOS_Platform_GetConnectInterface
+ }
+
+{
+ * Login/Authenticate given a valid set of external auth credentials.
+ *
+ * @param Options structure containing the external account credentials and type to use during the login operation.
+ * @param ClientData arbitrary data that is passed back to you in the CompletionDelegate.
+ * @param CompletionDelegate a callback that is fired when the login operation completes, either successfully or in error.
+ }
+procedure EOS_Connect_Login(Handle: EOS_HConnect; Options: PEOS_Connect_LoginOptions; ClientData: Pointer; CompletionDelegate: EOS_Connect_OnLoginCallback); cdecl; external EOSLIB;
+
+{
+ * Create an account association with the Epic Online Service as a product user given their external auth credentials.
+ *
+ * @param Options structure containing a continuance token from a "user not found" response during Login (always try login first).
+ * @param ClientData arbitrary data that is passed back to you in the CompletionDelegate.
+ * @param CompletionDelegate a callback that is fired when the create operation completes, either successfully or in error.
+ }
+procedure EOS_Connect_CreateUser(Handle: EOS_HConnect; Options: PEOS_Connect_CreateUserOptions; ClientData: Pointer; CompletionDelegate: EOS_Connect_OnCreateUserCallback); cdecl; external EOSLIB;
+
+{
+ * Link a set of external auth credentials with an existing product user on the Epic Online Service.
+ *
+ * @param Options structure containing a continuance token from a "user not found" response during Login (always try login first) and a currently logged in user not already associated with this external auth provider.
+ * @param ClientData arbitrary data that is passed back to you in the CompletionDelegate.
+ * @param CompletionDelegate a callback that is fired when the link operation completes, either successfully or in error.
+ }
+procedure EOS_Connect_LinkAccount(Handle: EOS_HConnect; Options: EOS_Connect_LinkAccountOptions; ClientData: Pointer; CompletionDelegate: EOS_Connect_OnLinkAccountCallback); cdecl; external EOSLIB;
+
+{
+ * Unlink external auth credentials from the owning keychain of a logged in product user.
+ *
+ * This function allows recovering the user from scenarios where they have accidentally proceeded to creating
+ * a new product user for the local native user account, instead of linking it with an existing keychain that
+ * they have previously created by playing the game (or another game owned by the organization) on another platform.
+ *
+ * In such scenario, after the initial platform login and a new product user creation, the user wishes to re-login
+ * using other set of external auth credentials to connect with their existing game progression data. In order to
+ * allow automatic login also on the current platform, they will need to unlink the accidentally created new keychain
+ * and product user and then use the EOS_Connect_Login and EOS_Connect_LinkAccount APIs to link the local native platform
+ * account with that previously created existing product user and its owning keychain.
+ *
+ * In another scenario, the user may simply want to disassociate the account that they have logged in with from the current
+ * keychain that it is linked with, perhaps to link it against another keychain or to separate the game progressions again.
+ *
+ * In order to protect against account theft, it is only possible to unlink user accounts that have been authenticated
+ * and logged in to the product user in the current session. This prevents a malicious actor from gaining access to one
+ * of the linked accounts and using it to remove all other accounts linked with the keychain. This also prevents a malicious
+ * actor from replacing the unlinked account with their own corresponding account on the same platform, as the unlinking
+ * operation will ensure that any existing authentication session cannot be used to re-link and overwrite the entry without
+ * authenticating with one of the other linked accounts in the keychain. These restrictions limit the potential attack surface
+ * related to account theft scenarios.
+ *
+ * @param Options structure containing operation input parameters.
+ * @param ClientData arbitrary data that is passed back to you in the CompletionDelegate.
+ * @param CompletionDelegate a callback that is fired when the unlink operation completes, either successfully or in error.
+ }
+procedure EOS_Connect_UnlinkAccount(Handle: EOS_HConnect; Options: PEOS_Connect_UnlinkAccountOptions; ClientData: Pointer; CompletionDelegate: EOS_Connect_OnUnlinkAccountCallback); cdecl; external EOSLIB;
+
+{
+ * Create a new unique pseudo-account that can be used to identify the current user profile on the local device.
+ *
+ * This function is intended to be used by mobile games and PC games that wish to allow
+ * a new user to start playing without requiring to login to the game using any user identity.
+ * In addition to this, the Device ID feature is used to automatically login the local user
+ * also when they have linked at least one external user account(s) with the local Device ID.
+ *
+ * It is possible to link many devices with the same user's account keyring using the Device ID feature.
+ *
+ * Linking a device later or immediately with a real user account will ensure that the player
+ * will not lose their progress if they switch devices or lose the device at some point,
+ * as they will be always able to login with one of their linked real accounts and also link
+ * another new device with the user account associations keychain. Otherwise, without having
+ * at least one permanent user account linked to the Device ID, the player would lose all of their
+ * game data and progression permanently should something happen to their device or the local
+ * user profile on the device.
+ *
+ * After a successful one-time CreateDeviceId operation, the game can login the local user
+ * automatically on subsequent game starts with EOS_Connect_Login using the EOS_ECT_DEVICEID_ACCESS_TOKEN
+ * credentials type. If a Device ID already exists for the local user on the device then EOS_DuplicateNotAllowed
+ * error result is returned and the caller should proceed to calling EOS_Connect_Login directly.
+ *
+ * @param Options structure containing operation input parameters.
+ * @param ClientData arbitrary data that is passed back to you in the CompletionDelegate.
+ * @param CompletionDelegate a callback that is fired when the create operation completes, either successfully or in error.
+ }
+procedure EOS_Connect_CreateDeviceId(Handle: EOS_HConnect; Options: PEOS_Connect_CreateDeviceIdOptions; ClientData: Pointer; CompletionDelegate: EOS_Connect_OnCreateDeviceIdCallback); cdecl; external EOSLIB;
+
+{
+ * Delete any existing Device ID access credentials for the current user profile on the local device.
+ *
+ * The deletion is permanent and it is not possible to recover lost game data and progression
+ * if the Device ID had not been linked with at least one real external user account.
+ *
+ * On Android and iOS devices, uninstalling the application will automatically delete any local
+ * Device ID credentials created by the application.
+ *
+ * On Desktop platforms (Linux, macOS, Windows), Device ID credentials are not automatically deleted.
+ * Applications may re-use existing Device ID credentials for the local OS user when the application is
+ * re-installed, or call the DeleteDeviceId API on the first run to ensure a fresh start for the user.
+ }
+procedure EOS_Connect_DeleteDeviceId(Handle: EOS_HConnect; Options: PEOS_Connect_DeleteDeviceIdOptions; ClientData: Pointer; CompletionDelegate: EOS_Connect_OnDeleteDeviceIdCallback); cdecl; external EOSLIB;
+
+{
+ * Transfer a Device ID pseudo-account and the product user associated with it into another
+ * keychain linked with real user accounts (such as Epic Games, PlayStation(TM)Network, Xbox Live, and other).
+ *
+ * This function allows transferring a product user, i.e. the local user's game progression
+ * backend data from a Device ID owned keychain into a keychain with real user accounts
+ * linked to it. The transfer of Device ID owned product user into a keychain of real user
+ * accounts allows persisting the user's game data on the backend in the event that they
+ * would lose access to the local device or otherwise switch to another device or platform.
+ *
+ * This function is only applicable in the situation of where the local user first plays
+ * the game using the anonymous Device ID login, then later logs in using a real user
+ * account that they have also already used to play the same game or another game under the
+ * same organization within Epic Online Services. In such situation, while normally the login
+ * attempt with a real user account would return EOS_InvalidUser and an EOS_ContinuanceToken
+ * and allow calling the EOS_Connect_LinkAccount API to link it with the Device ID's keychain,
+ * instead the login operation succeeds and finds an existing user because the association
+ * already exists. Because the user cannot have two product users simultaneously to play with,
+ * the game should prompt the user to choose which profile to keep and which one to discard
+ * permanently. Based on the user choice, the game may then proceed to transfer the Device ID
+ * login into the keychain that is persistent and backed by real user accounts, and if the user
+ * chooses so, move the product user as well into the destination keychain and overwrite the
+ * existing previous product user with it. To clarify, moving the product user with the Device ID
+ * login in this way into a persisted keychain allows to preserve the so far only locally persisted
+ * game progression and thus protect the user against a case where they lose access to the device.
+ *
+ * On success, the completion callback will return the preserved EOS_ProductUserId that remains
+ * logged in while the discarded EOS_ProductUserId has been invalidated and deleted permanently.
+ * Consecutive logins using the existing Device ID login type or the external account will
+ * connect the user to the same backend data belonging to the preserved EOS_ProductUserId.
+ *
+ * Example walkthrough: Cross-platform mobile game using the anonymous Device ID login.
+ *
+ * For onboarding new users, the game will attempt to always automatically login the local user
+ * by calling EOS_Connect_Login using the EOS_ECT_DEVICEID_ACCESS_TOKEN login type. If the local
+ * Device ID credentials are not found, and the game wants a frictionless entry for the first time
+ * user experience, the game will automatically call EOS_Connect_CreateDeviceId to create new
+ * Device ID pseudo-account and then login the local user into it. Consecutive game starts will
+ * thus automatically login the user to their locally persisted Device ID account.
+ *
+ * The user starts playing anonymously using the Device ID login type and makes significant game progress.
+ * Later, they login using an external account that they have already used previously for the
+ * same game perhaps on another platform, or another game owned by the same organization.
+ * In such case, EOS_Connect_Login will automatically login the user to their existing account
+ * linking keychain and create automatically a new empty product user for this product.
+ *
+ * In order for the user to use their existing previously created keychain and have the locally
+ * created Device ID login reference to that keychain instead, the user's current product user
+ * needs to be moved to be under that keychain so that their existing game progression will be
+ * preserved. To do so, the game can call EOS_Connect_TransferDeviceIdAccount to transfer the
+ * Device ID login and the product user associated with it into the other keychain that has real
+ * external user account(s) linked to it. Note that it is important that the game either automatically
+ * checks that the other product user does not have any meaningful progression data, or otherwise
+ * will prompt the user to make the choice on which game progression to preserve and which can
+ * be discarded permanently. The other product user will be discarded permanently and cannot be
+ * recovered, so it is very important that the user is guided to make the right choice to avoid
+ * accidental loss of all game progression.
+ *
+ * @see EOS_Connect_Login
+ * @see EOS_Connect_CreateDeviceId
+ *
+ * @param Options structure containing the logged in product users and specifying which one will be preserved.
+ * @param ClientData arbitrary data that is passed back to you in the CompletionDelegate.
+ * @param CompletionDelegate a callback that is fired when the transfer operation completes, either successfully or in error.
+ }
+procedure EOS_Connect_TransferDeviceIdAccount(Handle: EOS_HConnect; Options: PEOS_Connect_TransferDeviceIdAccountOptions; ClientData: Pointer; CompletionDelegate: EOS_Connect_OnTransferDeviceIdAccountCallback); cdecl; external EOSLIB;
+
+{
+ * Retrieve the equivalent Product User IDs from a list of external account IDs from supported account providers.
+ * The values will be cached and retrievable through EOS_Connect_GetExternalAccountMapping.
+ *
+ * @param Options structure containing a list of external account IDs, in string form, to query for the Product User ID representation.
+ * @param ClientData arbitrary data that is passed back to you in the CompletionDelegate.
+ * @param CompletionDelegate a callback that is fired when the query operation completes, either successfully or in error.
+ }
+procedure EOS_Connect_QueryExternalAccountMappings(Handle: EOS_HConnect; Options: PEOS_Connect_QueryExternalAccountMappingsOptions; ClientData: Pointer; CompletionDelegate: EOS_Connect_OnQueryExternalAccountMappingsCallback); cdecl; external EOSLIB;
+
+{
+ * Retrieve the equivalent external account mappings from a list of Product User IDs.
+ *
+ * The values will be cached and retrievable via EOS_Connect_GetProductUserIdMapping, EOS_Connect_CopyProductUserExternalAccountByIndex,
+ * EOS_Connect_CopyProductUserExternalAccountByAccountType or EOS_Connect_CopyProductUserExternalAccountByAccountId.
+ *
+ * @see EOS_Connect_ExternalAccountInfo
+ * @see EOS_Connect_GetProductUserExternalAccountCount
+ * @see EOS_Connect_GetProductUserIdMapping
+ * @see EOS_Connect_CopyProductUserExternalAccountByIndex
+ * @see EOS_Connect_CopyProductUserExternalAccountByAccountType
+ * @see EOS_Connect_CopyProductUserExternalAccountByAccountId
+ * @see EOS_Connect_CopyProductUserInfo
+ *
+ * @param Options structure containing a list of Product User IDs to query for the external account representation.
+ * @param ClientData arbitrary data that is passed back to you in the CompletionDelegate.
+ * @param CompletionDelegate a callback that is fired when the query operation completes, either successfully or in error.
+ }
+procedure EOS_Connect_QueryProductUserIdMappings(Handle: EOS_HConnect; Options: PEOS_Connect_QueryProductUserIdMappingsOptions; ClientData: Pointer; CompletionDelegate: EOS_Connect_OnQueryProductUserIdMappingsCallback); cdecl; external EOSLIB;
+
+{
+ * Fetch a Product User ID that maps to an external account ID cached from a previous query.
+ *
+ * @param Options structure containing the local user and target external account ID.
+ *
+ * @return The Product User ID, previously retrieved from the backend service, for the given target external account.
+ }
+function EOS_Connect_GetExternalAccountMapping(Handle: EOS_HConnect; Options: PEOS_Connect_GetExternalAccountMappingsOptions): EOS_ProductUserId; cdecl; external EOSLIB;
+
+{
+ * Fetch an external account ID, in string form, that maps to a given Product User ID.
+ *
+ * @param Options structure containing the local user and target Product User ID.
+ * @param OutBuffer The buffer into which the external account ID data should be written. The buffer must be long enough to hold a string of EOS_CONNECT_EXTERNAL_ACCOUNT_ID_MAX_LENGTH.
+ * @param InOutBufferLength The size of the OutBuffer in characters.
+ *                          The input buffer should include enough space to be null-terminated.
+ *                          When the function returns, this parameter will be filled with the length of the string copied into OutBuffer.
+ *
+ * @return An EOS_EResult that indicates the external account ID was copied into the OutBuffer.
+ *         EOS_Success if the information is available and passed out in OutUserInfo.
+ *         EOS_InvalidParameters if you pass a null pointer for the out parameter.
+ *         EOS_NotFound if the mapping doesn't exist or hasn't been queried yet.
+ *         EOS_LimitExceeded if the OutBuffer is not large enough to receive the external account ID. InOutBufferLength contains the required minimum length to perform the operation successfully.
+ }
+function EOS_Connect_GetProductUserIdMapping(Handle: EOS_HConnect; Options: PEOS_Connect_GetProductUserIdMappingOptions; OutBuffer: Pointer; InOutBufferLength: pcint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Fetch the number of linked external accounts for a Product User ID.
+ *
+ * @param Options The Options associated with retrieving the external account info count.
+ *
+ * @see EOS_Connect_CopyProductUserExternalAccountByIndex
+ *
+ * @return Number of external accounts or 0 otherwise.
+ }
+function EOS_Connect_GetProductUserExternalAccountCount(Handle: EOS_HConnect; Options: PEOS_Connect_GetProductUserExternalAccountCountOptions): cuint32; cdecl; external EOSLIB;
+
+{
+ * Fetch information about an external account linked to a Product User ID.
+ * On a successful call, the caller must release the returned structure using the EOS_Connect_ExternalAccountInfo_Release API.
+ *
+ * @param Options Structure containing the target index.
+ * @param OutExternalAccountInfo The external account info data for the user with given index.
+ *
+ * @see EOS_Connect_ExternalAccountInfo_Release
+ *
+ * @return An EOS_EResult that indicates the external account data was copied into the OutExternalAccountInfo.
+ *         EOS_Success if the information is available and passed out in OutExternalAccountInfo.
+ *         EOS_InvalidParameters if you pass a null pointer for the out parameter.
+ *         EOS_NotFound if the account data doesn't exist or hasn't been queried yet.
+ }
+function EOS_Connect_CopyProductUserExternalAccountByIndex(Handle: EOS_HConnect; Options: PEOS_Connect_CopyProductUserExternalAccountByIndexOptions; OutExternalAccountInfo: PPEOS_Connect_ExternalAccountInfo): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Fetch information about an external account of a specific type linked to a Product User ID.
+ * On a successful call, the caller must release the returned structure using the EOS_Connect_ExternalAccountInfo_Release API.
+ *
+ * @param Options Structure containing the target external account type.
+ * @param OutExternalAccountInfo The external account info data for the user with given external account type.
+ *
+ * @see EOS_Connect_ExternalAccountInfo_Release
+ *
+ * @return An EOS_EResult that indicates the external account data was copied into the OutExternalAccountInfo.
+ *         EOS_Success if the information is available and passed out in OutExternalAccountInfo.
+ *         EOS_InvalidParameters if you pass a null pointer for the out parameter.
+ *         EOS_NotFound if the account data doesn't exist or hasn't been queried yet.
+ }
+function EOS_Connect_CopyProductUserExternalAccountByAccountType(Handle: EOS_HConnect; Options: PEOS_Connect_CopyProductUserExternalAccountByAccountTypeOptions; OutExternalAccountInfo: PPEOS_Connect_ExternalAccountInfo): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Fetch information about an external account linked to a Product User ID.
+ * On a successful call, the caller must release the returned structure using the EOS_Connect_ExternalAccountInfo_Release API.
+ *
+ * @param Options Structure containing the target external account ID.
+ * @param OutExternalAccountInfo The external account info data for the user with given external account ID.
+ *
+ * @see EOS_Connect_ExternalAccountInfo_Release
+ *
+ * @return An EOS_EResult that indicates the external account data was copied into the OutExternalAccountInfo.
+ *         EOS_Success if the information is available and passed out in OutExternalAccountInfo.
+ *         EOS_InvalidParameters if you pass a null pointer for the out parameter.
+ *         EOS_NotFound if the account data doesn't exist or hasn't been queried yet.
+ }
+function EOS_Connect_CopyProductUserExternalAccountByAccountId(Handle: EOS_HConnect; Options: PEOS_Connect_CopyProductUserExternalAccountByAccountIdOptions; OutExternalAccountInfo: PPEOS_Connect_ExternalAccountInfo): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Fetch information about a Product User, using the external account that they most recently logged in with as the reference.
+ * On a successful call, the caller must release the returned structure using the EOS_Connect_ExternalAccountInfo_Release API.
+ *
+ * @param Options Structure containing the target external account ID.
+ * @param OutExternalAccountInfo The external account info data last logged in for the user.
+ *
+ * @see EOS_Connect_ExternalAccountInfo_Release
+ *
+ * @return An EOS_EResult that indicates the external account data was copied into the OutExternalAccountInfo.
+ *         EOS_Success if the information is available and passed out in OutExternalAccountInfo.
+ *         EOS_InvalidParameters if you pass a null pointer for the out parameter.
+ *         EOS_NotFound if the account data doesn't exist or hasn't been queried yet.
+ }
+function EOS_Connect_CopyProductUserInfo(Handle: EOS_HConnect; Options: PEOS_Connect_CopyProductUserInfoOptions; OutExternalAccountInfo: PPEOS_Connect_ExternalAccountInfo): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Fetch the number of product users that are logged in.
+ *
+ * @return the number of product users logged in.
+ }
+function EOS_Connect_GetLoggedInUsersCount(Handle: EOS_HConnect): cint32; cdecl; external EOSLIB;
+
+{
+ * Fetch a Product User ID that is logged in. This Product User ID is in the Epic Online Services namespace.
+ *
+ * @param Index an index into the list of logged in users. If the index is out of bounds, the returned Product User ID will be invalid.
+ *
+ * @return the Product User ID associated with the index passed.
+ }
+function EOS_Connect_GetLoggedInUserByIndex(Handle: EOS_HConnect; _Index: cint32): EOS_ProductUserId; cdecl; external EOSLIB;
+
+{
+ * Fetches the login status for an Product User ID.  This Product User ID is considered logged in as long as the underlying access token has not expired.
+ *
+ * @param LocalUserId the Product User ID of the user being queried.
+ *
+ * @return the enum value of a user's login status.
+ }
+function EOS_Connect_GetLoginStatus(Handle: EOS_HConnect; LocalUserId: EOS_ProductUserId): EOS_ELoginStatus; cdecl; external EOSLIB;
+
+{
+ * Register to receive upcoming authentication expiration notifications.
+ * Notification is approximately 10 minutes prior to expiration.
+ * Call EOS_Connect_Login again with valid third party credentials to refresh access.
+ *
+ * @note must call RemoveNotifyAuthExpiration to remove the notification.
+ *
+ * @param Options structure containing the API version of the callback to use.
+ * @param ClientData arbitrary data that is passed back to you in the callback.
+ * @param Notification a callback that is fired when the authentication is about to expire.
+ *
+ * @return handle representing the registered callback.
+ }
+function EOS_Connect_AddNotifyAuthExpiration(Handle: EOS_HConnect; Options: PEOS_Connect_AddNotifyAuthExpirationOptions; ClientData: Pointer; Notification: EOS_Connect_OnAuthExpirationCallback): EOS_NotificationId; cdecl; external EOSLIB;
+
+{
+ * Unregister from receiving expiration notifications.
+ *
+ * @param InId handle representing the registered callback.
+ }
+procedure EOS_Connect_RemoveNotifyAuthExpiration(Handle: EOS_HConnect; InId: EOS_NotificationId); cdecl; external EOSLIB;
+
+{
+ * Register to receive user login status updates.
+ * @note must call RemoveNotifyLoginStatusChanged to remove the notification.
+ *
+ * @param Options structure containing the API version of the callback to use.
+ * @param ClientData arbitrary data that is passed back to you in the callback.
+ * @param Notification a callback that is fired when the login status for a user changes.
+ *
+ * @return handle representing the registered callback.
+ }
+function EOS_Connect_AddNotifyLoginStatusChanged(Handle: EOS_HConnect; Options: PEOS_Connect_AddNotifyLoginStatusChangedOptions; ClientData: Pointer; Notification: EOS_Connect_OnLoginStatusChangedCallback): EOS_NotificationId; cdecl; external EOSLIB;
+
+{
+ * Unregister from receiving user login status updates.
+ *
+ * @param InId handle representing the registered callback.
+ }
+procedure EOS_Connect_RemoveNotifyLoginStatusChanged(Handle: EOS_HConnect; InId: EOS_NotificationId); cdecl; external EOSLIB;
+
+{
+ * Fetches an ID token for a Product User ID.
+ *
+ * @param Options Structure containing information about the ID token to copy.
+ * @param OutIdToken The ID token for the given user, if it exists and is valid; use EOS_Connect_IdToken_Release when finished.
+ *
+ * @see EOS_Connect_IdToken_Release
+ *
+ * @return EOS_Success if the information is available and passed out in OutIdToken.
+ *         EOS_InvalidParameters if you pass a null pointer for the out parameter.
+ *         EOS_NotFound if the ID token is not found or expired.
+ }
+function EOS_Connect_CopyIdToken(Handle: EOS_HConnect; Options: PEOS_Connect_CopyIdTokenOptions; var OutIdToken: PEOS_Connect_IdToken): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Verify a given ID token for authenticity and validity.
+ * @note Can only be called by dedicated servers.
+ *
+ * @param Options structure containing information about the ID token to verify.
+ * @param ClientData arbitrary data that is passed back to you in the callback.
+ * @param CompletionDelegate a callback that is fired when the operation completes, either successfully or in error.
+ }
+procedure EOS_Connect_VerifyIdToken(Handle: EOS_HConnect; Options: PEOS_Connect_VerifyIdTokenOptions; ClientData: Pointer; CompletionDelegate: EOS_Connect_OnVerifyIdTokenCallback); cdecl; external EOSLIB;

--- a/shared/libs/EOS/eos_connect_types.pas
+++ b/shared/libs/EOS/eos_connect_types.pas
@@ -1,0 +1,781 @@
+type EOS_HConnect = Pointer;
+
+{ Max length of an external account ID in string form }
+const EOS_CONNECT_EXTERNAL_ACCOUNT_ID_MAX_LENGTH = 256;
+
+{ The most recent version of the EOS_Connect_Credentials struct. }
+const EOS_CONNECT_CREDENTIALS_API_LATEST = 1;
+
+{
+ * A structure that contains external login credentials.
+ *
+ * This is part of the input structure EOS_Connect_LoginOptions.
+ *
+ * @see EOS_EExternalCredentialType
+ * @see EOS_Connect_Login
+ }
+type EOS_Connect_Credentials = record
+    { API Version: Set this to EOS_CONNECT_CREDENTIALS_API_LATEST. }
+    ApiVersion: cint32;
+    { External token associated with the user logging in. }
+    Token: PChar;
+    { Type of external login; identifies the auth method to use. }
+    _Type: EOS_EExternalCredentialType;
+end;
+
+{ Max length of a display name, not including the terminating null. }
+const EOS_CONNECT_USERLOGININFO_DISPLAYNAME_MAX_LENGTH = 32;
+
+{ The most recent version of the EOS_Connect_UserLoginInfo struct. }
+const EOS_CONNECT_USERLOGININFO_API_LATEST = 1;
+
+{
+ * Additional information about the local user.
+ *
+ * As the information passed here is client-controlled and not part of the user authentication tokens,
+ * it is only treated as non-authoritative informational data to be used by some of the feature services.
+ * For example displaying player names in Leaderboards rankings.
+ }
+type EOS_Connect_UserLoginInfo = record
+    { API Version: Set this to EOS_CONNECT_USERLOGININFO_API_LATEST. }
+    ApiVersion: cint32;
+    {
+     * The user's display name on the identity provider systems as UTF-8 encoded null-terminated string.
+     * The length of the name can be at maximum up to EOS_CONNECT_USERLOGININFO_DISPLAYNAME_MAX_LENGTH bytes.
+     }
+    DisplayName: PChar;
+end;
+
+
+{ The most recent version of the EOS_Connect_Login API. }
+const EOS_CONNECT_LOGIN_API_LATEST = 2;
+
+{
+ * Input parameters for the EOS_Connect_Login function.
+ }
+type EOS_Connect_LoginOptions = record
+    { API Version: Set this to EOS_CONNECT_LOGIN_API_LATEST. }
+    ApiVersion: cint32;
+    { Credentials specified for a given login method }
+    Credentials: ^EOS_Connect_Credentials;
+    {
+     * Additional non-authoritative information about the local user.
+     *
+     * This field is required to be set and only used when authenticating the user using Amazon, Apple, Google, Nintendo Account, Nintendo Service Account, Oculus or the Device ID feature login.
+     * When using other identity providers, set to NULL.
+     }
+    UserLoginInfo: ^EOS_Connect_UserLoginInfo;
+end;
+
+type PEOS_Connect_LoginOptions = ^EOS_Connect_LoginOptions;
+
+{
+ * Output parameters for the EOS_Connect_Login function.
+ }
+type EOS_Connect_LoginCallbackInfo = record
+    { The EOS_EResult code for the operation. EOS_Success indicates that the operation succeeded; other codes indicate errors. }
+    ResultCode: EOS_EResult;
+    { Context that was passed into EOS_Connect_Login. }
+    ClientData: Pointer;
+    { If login was succesful, this is the Product User ID of the local player that logged in. }
+    LocalUserId: EOS_ProductUserId;
+    {
+     * If the user was not found with credentials passed into EOS_Connect_Login,
+     * this continuance token can be passed to either EOS_Connect_CreateUser
+     * or EOS_Connect_LinkAccount to continue the flow.
+     }
+    ContinuanceToken: EOS_ContinuanceToken;
+end;
+
+type PEOS_Connect_LoginCallbackInfo = ^EOS_Connect_LoginCallbackInfo;
+
+{
+ * Function prototype definition for callbacks passed to EOS_Connect_Login.
+ *
+ * @param Data A EOS_Connect_LoginCallbackInfo containing the output information and result.
+ }
+type EOS_Connect_OnLoginCallback = procedure(Data: PEOS_Connect_LoginCallbackInfo); stdcall;
+
+{ The most recent version of the EOS_Connect_CreateUser API. }
+const EOS_CONNECT_CREATEUSER_API_LATEST = 1;
+
+{
+ * Input parameters for the EOS_Connect_CreateUser function.
+ }
+type EOS_Connect_CreateUserOptions = record
+    { API Version: Set this to EOS_CONNECT_CREATEUSER_API_LATEST. }
+    ApiVersion: cint32;
+    { Continuance token from previous call to EOS_Connect_Login }
+    ContinuanceToken: EOS_ContinuanceToken;
+end;
+
+type PEOS_Connect_CreateUserOptions = ^EOS_Connect_CreateUserOptions;
+
+{
+ * Output parameters for the EOS_Connect_CreateUser function.
+ }
+type EOS_Connect_CreateUserCallbackInfo = record
+    { The EOS_EResult code for the operation. EOS_Success indicates that the operation succeeded; other codes indicate errors. }
+    ResultCode: EOS_EResult;
+    { Context that was passed into EOS_Connect_CreateUser. }
+    ClientData: Pointer;
+    { If the operation succeeded, this is the Product User ID of the local user who was created. }
+    LocalUserId: EOS_ProductUserId;
+end;
+
+type PEOS_Connect_CreateUserCallbackInfo = ^EOS_Connect_CreateUserCallbackInfo;
+
+type EOS_Connect_OnCreateUserCallback = procedure(Data: PEOS_Connect_CreateUserCallbackInfo);
+{ The most recent version of the EOS_Connect_LinkAccount API. }
+const EOS_CONNECT_LINKACCOUNT_API_LATEST = 1;
+
+{
+ * Input parameters for the EOS_Connect_LinkAccount function.
+ }
+type EOS_Connect_LinkAccountOptions = record
+    { API Version: Set this to EOS_CONNECT_LINKACCOUNT_API_LATEST. }
+    ApiVersion: cint32;
+    { The existing logged in product user for which to link the external account described by the continuance token. }
+    LocalUserId: EOS_ProductUserId;
+    { Continuance token from previous call to EOS_Connect_Login. }
+    ContinuanceToken: EOS_ContinuanceToken;
+end;
+
+type PEOS_Connect_LinkAccountOptions = ^EOS_Connect_LinkAccountOptions;
+
+{
+ * Output parameters for the EOS_Connect_LinkAccount function.
+ }
+type EOS_Connect_LinkAccountCallbackInfo = record
+    { The EOS_EResult code for the operation. EOS_Success indicates that the operation succeeded; other codes indicate errors. }
+    ResultCode: EOS_EResult;
+    { Context that was passed into EOS_Connect_LinkAccount. }
+    ClientData: Pointer;
+    { The Product User ID of the existing, logged-in user whose account was linked (on success). }
+    LocalUserId: EOS_ProductUserId;
+end;
+
+type PEOS_Connect_LinkAccountCallbackInfo = ^EOS_Connect_LinkAccountCallbackInfo;
+
+{
+ * Function prototype definition for callbacks passed to EOS_Connect_LinkAccount.
+ *
+ * @param Data A EOS_Connect_LinkAccountCallbackInfo containing the output information and result.
+ }
+type EOS_Connect_OnLinkAccountCallback = procedure(Data: PEOS_Connect_LinkAccountCallbackInfo);
+{ The most recent version of the EOS_Connect_UnlinkAccount API. }
+const EOS_CONNECT_UNLINKACCOUNT_API_LATEST = 1;
+
+{
+ * Input parameters for the EOS_Connect_UnlinkAccount Function.
+ }
+type EOS_Connect_UnlinkAccountOptions = record
+    { API Version: Set this to EOS_CONNECT_UNLINKACCOUNT_API_LATEST. }
+    ApiVersion: cint32;
+    {
+     * Existing logged in product user that is subject for the unlinking operation.
+     * The external account that was used to login to the product user will be unlinked from the owning keychain.
+     *
+     * On a successful operation, the product user will be logged out as the external account used to authenticate the user was unlinked from the owning keychain.
+     }
+    LocalUserId: EOS_ProductUserId;
+end;
+
+type PEOS_Connect_UnlinkAccountOptions = ^EOS_Connect_UnlinkAccountOptions;
+
+{
+ * Output parameters for the EOS_Connect_UnlinkAccount Function.
+ }
+type EOS_Connect_UnlinkAccountCallbackInfo = record
+    { The EOS_EResult code for the operation. EOS_Success indicates that the operation succeeded; other codes indicate errors. }
+    ResultCode: EOS_EResult;
+    { Context that was passed into EOS_Connect_UnlinkAccount. }
+    ClientData: Pointer;
+    {
+     * The product user that was subject for the unlinking operation.
+     *
+     * On a successful operation, the local authentication session for the product user will have been invalidated.
+     * As such, the LocalUserId value will no longer be valid in any context unless the user is logged into it again.
+     }
+    LocalUserId: EOS_ProductUserId;
+end;
+
+type PEOS_Connect_UnlinkAccountCallbackInfo = ^EOS_Connect_UnlinkAccountCallbackInfo;
+
+{
+ * Function prototype definition for callbacks passed to EOS_Connect_UnlinkAccount.
+ *
+ * @param Data A EOS_Connect_UnlinkAccountCallbackInfo containing the output information and result
+ }
+type EOS_Connect_OnUnlinkAccountCallback = procedure(Data: PEOS_Connect_UnlinkAccountCallbackInfo);
+{ The most recent version of the EOS_Connect_CreateDeviceId API. }
+const EOS_CONNECT_CREATEDEVICEID_API_LATEST = 1;
+
+{ Max length of a device model name, not including the terminating null }
+const EOS_CONNECT_CREATEDEVICEID_DEVICEMODEL_MAX_LENGTH = 64;
+
+{
+ * Input parameters for the EOS_Connect_CreateDeviceId function.
+ }
+type EOS_Connect_CreateDeviceIdOptions = record
+    { API Version: Set this to EOS_CONNECT_CREATEDEVICEID_API_LATEST. }
+    ApiVersion: cint32;
+    {
+     * A freeform text description identifying the device type and model,
+     * which can be used in account linking management to allow the player
+     * and customer support to identify different devices linked to an EOS
+     * user keychain. For example 'iPhone 6S' or 'PC Windows'.
+     *
+     * The input string must be in UTF-8 character format, with a maximum
+     * length of 64 characters. Longer string will be silently truncated.
+     *
+     * This field is required to be present.
+     }
+    DeviceModel: PChar;
+end;
+
+type PEOS_Connect_CreateDeviceIdOptions = ^EOS_Connect_CreateDeviceIdOptions;
+
+{
+ * Output parameters for the EOS_Connect_CreateDeviceId function.
+ }
+type EOS_Connect_CreateDeviceIdCallbackInfo = record
+    { The EOS_EResult code for the operation. EOS_Success indicates that the operation succeeded; other codes indicate errors. }
+    ResultCode: EOS_EResult;
+    { Context that was passed into EOS_Connect_CreateDeviceId. }
+    ClientData: Pointer;
+end;
+
+type PEOS_Connect_CreateDeviceIdCallbackInfo = ^EOS_Connect_CreateDeviceIdCallbackInfo;
+
+type EOS_Connect_OnCreateDeviceIdCallback = procedure(Data: PEOS_Connect_CreateDeviceIdCallbackInfo); stdcall;
+{ The most recent version of the EOS_Connect_DeleteDeviceId API. }
+const EOS_CONNECT_DELETEDEVICEID_API_LATEST = 1;
+
+{
+ * Input parameters for the EOS_Connect_DeleteDeviceId function.
+ }
+type EOS_Connect_DeleteDeviceIdOptions = record
+    { API Version: Set this to EOS_CONNECT_DELETEDEVICEID_API_LATEST. }
+    ApiVersion: cint32;
+end;
+
+type PEOS_Connect_DeleteDeviceIdOptions = ^EOS_Connect_DeleteDeviceIdOptions;
+
+{
+ * Output parameters for the EOS_Connect_DeleteDeviceId function.
+ }
+type EOS_Connect_DeleteDeviceIdCallbackInfo = record
+    { The EOS_EResult code for the operation. EOS_Success indicates that the operation succeeded; other codes indicate errors. }
+    ResultCode: EOS_EResult;
+    { Context that was passed into EOS_Connect_DeleteDeviceId }
+    ClientData: Pointer;
+end;
+
+type PEOS_Connect_DeleteDeviceIdCallbackInfo = ^EOS_Connect_DeleteDeviceIdCallbackInfo;
+
+type EOS_Connect_OnDeleteDeviceIdCallback = procedure(Data: PEOS_Connect_DeleteDeviceIdCallbackInfo);
+
+{ The most recent version of the EOS_Connect_TransferDeviceIdAccount API. }
+const EOS_CONNECT_TRANSFERDEVICEIDACCOUNT_API_LATEST = 1;
+
+{
+ * Input parameters for the EOS_Connect_TransferDeviceIdAccount Function.
+ }
+type EOS_Connect_TransferDeviceIdAccountOptions = record
+    { API Version: Set this to EOS_CONNECT_TRANSFERDEVICEIDACCOUNT_API_LATEST. }
+    ApiVersion: cint32;
+    {
+     * The primary product user id, currently logged in, that is already associated with a real external user account (such as Epic Games, PlayStation(TM)Network, Xbox Live and other).
+     *
+     * The account linking keychain that owns this product user will be preserved and receive
+     * the Device ID login credentials under it.
+     }
+    PrimaryLocalUserId: EOS_ProductUserId;
+    {
+     * The product user id, currently logged in, that has been originally created using the anonymous local Device ID login type,
+     * and whose Device ID login will be transferred to the keychain of the PrimaryLocalUserId.
+     }
+    LocalDeviceUserId: EOS_ProductUserId;
+    {
+     * Specifies which EOS_ProductUserId (i.e. game progression) will be preserved in the operation.
+     *
+     * After a successful transfer operation, subsequent logins using the same external account or
+     * the same local Device ID login will return user session for the ProductUserIdToPreserve.
+     *
+     * Set to either PrimaryLocalUserId or LocalDeviceUserId.
+     }
+    ProductUserIdToPreserve: EOS_ProductUserId;
+end;
+
+type PEOS_Connect_TransferDeviceIdAccountOptions = ^EOS_Connect_TransferDeviceIdAccountOptions;
+
+{
+ * Output parameters for the EOS_Connect_TransferDeviceIdAccount Function.
+ }
+type EOS_Connect_TransferDeviceIdAccountCallbackInfo = record
+    { The EOS_EResult code for the operation. EOS_Success indicates that the operation succeeded; other codes indicate errors. }
+    ResultCode: EOS_EResult;
+    { Context that was passed into EOS_Connect_TransferDeviceIdAccount. }
+    ClientData: Pointer;
+    {
+     * The ProductUserIdToPreserve that was passed to the original EOS_Connect_TransferDeviceIdAccount call.
+     *
+     * On successful operation, this EOS_ProductUserId will have a valid authentication session
+     * and the other EOS_ProductUserId value has been discarded and lost forever.
+     *
+     * The application should remove any registered notification callbacks for the discarded EOS_ProductUserId as obsolete.
+     }
+    LocalUserId: EOS_ProductUserId;
+end;
+
+type PEOS_Connect_TransferDeviceIdAccountCallbackInfo = ^EOS_Connect_TransferDeviceIdAccountCallbackInfo;
+
+{
+ * Function prototype definition for callbacks passed to EOS_Connect_TransferDeviceIdAccount.
+ *
+ * @param Data A EOS_Connect_TransferDeviceIdAccountCallbackInfo containing the output information and result.
+ }
+type EOS_Connect_OnTransferDeviceIdAccountCallback = procedure(Data: PEOS_Connect_TransferDeviceIdAccountCallbackInfo);
+{ The most recent version of the EOS_Connect_QueryExternalAccountMappings API. }
+const EOS_CONNECT_QUERYEXTERNALACCOUNTMAPPINGS_API_LATEST = 1;
+
+{ Maximum number of account IDs that can be queried at once }
+const EOS_CONNECT_QUERYEXTERNALACCOUNTMAPPINGS_MAX_ACCOUNT_IDS = 128;
+
+{
+ * Input parameters for the EOS_Connect_QueryExternalAccountMappings function.
+ }
+type EOS_Connect_QueryExternalAccountMappingsOptions = record
+    { API Version: Set this to EOS_CONNECT_QUERYEXTERNALACCOUNTMAPPINGS_API_LATEST. }
+    ApiVersion: cint32;
+    { The Product User ID of the existing, logged-in user who is querying account mappings. }
+    LocalUserId: EOS_ProductUserId;
+    { External auth service supplying the account IDs in string form. }
+    AccountIdType: EOS_EExternalAccountType;
+    { An array of external account IDs to map to the product user ID representation. }
+    ExternalAccountIds: PPChar;
+    { Number of account IDs to query. }
+    ExternalAccountIdCount: cuint32;
+end;
+
+type PEOS_Connect_QueryExternalAccountMappingsOptions = ^EOS_Connect_QueryExternalAccountMappingsOptions;
+
+{
+ * Output parameters for the EOS_Connect_QueryExternalAccountMappings function.
+ }
+type EOS_Connect_QueryExternalAccountMappingsCallbackInfo = record
+    { The EOS_EResult code for the operation. EOS_Success indicates that the operation succeeded; other codes indicate errors. }
+    ResultCode: EOS_EResult;
+    { Context that was passed into EOS_Connect_QueryExternalAccountMappings. }
+    ClientData: Pointer;
+    { The Product User ID of the existing, logged-in user who made the request. }
+    LocalUserId: EOS_ProductUserId;
+end;
+
+type PEOS_Connect_QueryExternalAccountMappingsCallbackInfo = ^EOS_Connect_QueryExternalAccountMappingsCallbackInfo;
+
+{
+ * Function prototype definition for callbacks passed to EOS_Connect_QueryExternalAccountMappings.
+ *
+ * @param Data A EOS_Connect_QueryExternalAccountMappingsCallbackInfo containing the output information and result.
+ }
+type EOS_Connect_OnQueryExternalAccountMappingsCallback = procedure(Data: PEOS_Connect_QueryExternalAccountMappingsCallbackInfo);
+{ The most recent version of the EOS_Connect_GetExternalAccountMapping API. }
+const EOS_CONNECT_GETEXTERNALACCOUNTMAPPING_API_LATEST = 1;
+
+{ DEPRECATED! Use EOS_CONNECT_GETEXTERNALACCOUNTMAPPING_API_LATEST instead. }
+const EOS_CONNECT_GETEXTERNALACCOUNTMAPPINGS_API_LATEST  = EOS_CONNECT_GETEXTERNALACCOUNTMAPPING_API_LATEST;
+
+{
+ * Input parameters for the EOS_Connect_GetExternalAccountMapping function.
+ }
+type EOS_Connect_GetExternalAccountMappingsOptions = record
+    { API Version: Set this to EOS_CONNECT_GETEXTERNALACCOUNTMAPPING_API_LATEST. }
+    ApiVersion: cint32;
+    { The Product User ID of the existing, logged-in user who is querying account mappings. }
+    LocalUserId: EOS_ProductUserId;
+    { External auth service supplying the account IDs in string form. }
+    AccountIdType: EOS_EExternalAccountType;
+    { Target user to retrieve the mapping for, as an external account ID. }
+    TargetExternalUserId: PChar;
+end;
+
+type PEOS_Connect_GetExternalAccountMappingsOptions = ^EOS_Connect_GetExternalAccountMappingsOptions;
+
+{ The most recent version of the EOS_Connect_QueryProductUserIdMappings API. }
+const EOS_CONNECT_QUERYPRODUCTUSERIDMAPPINGS_API_LATEST = 2;
+
+{
+ * Input parameters for the EOS_Connect_QueryProductUserIdMappings function.
+ }
+type EOS_Connect_QueryProductUserIdMappingsOptions = record
+    { API Version: Set this to EOS_CONNECT_QUERYPRODUCTUSERIDMAPPINGS_API_LATEST. }
+    ApiVersion: cint32;
+    {
+     * Game Clients set this field to the Product User ID of the local authenticated user querying account mappings.
+     * Game Servers set this field to NULL. Usage is allowed given that the configured client policy for server credentials permit it.
+   }
+    { Deprecated - all external mappings are included in this call, it is no longer necessary to specify this value. }
+    AccountIdType_DEPRECATED: EOS_EExternalAccountType;
+    { An array of Product User IDs to query for the given external account representation. }
+    ProductUserIds: ^EOS_ProductUserId;
+    { Number of Product User IDs to query. }
+    ProductUserIdCount: cuint32;
+end;
+
+type PEOS_Connect_QueryProductUserIdMappingsOptions = ^EOS_Connect_QueryProductUserIdMappingsOptions;
+
+{
+ * Output parameters for the EOS_Connect_QueryProductUserIdMappings function.
+ }
+type EOS_Connect_QueryProductUserIdMappingsCallbackInfo = record
+    { The EOS_EResult code for the operation. EOS_Success indicates that the operation succeeded; other codes indicate errors. }
+    ResultCode: EOS_EResult;
+    { Context that was passed into EOS_Connect_QueryProductUserIdMappings. }
+    ClientData: Pointer;
+    { The local Product User ID that was passed with the input options. }
+    LocalUserId: EOS_ProductUserId;
+end;
+
+type PEOS_Connect_QueryProductUserIdMappingsCallbackInfo = ^EOS_Connect_QueryProductUserIdMappingsCallbackInfo;
+
+{
+ * Function prototype definition for callbacks passed to EOS_Connect_QueryProductUserIdMappings.
+ *
+ * @param Data A EOS_Connect_QueryProductUserIdMappingsCallbackInfo containing the output information and result.
+ }
+type EOS_Connect_OnQueryProductUserIdMappingsCallback = procedure(Data: PEOS_Connect_QueryProductUserIdMappingsCallbackInfo); stdcall;
+{ The most recent version of the EOS_Connect_GetProductUserIdMapping API. }
+const EOS_CONNECT_GETPRODUCTUSERIDMAPPING_API_LATEST = 1;
+
+{
+ * Input parameters for the EOS_Connect_GetProductUserIdMapping function.
+ }
+type EOS_Connect_GetProductUserIdMappingOptions = record
+    { API Version: Set this to EOS_CONNECT_GETPRODUCTUSERIDMAPPING_API_LATEST. }
+    ApiVersion: cint32;
+    { The Product User ID of the existing, logged-in user that is querying account mappings. }
+    LocalUserId: EOS_ProductUserId;
+    { External auth service mapping to retrieve. }
+    AccountIdType: EOS_EExternalAccountType;
+    { The Product User ID of the user whose information is being requested. }
+    TargetProductUserId: EOS_ProductUserId;
+end;
+
+type PEOS_Connect_GetProductUserIdMappingOptions = ^EOS_Connect_GetProductUserIdMappingOptions;
+
+{ The most recent version of the EOS_Connect_GetProductUserExternalAccountCount API. }
+const EOS_CONNECT_GETPRODUCTUSEREXTERNALACCOUNTCOUNT_API_LATEST = 1;
+
+{
+ * Input parameters for the EOS_Connect_GetProductUserExternalAccountCount function.
+ }
+type EOS_Connect_GetProductUserExternalAccountCountOptions = record
+    { API Version: Set this to EOS_CONNECT_GETPRODUCTUSEREXTERNALACCOUNTCOUNT_API_LATEST. }
+    ApiVersion: cint32;
+    { The Product User ID to look for when getting external account info count from the cache. }
+    TargetUserId: EOS_ProductUserId;
+end;
+
+type PEOS_Connect_GetProductUserExternalAccountCountOptions = ^EOS_Connect_GetProductUserExternalAccountCountOptions;
+
+{ The most recent version of the EOS_Connect_CopyProductUserExternalAccountByIndex API. }
+const EOS_CONNECT_COPYPRODUCTUSEREXTERNALACCOUNTBYINDEX_API_LATEST = 1;
+
+{
+ * Input parameters for the EOS_Connect_CopyProductUserExternalAccountByIndex function.
+ }
+type EOS_Connect_CopyProductUserExternalAccountByIndexOptions = record
+    { API Version: Set this to EOS_CONNECT_COPYPRODUCTUSEREXTERNALACCOUNTBYINDEX_API_LATEST. }
+    ApiVersion: cint32;
+    { The Product User ID to look for when copying external account info from the cache. }
+    TargetUserId: EOS_ProductUserId;
+    { Index of the external account info to retrieve from the cache. }
+    ExternalAccountInfoIndex: cuint32;
+end;
+
+type PEOS_Connect_CopyProductUserExternalAccountByIndexOptions = ^EOS_Connect_CopyProductUserExternalAccountByIndexOptions;
+
+{ The most recent version of the EOS_Connect_CopyProductUserExternalAccountByAccountType API. }
+const EOS_CONNECT_COPYPRODUCTUSEREXTERNALACCOUNTBYACCOUNTTYPE_API_LATEST = 1;
+
+{
+ * Input parameters for the EOS_Connect_CopyProductUserExternalAccountByAccountType function.
+ }
+type EOS_Connect_CopyProductUserExternalAccountByAccountTypeOptions = record
+    { API Version: Set this to EOS_CONNECT_COPYPRODUCTUSEREXTERNALACCOUNTBYACCOUNTTYPE_API_LATEST. }
+    ApiVersion: cint32;
+    { The Product User ID to look for when copying external account info from the cache. }
+    TargetUserId: EOS_ProductUserId;
+    { External auth service account type to look for when copying external account info from the cache. }
+    AccountIdType: EOS_EExternalAccountType;
+end;
+
+type PEOS_Connect_CopyProductUserExternalAccountByAccountTypeOptions = ^EOS_Connect_CopyProductUserExternalAccountByAccountTypeOptions;
+
+{ The most recent version of the EOS_Connect_CopyProductUserExternalAccountByAccountId API. }
+const EOS_CONNECT_COPYPRODUCTUSEREXTERNALACCOUNTBYACCOUNTID_API_LATEST = 1;
+
+{
+ * Input parameters for the EOS_Connect_CopyProductUserExternalAccountByAccountId function.
+ }
+type EOS_Connect_CopyProductUserExternalAccountByAccountIdOptions = record
+    { API Version: Set this to EOS_CONNECT_COPYPRODUCTUSEREXTERNALACCOUNTBYACCOUNTID_API_LATEST. }
+    ApiVersion: cint32;
+    { The Product User ID to look for when copying external account info from the cache. }
+    TargetUserId: EOS_ProductUserId;
+    { External auth service account ID to look for when copying external account info from the cache. }
+    AccountId: PChar;
+end;
+
+type PEOS_Connect_CopyProductUserExternalAccountByAccountIdOptions = ^EOS_Connect_CopyProductUserExternalAccountByAccountIdOptions;
+
+{ The most recent version of the EOS_Connect_CopyProductUserInfo API. }
+const EOS_CONNECT_COPYPRODUCTUSERINFO_API_LATEST = 1;
+
+{
+ * Input parameters for the EOS_Connect_CopyProductUserInfo function.
+ }
+type EOS_Connect_CopyProductUserInfoOptions = record
+    { API Version: Set this to EOS_CONNECT_COPYPRODUCTUSERINFO_API_LATEST. }
+    ApiVersion: cint32;
+    { Product user ID to look for when copying external account info from the cache. }
+    TargetUserId: EOS_ProductUserId;
+end;
+
+type PEOS_Connect_CopyProductUserInfoOptions = ^EOS_Connect_CopyProductUserInfoOptions;
+
+{ Timestamp value representing an undefined time for last login time. }
+const EOS_CONNECT_TIME_UNDEFINED = -1;
+
+{ The most recent version of the EOS_Connect_ExternalAccountInfo struct. }
+const EOS_CONNECT_EXTERNALACCOUNTINFO_API_LATEST = 1;
+
+{
+ * Contains information about an external account linked with a Product User ID.
+ }
+type EOS_Connect_ExternalAccountInfo = record
+    { API Version: Set this to EOS_CONNECT_EXTERNALACCOUNTINFO_API_LATEST. }
+    ApiVersion: cint32;
+    { The Product User ID of the target user. }
+    ProductUserId: EOS_ProductUserId;
+    { Display name, can be null if not set. }
+    DisplayName: PChar;
+    { External account ID.
+     * May be set to an empty string if the AccountIdType of another user belongs
+     * to different account system than the local user's authenticated account.
+     * The availability of this field is dependent on account system specifics.
+     }
+    AccountId: PChar;
+    { The identity provider that owns the external account. }
+    AccountIdType: EOS_EExternalAccountType;
+    { The POSIX timestamp for the time the user last logged in, or EOS_CONNECT_TIME_UNDEFINED. }
+    LastLoginTime: cint64;
+end;
+
+type PEOS_Connect_ExternalAccountInfo = ^EOS_Connect_ExternalAccountInfo;
+type PPEOS_Connect_ExternalAccountInfo = ^PEOS_Connect_ExternalAccountInfo;
+
+
+{
+ * Release the memory associated with an external account info. This must be called on data retrieved from
+ * EOS_Connect_CopyProductUserExternalAccountByIndex, EOS_Connect_CopyProductUserExternalAccountByAccountType,
+ * EOS_Connect_CopyProductUserExternalAccountByAccountId or EOS_Connect_CopyProductUserInfo.
+ *
+ * @param ExternalAccountInfo The external account info data to release.
+ *
+ * @see EOS_Connect_CopyProductUserExternalAccountByIndex
+ * @see EOS_Connect_CopyProductUserExternalAccountByAccountType
+ * @see EOS_Connect_CopyProductUserExternalAccountByAccountId
+ * @see EOS_Connect_CopyProductUserInfo
+ }
+//EOS_DECLARE_FUNC(void) EOS_Connect_ExternalAccountInfo_Release(EOS_Connect_ExternalAccountInfo* ExternalAccountInfo);
+procedure EOS_Connect_ExternalAccountInfo_Release(ExternalAccountInfo: PEOS_Connect_ExternalAccountInfo); cdecl; external EOSLIB;
+
+{ The most recent version of the EOS_Connect_AddNotifyAuthExpiration API. }
+const EOS_CONNECT_ADDNOTIFYAUTHEXPIRATION_API_LATEST = 1;
+{
+ * Structure containing information for the auth expiration notification callback.
+ }
+type EOS_Connect_AddNotifyAuthExpirationOptions = record
+    { API Version: Set this to EOS_CONNECT_ADDNOTIFYAUTHEXPIRATION_API_LATEST. }
+    ApiVersion: cint32;
+end;
+
+type PEOS_Connect_AddNotifyAuthExpirationOptions = ^EOS_Connect_AddNotifyAuthExpirationOptions;
+
+{ The most recent version of the EOS_Connect_OnAuthExpirationCallback API. }
+const EOS_CONNECT_ONAUTHEXPIRATIONCALLBACK_API_LATEST = 1;
+
+{
+ * Output parameters for the EOS_Connect_OnAuthExpirationCallback function.
+ }
+type EOS_Connect_AuthExpirationCallbackInfo = record
+    { Context that was passed into EOS_Connect_AddNotifyAuthExpiration. }
+    ClientData: Pointer;
+    { The Product User ID of the local player whose status has changed. }
+    LocalUserId: EOS_ProductUserId;
+end;
+
+type PEOS_Connect_AuthExpirationCallbackInfo = ^EOS_Connect_AuthExpirationCallbackInfo;
+
+{
+ * Function prototype definition for notifications that come from EOS_Connect_AddNotifyAuthExpiration.
+ *
+ * @param Data A EOS_Connect_AuthExpirationCallbackInfo containing the output information and result.
+ }
+type EOS_Connect_OnAuthExpirationCallback = procedure(Data: PEOS_Connect_AuthExpirationCallbackInfo);
+
+{ The most recent version of the EOS_Connect_AddNotifyLoginStatusChanged API. }
+const EOS_CONNECT_ADDNOTIFYLOGINSTATUSCHANGED_API_LATEST = 1;
+{
+ * Structure containing information or the connect user login status change callback.
+ }
+type EOS_Connect_AddNotifyLoginStatusChangedOptions = record
+    { API Version: Set this to EOS_CONNECT_ADDNOTIFYLOGINSTATUSCHANGED_API_LATEST. }
+    ApiVersion: cint32;
+end;
+
+PEOS_Connect_AddNotifyLoginStatusChangedOptions = ^EOS_Connect_AddNotifyLoginStatusChangedOptions;
+
+{
+ * Output parameters for the EOS_Connect_OnLoginStatusChangedCallback function.
+ }
+type EOS_Connect_LoginStatusChangedCallbackInfo = record
+    { Context that was passed into EOS_Connect_AddNotifyLoginStatusChanged. }
+    ClientData: Pointer;
+    { The Product User ID of the local player whose status has changed. }
+    LocalUserId: EOS_ProductUserId;
+    { The status prior to the change. }
+    PreviousStatus: EOS_ELoginStatus;
+    { The status at the time of the notification. }
+    CurrentStatus: EOS_ELoginStatus;
+end;
+
+type PEOS_Connect_LoginStatusChangedCallbackInfo = ^EOS_Connect_LoginStatusChangedCallbackInfo;
+
+{
+ * Function prototype definition for notifications that come from EOS_Connect_AddNotifyLoginStatusChanged.
+ *
+ * @param Data A EOS_Connect_LoginStatusChangedCallbackInfo containing the output information and result.
+ }
+type EOS_Connect_OnLoginStatusChangedCallback = procedure(Data: PEOS_Connect_LoginStatusChangedCallbackInfo);
+
+{ The most recent version of the EOS_Connect_IdToken struct. }
+const EOS_CONNECT_IDTOKEN_API_LATEST = 1;
+
+{
+ * A structure that contains an ID token.
+ * These structures are created by EOS_Connect_CopyIdToken and must be passed to EOS_Connect_IdToken_Release.
+ }
+type EOS_Connect_IdToken = record
+    { API Version: Set this to EOS_CONNECT_IDTOKEN_API_LATEST. }
+    ApiVersion: cint32;
+    {
+     * The Product User ID described by the ID token.
+     * Use EOS_ProductUserId_FromString to populate this field when validating a received ID token.
+     }
+    ProductUserId: EOS_ProductUserId;
+    { The ID token as a Json Web Token (JWT) string. }
+    JsonWebToken: PChar;
+end;
+
+type PEOS_Connect_IdToken = ^EOS_Connect_IdToken;
+
+{
+ * Release the memory associated with an EOS_Connect_IdToken structure. This must be called on data retrieved from EOS_Connect_CopyIdToken.
+ *
+ * @param IdToken The ID token structure to be released.
+ *
+ * @see EOS_Connect_IdToken
+ * @see EOS_Connect_CopyIdToken
+ }
+procedure EOS_Connect_IdToken_Release(IdToken: PEOS_Connect_IdToken); cdecl; external EOSLIB;
+
+{ The most recent version of the EOS_Connect_CopyIdToken API. }
+const EOS_CONNECT_COPYIDTOKEN_API_LATEST = 1;
+
+{
+ * Input parameters for the EOS_Connect_CopyIdToken function.
+ }
+type EOS_Connect_CopyIdTokenOptions = record
+    { API Version: Set this to EOS_CONNECT_COPYIDTOKEN_API_LATEST. }
+    ApiVersion: cint32;
+    { The local Product User ID whose ID token should be copied. }
+    LocalUserId: EOS_ProductUserId;
+end;
+
+type PEOS_Connect_CopyIdTokenOptions = ^EOS_Connect_CopyIdTokenOptions;
+
+{ The most recent version of the EOS_Connect_VerifyIdToken API. }
+const EOS_CONNECT_VERIFYIDTOKEN_API_LATEST = 1;
+
+{
+ * Input parameters for the EOS_Connect_VerifyIdToken function.
+ }
+type EOS_Connect_VerifyIdTokenOptions = record
+    { API Version: Set this to EOS_CONNECT_VERIFYIDTOKEN_API_LATEST. }
+    ApiVersion: cint32;
+    {
+     * The ID token to verify.
+     * Use EOS_ProductUserId_FromString to populate the ProductUserId field of this struct.
+     }
+    IdToken: ^EOS_Connect_IdToken;
+end;
+
+type PEOS_Connect_VerifyIdTokenOptions = ^EOS_Connect_VerifyIdTokenOptions;
+
+{
+ * Output parameters for the EOS_Connect_VerifyIdToken Function.
+ }
+type EOS_Connect_VerifyIdTokenCallbackInfo = record
+    { The EOS_EResult code for the operation. EOS_Success indicates that the operation succeeded; other codes indicate errors. }
+    ResultCode: EOS_EResult;
+    { Context that was passed into EOS_Connect_VerifyIdToken }
+    ClientData: Pointer;
+    { The Product User ID associated with the ID token. }
+    ProductUserId: EOS_ProductUserId;
+    {
+     * Flag set to indicate whether account information is available.
+     * Applications must always first check this value to be set before attempting
+     * to read the AccountType, AccountId, Platform and DeviceType fields.
+     *
+     * This flag is always false for users that authenticated using EOS Connect Device ID.
+    }
+    bIsAccountInfoPresent: EOS_Bool;
+    {
+     * The identity provider that the user authenticated with to EOS Connect.
+     *
+     * If bIsAccountInfoPresent is set, this field describes the external account type.
+    }
+    AccountIdType: EOS_EExternalAccountType;
+    {
+     * The external account ID of the authenticated user.
+     *
+     * This value may be set to an empty string.
+     }
+    AccountId: PChar;
+    {
+     * Platform that the user is connected from.
+     *
+     * This value may be set to an empty string.
+    }
+    Platform: PCHar;
+    {
+     * Identifies the device type that the user is connected from.
+     * Can be used to securely verify that the user is connected through a real Console device.
+     *
+     * This value may be set to an empty string.
+    }
+    DeviceType: PChar;
+end;
+
+type PEOS_Connect_VerifyIdTokenCallbackInfo = ^EOS_Connect_VerifyIdTokenCallbackInfo;
+
+{
+ * Function prototype definition for callbacks passed into EOS_Connect_VerifyIdToken.
+ *
+ * @param Data A EOS_Connect_VerifyIdTokenCallbackInfo containing the output information and result.
+}
+type EOS_Connect_OnVerifyIdTokenCallback = procedure(Data: PEOS_Connect_VerifyIdTokenCallbackInfo); stdcall;

--- a/shared/libs/EOS/eos_init.pas
+++ b/shared/libs/EOS/eos_init.pas
@@ -1,0 +1,142 @@
+{
+ * Function prototype type definition for functions that allocate memory.
+ *
+ * Functions passed to EOS_Initialize to serve as memory allocators should return a pointer to the allocated memory.
+ *
+ * The returned pointer should have at least SizeInBytes available capacity and the memory address should be a multiple of Alignment.
+ * The SDK will always call the provided function with an Alignment that is a power of 2.
+ * Allocation failures should return a null pointer.
+ }
+//EXTERN_C typedef void* (EOS_MEMORY_CALL * EOS_AllocateMemoryFunc)(size_t SizeInBytes, size_t Alignment);
+type EOS_AllocateMemoryFunc = function(SizeInBytes: csize_t; Alignment: csize_t): Pointer; stdcall;
+
+{
+ * Function prototype type definition for functions that reallocate memory.
+ *
+ * Functions passed to EOS_Initialize to serve as memory reallocators should return a pointer to the reallocated memory.
+ * The returned pointer should have at least SizeInBytes available capacity and the memory address should be a multiple of alignment.
+ * The SDK will always call the provided function with an Alignment that is a power of 2.
+ * Reallocation failures should return a null pointer.
+ }
+//EXTERN_C typedef void* (EOS_MEMORY_CALL * EOS_ReallocateMemoryFunc)(void* Pointer, size_t SizeInBytes, size_t Alignment);
+type EOS_ReallocateMemoryFunc = function(Pointer_: Pointer; SizeInBytes: csize_t; Alignment: csize_t): Pointer stdcall;
+{
+ * Function prototype type definition for functions that release memory.
+ *
+ * When the SDK is done with memory that has been allocated by a custom allocator passed to EOS_Initialize, it will call the corresponding memory release function.
+ }
+//EXTERN_C typedef void (EOS_MEMORY_CALL * EOS_ReleaseMemoryFunc)(void* Pointer);
+type EOS_ReleaseMemoryFunc = procedure(Pointer_: Pointer); stdcall;
+
+{ The most recent version of the EOS_Initialize_ThreadAffinity API. }
+const EOS_INITIALIZE_THREADAFFINITY_API_LATEST = 1;
+
+{
+ * Options for initializing defining thread affinity for use by Epic Online Services SDK.
+ * Set the affinity to 0 to allow EOS SDK to use a platform specific default value.
+ }
+type EOS_Initialize_ThreadAffinity = record
+    { API Version: Set this to EOS_INITIALIZE_THREADAFFINITY_API_LATEST. }
+    ApiVersion: cint32;
+    { Any thread related to network management that is not IO. }
+    NetworkWork: cuint64;
+    { Any thread that will interact with a storage device. }
+    StorageIo: cuint64;
+    { Any thread that will generate web socket IO. }
+    WebSocketIo: cuint64;
+    { Any thread that will generate IO related to P2P traffic and mangement. }
+    P2PIo: cuint64;
+    { Any thread that will generate http request IO. }
+    HttpRequestIo: cuint64;
+end;
+
+{ The most recent version of the EOS_Initialize API. }
+const EOS_INITIALIZE_API_LATEST = 4;
+
+{
+ * Options for initializing the Epic Online Services SDK.
+ }
+type EOS_InitializeOptions = record
+    { API Version: Set this to EOS_INITIALIZE_API_LATEST. }
+    ApiVersion: cint32;
+    { A custom memory allocator, if desired. }
+    AllocateMemoryFunction: EOS_AllocateMemoryFunc;
+    { A corresponding memory reallocator. If the AllocateMemoryFunction is nulled, then this field must also be nulled. }
+    ReallocateMemoryFunction: EOS_ReallocateMemoryFunc;
+    { A corresponding memory releaser. If the AllocateMemoryFunction is nulled, then this field must also be nulled. }
+    ReleaseMemoryFunction: EOS_ReleaseMemoryFunc;
+    {
+     * The name of the product using the Epic Online Services SDK.
+     *
+     * The name string is required to be non-empty and at maximum of 64 characters long.
+     * The string buffer can consist of the following characters:
+     * A-Z, a-z, 0-9, dot, underscore, space, exclamation mark, question mark, and sign, hyphen, parenthesis, plus, minus, colon.
+     }
+    ProductName: PChar;
+    {
+     * Product version of the running application.
+     *
+     * The name string has same requirements as the ProductName string.
+     }
+    ProductVersion: PChar;
+    { A reserved field that should always be nulled. }
+    Reserved: Pointer;
+    { 
+     * This field is for system specific initialization if any.
+     *
+     * If provided then the structure will be located in <System>/eos_<system>.h.
+     * The structure will be named EOS_<System>_InitializeOptions.
+     }
+    SystemInitializeOptions: Pointer;
+    { The thread affinity override values for each category of thread. }
+    OverrideThreadAffinity: Pointer;
+end;
+
+type PEOS_InitializeOptions = ^EOS_InitializeOptions;
+
+{
+ * Initialize the Epic Online Services SDK.
+ *
+ * Before calling any other function in the SDK, clients must call this function.
+ *
+ * This function must only be called one time and must have a corresponding EOS_Shutdown call.
+ *
+ * @param Options - The initialization options to use for the SDK.
+ * @return An EOS_EResult is returned to indicate success or an error. 
+ *
+ * EOS_Success is returned if the SDK successfully initializes.
+ * EOS_AlreadyConfigured is returned if the function has already been called.
+ * EOS_InvalidParameters is returned if the provided options are invalid.
+ }
+function EOS_Initialize(const Options: PEOS_InitializeOptions): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Tear down the Epic Online Services SDK.
+ *
+ * Once this function has been called, no more SDK calls are permitted; calling anything after EOS_Shutdown will result in undefined behavior.
+ * @return An EOS_EResult is returned to indicate success or an error.
+ * EOS_Success is returned if the SDK is successfully torn down.
+ * EOS_NotConfigured is returned if a successful call to EOS_Initialize has not been made.
+ * EOS_UnexpectedError is returned if EOS_Shutdown has already been called.
+ }
+function EOS_Shutdown(): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Create a single Epic Online Services Platform Instance.
+ *
+ * The platform instance is used to gain access to the various Epic Online Services.
+ *
+ * This function returns an opaque handle to the platform instance, and that handle must be passed to EOS_Platform_Release to release the instance.
+ *
+ * @return An opaque handle to the platform instance.
+ }
+function EOS_Platform_Create(Options: PEOS_Platform_Options): EOS_HPlatform; cdecl; external EOSLIB;
+
+{
+ * Release an Epic Online Services platform instance previously returned from EOS_Platform_Create.
+ *
+ * This function should only be called once per instance returned by EOS_Platform_Create. Undefined behavior will result in calling it with a single instance more than once.
+ * Typically only a single platform instance needs to be created during the lifetime of a game.
+ * You should release each platform instance before calling the EOS_Shutdown function.
+ }
+procedure EOS_Platform_Release(Handle: EOS_HPlatform); cdecl; external EOSLIB;

--- a/shared/libs/EOS/eos_logging.pas
+++ b/shared/libs/EOS/eos_logging.pas
@@ -1,0 +1,136 @@
+{
+ * Logging levels. When a log message is output, it has an associated log level.
+ * Messages will only be sent to the callback function if the message's associated log level is less than or equal to the configured log level for that category.
+ *
+ * @see EOS_Logging_SetCallback
+ * @see EOS_Logging_SetLogLevel
+ }
+type
+EOS_ELogLevel = (
+    EOS_LOG_Off = 0,
+    EOS_LOG_Fatal = 100,
+    EOS_LOG_Error = 200,
+    EOS_LOG_Warning = 300,
+    EOS_LOG_Info = 400,
+    EOS_LOG_Verbose = 500,
+    EOS_LOG_VeryVerbose = 600
+);
+
+{
+ * Logging Categories
+ }
+type
+EOS_ELogCategory = (
+    { Low level logs unrelated to specific services }
+    EOS_LC_Core = 0,
+    { Logs related to the Auth service }
+    EOS_LC_Auth = 1,
+    { Logs related to the Friends service }
+    EOS_LC_Friends = 2,
+    { Logs related to the Presence service }
+    EOS_LC_Presence = 3,
+    { Logs related to the UserInfo service }
+    EOS_LC_UserInfo = 4,
+    { Logs related to HTTP serialization }
+    EOS_LC_HttpSerialization = 5,
+    { Logs related to the Ecommerce service }
+    EOS_LC_Ecom = 6,
+    { Logs related to the P2P service }
+    EOS_LC_P2P = 7,
+    { Logs related to the Sessions service }
+    EOS_LC_Sessions = 8,
+    { Logs related to rate limiting }
+    EOS_LC_RateLimiter = 9,
+    { Logs related to the PlayerDataStorage service }
+    EOS_LC_PlayerDataStorage = 10,
+    { Logs related to sdk analytics }
+    EOS_LC_Analytics = 11,
+    { Logs related to the messaging service }
+    EOS_LC_Messaging = 12,
+    { Logs related to the Connect service }
+    EOS_LC_Connect = 13,
+    { Logs related to the Overlay }
+    EOS_LC_Overlay = 14,
+    { Logs related to the Achievements service }
+    EOS_LC_Achievements = 15,
+    { Logs related to the Stats service }
+    EOS_LC_Stats = 16,
+    { Logs related to the UI service }
+    EOS_LC_UI = 17,
+    { Logs related to the lobby service }
+    EOS_LC_Lobby = 18,
+    { Logs related to the Leaderboards service }
+    EOS_LC_Leaderboards = 19,
+    { Logs related to an internal Keychain feature that the authentication interfaces use }
+    EOS_LC_Keychain = 20,
+    { Logs related to external identity providers }
+    EOS_LC_IdentityProvider = 21,
+    { Logs related to Title Storage }
+    EOS_LC_TitleStorage = 22,
+    { Logs related to the Mods service }
+    EOS_LC_Mods = 23,
+    { Logs related to the Anti-Cheat service }
+    EOS_LC_AntiCheat = 24,
+    { Logs related to reports client. }
+    EOS_LC_Reports = 25,
+    { Logs related to the Sanctions service }
+    EOS_LC_Sanctions = 26,
+    { Logs related to the Progression Snapshot service }
+    EOS_LC_ProgressionSnapshots = 27,
+    { Logs related to the Kids Web Services integration }
+    EOS_LC_KWS = 28,
+    { Logs related to the RTC API }
+    EOS_LC_RTC = 29,
+    { Logs related to the RTC Admin API }
+    EOS_LC_RTCAdmin = 30,
+    { Logs related to the Inventory service *}
+    EOS_LC_Inventory = 31,
+    { Logs related to the Receipt Validator API *}
+    EOS_LC_ReceiptValidator = 32,
+    { Logs related to the Custom Invites API *}
+    EOS_LC_CustomInvites = 33,
+
+    { Not a real log category. Used by EOS_Logging_SetLogLevel to set the log level for all categories at the same time }
+    EOS_LC_ALL_CATEGORIES = $7fffffff
+);
+
+{ A structure representing a log message }
+EOS_LogMessage = record
+    { A string representation of the log message category, encoded in UTF-8. Only valid during the life of the callback, so copy the string if you need it later. }
+    Category: PChar;
+    { The log message, encoded in UTF-8. Only valid during the life of the callback, so copy the string if you need it later. }
+    Message: PChar;
+    { The log level associated with the message }
+    Level: EOS_ELogLevel;
+end;
+
+{
+ * Function prototype definition for functions that receive log messages.
+ *
+ * @param Message A EOS_LogMessage containing the log category, log level, and message.
+ * @see EOS_LogMessage
+ }
+type
+  EOS_LogMessageFunc = procedure(var Message: EOS_LogMessage);
+
+{
+ * Set the callback function to use for SDK log messages. Any previously set callback will no longer be called.
+ *
+ * @param Callback the function to call when the SDK logs messages
+ * @return EOS_Success is returned if the callback will be used for future log messages.
+ *         EOS_NotConfigured is returned if the SDK has not yet been initialized, or if it has been shut down
+ *
+ * @see EOS_Initialize
+ }
+function EOS_Logging_SetCallback(Callback: EOS_LogMessageFunc): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Set the logging level for the specified logging category. By default all log categories will callback for Warnings, Errors, and Fatals.
+ *
+ * @param LogCategory the specific log category to configure. Use EOS_LC_ALL_CATEGORIES to configure all categories simultaneously to the same log level.
+ * @param LogLevel the log level to use for the log category
+ *
+ * @return EOS_Success is returned if the log levels are now in use.
+ *         EOS_NotConfigured is returned if the SDK has not yet been initialized, or if it has been shut down.
+ }
+function EOS_Logging_SetLogLevel(LogCategory: EOS_ELogCategory; LogLevel: EOS_ELogLevel): EOS_EResult; cdecl; external EOSLIB;

--- a/shared/libs/EOS/eos_result.pas
+++ b/shared/libs/EOS/eos_result.pas
@@ -1,0 +1,431 @@
+type EOS_EResult = (
+  { Successful result. no further error processing needed }
+  EOS_Success = 0,
+
+  { Failed due to no connection }
+  EOS_NoConnection = 1,
+  { Failed login due to invalid credentials }
+  EOS_InvalidCredentials = 2,
+  { Failed due to invalid or missing user }
+  EOS_InvalidUser = 3,
+  { Failed due to invalid or missing authentication token for user (e.g. not logged in, }
+  EOS_InvalidAuth = 4,
+  { Failed due to invalid access }
+  EOS_AccessDenied = 5,
+  { If the client does not possess the permission required }
+  EOS_MissingPermissions = 6,
+  { If the token provided does not represent an account }
+  EOS_Token_Not_Account = 7,
+  { Throttled due to too many requests }
+  EOS_TooManyRequests = 8,
+  { Async request was already pending }
+  EOS_AlreadyPending = 9,
+  { Invalid parameters specified for request }
+  EOS_InvalidParameters = 10,
+  { Invalid request }
+  EOS_InvalidRequest = 11,
+  { Failed due to unable to parse or recognize a backend response }
+  EOS_UnrecognizedResponse = 12,
+  { Incompatible client for backend version }
+  EOS_IncompatibleVersion = 13,
+  { Not configured correctly for use }
+  EOS_NotConfigured = 14,
+  { Already configured for use. }
+  EOS_AlreadyConfigured = 15,
+  { Feature not available on this implementation }
+  EOS_NotImplemented = 16,
+  { Operation was canceled (likely by user, }
+  EOS_Canceled = 17,
+  { The requested information was not found }
+  EOS_NotFound = 18,
+  { An error occurred during an asynchronous operation = and it will be retried. Callbacks receiving this result will be called again in the future. }
+  EOS_OperationWillRetry = 19,
+  { The request had no effect }
+  EOS_NoChange = 20,
+  { The request attempted to use multiple or inconsistent API versions }
+  EOS_VersionMismatch = 21,
+  { A maximum limit was exceeded on the client = different from EOS_TooManyRequests }
+  EOS_LimitExceeded = 22,
+  { Feature or client ID performing the operation has been disabled. }
+  EOS_Disabled = 23,
+  { Duplicate entry not allowed }
+  EOS_DuplicateNotAllowed = 24,
+  { Required parameters are missing. DEPRECATED: This error is no longer used. }
+  EOS_MissingParameters_DEPRECATED = 25,
+  { Sandbox ID is invalid }
+  EOS_InvalidSandboxId = 26,
+  { Request timed out }
+  EOS_TimedOut = 27,
+  { A query returned some but not all of the requested results.  }
+  EOS_PartialResult = 28,
+  { Client is missing the whitelisted role }
+  EOS_Missing_Role = 29,
+  { Client is missing the whitelisted feature }
+  EOS_Missing_Feature = 30,
+  { The sandbox given to the backend is invalid }
+  EOS_Invalid_Sandbox = 31,
+  { The deployment given to the backend is invalid }
+  EOS_Invalid_Deployment = 32,
+  { The product ID specified to the backend is invalid }
+  EOS_Invalid_Product = 33,
+  { The product user ID specified to the backend is invalid }
+  EOS_Invalid_ProductUserID = 34,
+  { There was a failure with the backend service }
+  EOS_ServiceFailure = 35,
+  { Cache directory is not set in platform options. }
+  EOS_CacheDirectoryMissing = 36,
+  { Cache directory is not accessible. }
+  EOS_CacheDirectoryInvalid = 37,
+  { The request failed because resource was in an invalid state }
+  EOS_InvalidState = 38,
+  { Request is in progress }
+  EOS_RequestInProgress = 39,
+
+  { Account locked due to login failures }
+  EOS_Auth_AccountLocked = 1001,
+  { Account locked by update operation. }
+  EOS_Auth_AccountLockedForUpdate = 1002,
+  { Refresh token used was invalid }
+  EOS_Auth_InvalidRefreshToken = 1003,
+  { Invalid access token = typically when switching between backend environments }
+  EOS_Auth_InvalidToken = 1004,
+  { Invalid bearer token }
+  EOS_Auth_AuthenticationFailure = 1005,
+  { Invalid platform token }
+  EOS_Auth_InvalidPlatformToken = 1006,
+  { Auth parameters are not associated with this account }
+  EOS_Auth_WrongAccount = 1007,
+  { Auth parameters are not associated with this client }
+  EOS_Auth_WrongClient = 1008,
+  { Full account is required }
+  EOS_Auth_FullAccountRequired = 1009,
+  { Headless account is required }
+  EOS_Auth_HeadlessAccountRequired = 1010,
+  { Password reset is required }
+  EOS_Auth_PasswordResetRequired = 1011,
+  { Password was previously used and cannot be reused }
+  EOS_Auth_PasswordCannotBeReused = 1012,
+  { Authorization code/exchange code has expired }
+  EOS_Auth_Expired = 1013,
+  { Consent has not been given by the user }
+  EOS_Auth_ScopeConsentRequired = 1014,
+  { The application has no profile on the backend }
+  EOS_Auth_ApplicationNotFound = 1015,
+  { The requested consent wasn't found on the backend }
+  EOS_Auth_ScopeNotFound = 1016,
+  { This account has been denied access to login }
+  EOS_Auth_AccountFeatureRestricted = 1017,
+
+  { Pin grant code initiated }
+  EOS_Auth_PinGrantCode = 1020,
+  { Pin grant code attempt expired }
+  EOS_Auth_PinGrantExpired = 1021,
+  { Pin grant code attempt pending }
+  EOS_Auth_PinGrantPending = 1022,
+
+  { External auth source did not yield an account }
+  EOS_Auth_ExternalAuthNotLinked = 1030,
+  { External auth access revoked }
+  EOS_Auth_ExternalAuthRevoked = 1032,
+  { External auth token cannot be interpreted }
+  EOS_Auth_ExternalAuthInvalid = 1033,
+  { External auth cannot be linked to his account due to restrictions }
+  EOS_Auth_ExternalAuthRestricted = 1034,
+  { External auth cannot be used for login }
+  EOS_Auth_ExternalAuthCannotLogin = 1035,
+  { External auth is expired }
+  EOS_Auth_ExternalAuthExpired = 1036,
+  { External auth cannot be removed since it's the last possible way to login }
+  EOS_Auth_ExternalAuthIsLastLoginType = 1037,
+
+  { Exchange code not found }
+  EOS_Auth_ExchangeCodeNotFound = 1040,
+  { Originating exchange code session has expired }
+  EOS_Auth_OriginatingExchangeCodeSessionExpired = 1041,
+
+  { The account has been disabled and cannot be used for authentication }
+  EOS_Auth_PersistentAuth_AccountNotActive = 1050,
+
+  { MFA challenge required }
+  EOS_Auth_MFARequired = 1060,
+
+  { Parental locks are in place }
+  EOS_Auth_ParentalControls = 1070,
+
+  { Korea real ID association required but missing }
+  EOS_Auth_NoRealId = 1080,
+
+  { An outgoing friend invitation is awaiting acceptance; sending another invite to the same user is erroneous }
+  EOS_Friends_InviteAwaitingAcceptance = 2000,
+  { There is no friend invitation to accept/reject }
+  EOS_Friends_NoInvitation = 2001,
+  { Users are already friends = so sending another invite is erroneous }
+  EOS_Friends_AlreadyFriends = 2003,
+  { Users are not friends = so deleting the friend is erroneous }
+  EOS_Friends_NotFriends = 2004,
+  { Remote user has too many invites to receive new invites }
+  EOS_Friends_TargetUserTooManyInvites = 2005,
+  { Local user has too many invites to send new invites }
+  EOS_Friends_LocalUserTooManyInvites = 2006,
+  { Remote user has too many friends to make a new friendship }
+  EOS_Friends_TargetUserFriendLimitExceeded = 2007,
+  { Local user has too many friends to make a new friendship }
+  EOS_Friends_LocalUserFriendLimitExceeded = 2008,
+
+  { Request data was null or invalid }
+  EOS_Presence_DataInvalid = 3000,
+  { Request contained too many or too few unique data items = or the request would overflow the maximum amount of data allowed }
+  EOS_Presence_DataLengthInvalid = 3001,
+  { Request contained data with an invalid key }
+  EOS_Presence_DataKeyInvalid = 3002,
+  { Request contained data with a key too long or too short }
+  EOS_Presence_DataKeyLengthInvalid = 3003,
+  { Request contained data with an invalid value }
+  EOS_Presence_DataValueInvalid = 3004,
+  { Request contained data with a value too long }
+  EOS_Presence_DataValueLengthInvalid = 3005,
+  { Request contained an invalid rich text string }
+  EOS_Presence_RichTextInvalid = 3006,
+  { Request contained a rich text string that was too long }
+  EOS_Presence_RichTextLengthInvalid = 3007,
+  { Request contained an invalid status state }
+  EOS_Presence_StatusInvalid = 3008,
+
+  { The entitlement retrieved is stale = requery for updated information }
+  EOS_Ecom_EntitlementStale = 4000,
+  { The offer retrieved is stale = requery for updated information }
+  EOS_Ecom_CatalogOfferStale = 4001,
+  { The item or associated structure retrieved is stale = requery for updated information }
+  EOS_Ecom_CatalogItemStale = 4002,
+  { The one or more offers has an invalid price. This may be caused by the price setup. }
+  EOS_Ecom_CatalogOfferPriceInvalid = 4003,
+  { The checkout page failed to load }
+  EOS_Ecom_CheckoutLoadError = 4004,
+
+  { Session is already in progress }
+  EOS_Sessions_SessionInProgress = 5000,
+  { Too many players to register with this session }
+  EOS_Sessions_TooManyPlayers = 5001,
+  { Client has no permissions to access this session }
+  EOS_Sessions_NoPermission = 5002,
+  { Session already exists in the system }
+  EOS_Sessions_SessionAlreadyExists = 5003,
+  { Session lock required for operation }
+  EOS_Sessions_InvalidLock = 5004,
+  { Invalid session reference }
+  EOS_Sessions_InvalidSession = 5005,
+  { Sandbox ID associated with auth didn't match }
+  EOS_Sessions_SandboxNotAllowed = 5006,
+  { Invite failed to send }
+  EOS_Sessions_InviteFailed = 5007,
+  { Invite was not found with the service }
+  EOS_Sessions_InviteNotFound = 5008,
+  { This client may not modify the session }
+  EOS_Sessions_UpsertNotAllowed = 5009,
+  { Backend nodes unavailable to process request }
+  EOS_Sessions_AggregationFailed = 5010,
+  { Individual backend node is as capacity }
+  EOS_Sessions_HostAtCapacity = 5011,
+  { Sandbox on node is at capacity }
+  EOS_Sessions_SandboxAtCapacity = 5012,
+  { An anonymous operation was attempted on a non anonymous session }
+  EOS_Sessions_SessionNotAnonymous = 5013,
+  { Session is currently out of sync with the backend = data is saved locally but needs to sync with backend }
+  EOS_Sessions_OutOfSync = 5014,
+  { User has received too many invites }
+  EOS_Sessions_TooManyInvites = 5015,
+  { Presence session already exists for the client }
+  EOS_Sessions_PresenceSessionExists = 5016,
+  { Deployment on node is at capacity }
+  EOS_Sessions_DeploymentAtCapacity = 5017,
+  { Session operation not allowed }
+  EOS_Sessions_NotAllowed = 5018,
+
+  { Request filename was invalid }
+  EOS_PlayerDataStorage_FilenameInvalid = 6000,
+  { Request filename was too long }
+  EOS_PlayerDataStorage_FilenameLengthInvalid = 6001,
+  { Request filename contained invalid characters }
+  EOS_PlayerDataStorage_FilenameInvalidChars = 6002,
+  { Request operation would grow file too large }
+  EOS_PlayerDataStorage_FileSizeTooLarge = 6003,
+  { Request file length is not valid }
+  EOS_PlayerDataStorage_FileSizeInvalid = 6004,
+  { Request file handle is not valid }
+  EOS_PlayerDataStorage_FileHandleInvalid = 6005,
+  { Request data is invalid }
+  EOS_PlayerDataStorage_DataInvalid = 6006,
+  { Request data length was invalid }
+  EOS_PlayerDataStorage_DataLengthInvalid = 6007,
+  { Request start index was invalid }
+  EOS_PlayerDataStorage_StartIndexInvalid = 6008,
+  { Request is in progress }
+  EOS_PlayerDataStorage_RequestInProgress = 6009,
+  { User is marked as throttled which means he can't perform some operations because limits are exceeded.  }
+  EOS_PlayerDataStorage_UserThrottled = 6010,
+  { Encryption key is not set during SDK init.  }
+  EOS_PlayerDataStorage_EncryptionKeyNotSet = 6011,
+  { User data callback returned error (EOS_PlayerDataStorage_EWriteResult::EOS_WR_FailRequest or EOS_PlayerDataStorage_EReadResult::EOS_RR_FailRequest, }
+  EOS_PlayerDataStorage_UserErrorFromDataCallback = 6012,
+  { User is trying to read file that has header from newer version of SDK. Game/SDK needs to be updated. }
+  EOS_PlayerDataStorage_FileHeaderHasNewerVersion = 6013,
+  { The file is corrupted. In some cases retry can fix the issue. }
+  EOS_PlayerDataStorage_FileCorrupted = 6014,
+
+  { EOS Auth service deemed the external token invalid }
+  EOS_Connect_ExternalTokenValidationFailed = 7000,
+  { EOS Auth user already exists }
+  EOS_Connect_UserAlreadyExists = 7001,
+  { EOS Auth expired }
+  EOS_Connect_AuthExpired = 7002,
+  { EOS Auth invalid token }
+  EOS_Connect_InvalidToken = 7003,
+  { EOS Auth doesn't support this token type }
+  EOS_Connect_UnsupportedTokenType = 7004,
+  { EOS Auth Account link failure }
+  EOS_Connect_LinkAccountFailed = 7005,
+  { EOS Auth External service for validation was unavailable }
+  EOS_Connect_ExternalServiceUnavailable = 7006,
+  { EOS Auth External Service configuration failure with Dev Portal }
+  EOS_Connect_ExternalServiceConfigurationFailure = 7007,
+  { EOS Auth Account link failure. Tried to link Nintendo Network Service Account without first linking Nintendo Account. DEPRECATED: The requirement has been removed and this error is no longer used. }
+  EOS_Connect_LinkAccountFailedMissingNintendoIdAccount_DEPRECATED = 7008,
+
+  { The social overlay page failed to load }
+  EOS_UI_SocialOverlayLoadError = 8000,
+
+  { Client has no permissions to modify this lobby }
+  EOS_Lobby_NotOwner = 9000,
+  { Lobby lock required for operation }
+  EOS_Lobby_InvalidLock = 9001,
+  { Lobby already exists in the system }
+  EOS_Lobby_LobbyAlreadyExists = 9002,
+  { Lobby is already in progress }
+  EOS_Lobby_SessionInProgress = 9003,
+  { Too many players to register with this lobby }
+  EOS_Lobby_TooManyPlayers = 9004,
+  { Client has no permissions to access this lobby }
+  EOS_Lobby_NoPermission = 9005,
+  { Invalid lobby session reference }
+  EOS_Lobby_InvalidSession = 9006,
+  { Sandbox ID associated with auth didn't match }
+  EOS_Lobby_SandboxNotAllowed = 9007,
+  { Invite failed to send }
+  EOS_Lobby_InviteFailed = 9008,
+  { Invite was not found with the service }
+  EOS_Lobby_InviteNotFound = 9009,
+  { This client may not modify the lobby }
+  EOS_Lobby_UpsertNotAllowed = 9010,
+  { Backend nodes unavailable to process request }
+  EOS_Lobby_AggregationFailed = 9011,
+  { Individual backend node is as capacity }
+  EOS_Lobby_HostAtCapacity = 9012,
+  { Sandbox on node is at capacity }
+  EOS_Lobby_SandboxAtCapacity = 9013,
+  { User has received too many invites }
+  EOS_Lobby_TooManyInvites = 9014,
+  { Deployment on node is at capacity }
+  EOS_Lobby_DeploymentAtCapacity = 9015,
+  { Lobby operation not allowed }
+  EOS_Lobby_NotAllowed = 9016,
+  { While restoring a lost connection lobby ownership changed and only local member data was updated }
+  EOS_Lobby_MemberUpdateOnly = 9017,
+  { Presence lobby already exists for the client }
+  EOS_Lobby_PresenceLobbyExists = 9018,
+
+  { User callback that receives data from storage returned error. }
+  EOS_TitleStorage_UserErrorFromDataCallback = 10000,
+  { User forgot to set Encryption key during platform init. Title Storage can't work without it. }
+  EOS_TitleStorage_EncryptionKeyNotSet = 10001,
+  { Downloaded file is corrupted. }
+  EOS_TitleStorage_FileCorrupted = 10002,
+  { Downloaded file's format is newer than client SDK version. }
+  EOS_TitleStorage_FileHeaderHasNewerVersion = 10003,
+
+  { ModSdk process is already running. This error comes from the EOSSDK. }
+  EOS_Mods_ModSdkProcessIsAlreadyRunning = 11000,
+  { ModSdk command is empty. Either the ModSdk configuration file is missing or the manifest location is empty. }
+  EOS_Mods_ModSdkCommandIsEmpty = 11001,
+  { Creation of the ModSdk process failed. This error comes from the SDK. }
+  EOS_Mods_ModSdkProcessCreationFailed = 11002,
+  { A critical error occurred in the external ModSdk process that we were unable to resolve. }
+  EOS_Mods_CriticalError = 11003,
+  { A internal error occurred in the external ModSdk process that we were unable to resolve. }
+  EOS_Mods_ToolInternalError = 11004,
+  { A IPC failure occurred in the external ModSdk process. }
+  EOS_Mods_IPCFailure = 11005,
+  { A invalid IPC response received in the external ModSdk process. }
+  EOS_Mods_InvalidIPCResponse = 11006,
+  { A URI Launch failure occurred in the external ModSdk process. }
+  EOS_Mods_URILaunchFailure = 11007,
+  { Attempting to perform an action with a mod that is not installed. This error comes from the external ModSdk process. }
+  EOS_Mods_ModIsNotInstalled = 11008,
+  { Attempting to perform an action on a game that the user doesn't own. This error comes from the external ModSdk process. }
+  EOS_Mods_UserDoesNotOwnTheGame = 11009,
+  { Invalid result of the request to get the offer for the mod. This error comes from the external ModSdk process. }
+  EOS_Mods_OfferRequestByIdInvalidResult = 11010,
+  { Could not find the offer for the mod. This error comes from the external ModSdk process. }
+  EOS_Mods_CouldNotFindOffer = 11011,
+  { Request to get the offer for the mod failed. This error comes from the external ModSdk process. }
+  EOS_Mods_OfferRequestByIdFailure = 11012,
+  { Request to purchase the mod failed. This error comes from the external ModSdk process. }
+  EOS_Mods_PurchaseFailure = 11013,
+  { Attempting to perform an action on a game that is not installed or is partially installed. This error comes from the external ModSdk process. }
+  EOS_Mods_InvalidGameInstallInfo = 11014,
+  { Failed to get manifest location. Either the ModSdk configuration file is missing or the manifest location is empty }
+  EOS_Mods_CannotGetManifestLocation = 11015,
+  { The anti-cheat client protection is not available. Check that the game was started using the anti-cheat bootstrapper. }
+  EOS_Mods_UnsupportedOS = 11016,
+
+  { The anti-cheat client protection is not available. Check that the game was started using the correct launcher. }
+  EOS_AntiCheat_ClientProtectionNotAvailable = 12000,
+  { The current anti-cheat mode is incorrect for using this API }
+  EOS_AntiCheat_InvalidMode = 12001,
+  { The ProductId provided to the anti-cheat client helper executable does not match what was used to initialize the EOS SDK }
+  EOS_AntiCheat_ClientProductIdMismatch = 12002,
+  { The SandboxId provided to the anti-cheat client helper executable does not match what was used to initialize the EOS SDK }
+  EOS_AntiCheat_ClientSandboxIdMismatch = 12003,
+  { (ProtectMessage/UnprotectMessage, No session key is available = but it is required to complete this operation }
+  EOS_AntiCheat_ProtectMessageSessionKeyRequired = 12004,
+  { (ProtectMessage/UnprotectMessage, Message integrity is invalid }
+  EOS_AntiCheat_ProtectMessageValidationFailed = 12005,
+  { (ProtectMessage/UnprotectMessage, Initialization failed }
+  EOS_AntiCheat_ProtectMessageInitializationFailed = 12006,
+  { (RegisterPeer, Peer is already registered }
+  EOS_AntiCheat_PeerAlreadyRegistered = 12007,
+  { (UnregisterPeer, Peer does not exist }
+  EOS_AntiCheat_PeerNotFound = 12008,
+  { (ReceiveMessageFromPeer, Invalid call: Peer is not protected }
+  EOS_AntiCheat_PeerNotProtected = 12009,
+  { The DeploymentId provided to the anti-cheat client helper executable does not match what was used to initialize the EOS SDK *}
+  EOS_AntiCheat_ClientDeploymentIdMismatch = 12010,
+  { EOS Connect DeviceID auth method is not supported for anti-cheat *}
+  EOS_AntiCheat_DeviceIdAuthIsNotSupported = 12011,
+
+  { EOS RTC room cannot accept more participants }
+  EOS_RTC_TooManyParticipants = 13000,
+  { EOS RTC room already exists}
+  EOS_RTC_RoomAlreadyExists = 13001,
+  { The user kicked out from the room }
+  EOS_RTC_UserKicked = 13002,
+  { The user is banned }
+  EOS_RTC_UserBanned = 13003,
+  { EOS RTC room was left successfully }
+  EOS_RTC_RoomWasLeft = 13004,
+  { Connection dropped due to long timeout }
+  EOS_RTC_ReconnectionTimegateExpired = 13005,
+
+  { The number of available Snapshot IDs have all been exhausted. }
+  EOS_ProgressionSnapshot_SnapshotIdUnavailable = 14000,
+
+  { The KWS user does not have a parental email associated with the account.  The parent account was unlinked or deleted }
+  EOS_KWS_ParentEmailMissing = 15000,
+  { The KWS user is no longer a minor and trying to update the parent email }
+  EOS_KWS_UserGraduated = 15001,
+
+  { EOS Android VM not stored }
+  EOS_Android_JavaVMNotStored = 17000,
+
+  { An unexpected error that we cannot identify has occurred. }
+  EOS_UnexpectedError = $7FFFFFFF
+);

--- a/shared/libs/EOS/eos_sdk.pas
+++ b/shared/libs/EOS/eos_sdk.pas
@@ -1,0 +1,375 @@
+{
+ * The Platform Instance is used to gain access to all other Epic Online Service interfaces and to drive internal operations through the Tick.
+ * All Platform Instance calls take a handle of type EOS_HPlatform as the first parameter.
+ * Handle: EOS_HPlatforms are created by calling EOS_Platform_Create and subsequently released by calling EOS_Platform_Release.
+ *
+ * @see eos_init.h
+ * @see EOS_Initialize
+ * @see EOS_Platform_Create
+ * @see EOS_Platform_Release
+ * @see EOS_Shutdown
+}
+
+{
+ * Notify the platform instance to do work. This function must be called frequently in order for the services provided by the SDK to properly
+ * function. For tick-based applications, it is usually desireable to call this once per-tick.
+}
+procedure EOS_Platform_Tick(Handle: EOS_HPlatform); cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Metrics Interface.
+ * @return EOS_HMetrics handle
+ *
+ * @see eos_metrics.h
+ * @see eos_metrics_types.h
+}
+function EOS_Platform_GetMetricsInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Auth Interface.
+ * @return EOS_HAuth handle
+ *
+ * @see eos_auth.h
+ * @see eos_auth_types.h
+}
+function EOS_Platform_GetAuthInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Connect Interface.
+ * @return EOS_HConnect handle
+ *
+ * @see eos_connect.h
+ * @see eos_connect_types.h
+}
+function EOS_Platform_GetConnectInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Ecom Interface.
+ * @return EOS_HEcom handle
+ *
+ * @see eos_ecom.h
+ * @see eos_ecom_types.h
+}
+function EOS_Platform_GetEcomInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the UI Interface.
+ * @return EOS_HUI handle
+ *
+ * @see eos_ui.h
+ * @see eos_ui_types.h
+}
+function EOS_Platform_GetUIInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Friends Interface.
+ * @return EOS_HFriends handle
+ *
+ * @see eos_friends.h
+ * @see eos_friends_types.h
+}
+function EOS_Platform_GetFriendsInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Presence Interface.
+ * @return EOS_HPresence handle
+ *
+ * @see eos_presence.h
+ * @see eos_presence_types.h
+}
+function EOS_Platform_GetPresenceInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Sessions Interface.
+ * @return EOS_HSessions handle
+ *
+ * @see eos_sessions.h
+ * @see eos_sessions_types.h
+}
+function EOS_Platform_GetSessionsInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Lobby Interface.
+ * @return EOS_HLobby handle
+ *
+ * @see eos_lobby.h
+ * @see eos_lobby_types.h
+}
+function EOS_Platform_GetLobbyInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the UserInfo Interface.
+ * @return EOS_HUserInfo handle
+ *
+ * @see eos_userinfo.h
+ * @see eos_userinfo_types.h
+}
+function EOS_Platform_GetUserInfoInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Peer-to-Peer Networking Interface.
+ * @return EOS_HP2P handle
+ *
+ * @see eos_p2p.h
+ * @see eos_p2p_types.h
+}
+function EOS_Platform_GetP2PInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Real Time Communications Interface (RTC).
+ * From the RTC interface you can retrieve the handle to the audio interface (RTCAudio), which is a component of RTC.
+ * @return EOS_HRTC handle
+ *
+ * @see EOS_RTC_GetAudioInterface
+ * @see eos_rtc.h
+ * @see eos_rtc_types.h
+}
+function EOS_Platform_GetRTCInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the RTC Admin interface
+ * @return EOS_HRTCAdmin handle
+ *
+ * @see eos_rtc_admin.h
+ * @see eos_admin_types.h
+}
+function EOS_Platform_GetRTCAdminInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the PlayerDataStorage Interface.
+ * @return EOS_HPlayerDataStorage handle
+ *
+ * @see eos_playerdatastorage.h
+ * @see eos_playerdatastorage_types.h
+}
+function EOS_Platform_GetPlayerDataStorageInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the TitleStorage Interface.
+ * @return EOS_HTitleStorage handle
+ *
+ * @see eos_titlestorage.h
+ * @see eos_titlestorage_types.h
+}
+function EOS_Platform_GetTitleStorageInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Achievements Interface.
+ * @return EOS_HAchievements handle
+ *
+ * @see eos_achievements.h
+ * @see eos_achievements_types.h
+}
+function EOS_Platform_GetAchievementsInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Stats Interface.
+ * @return EOS_HStats handle
+ *
+ * @see eos_stats.h
+ * @see eos_stats_types.h
+}
+function EOS_Platform_GetStatsInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Leaderboards Interface.
+ * @return EOS_HLeaderboards handle
+ *
+ * @see eos_leaderboards.h
+ * @see eos_leaderboards_types.h
+}
+function EOS_Platform_GetLeaderboardsInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Mods Interface.
+ * @return EOS_HMods handle
+ *
+ * @see eos_mods.h
+ * @see eos_mods_types.h
+}
+function EOS_Platform_GetModsInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Anti-Cheat Client Interface.
+ * @return EOS_HAntiCheatClient handle
+ *
+ * @see eos_anticheatclient.h
+ * @see eos_anticheatclient_types.h
+}
+function EOS_Platform_GetAntiCheatClientInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Anti-Cheat Server Interface.
+ * @return EOS_HAntiCheatServer handle
+ *
+ * @see eos_anticheatserver.h
+ * @see eos_anticheatserver_types.h
+}
+function EOS_Platform_GetAntiCheatServerInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get the active country code that the SDK will send to services which require it.
+ * This returns the override value otherwise it will use the country code of the given user.
+ * This is currently used for determining pricing.
+ * Get a handle to the ProgressionSnapshot Interface.
+ * @return EOS_HProgressionSnapshot handle
+ *
+ * @see eos_progressionsnapshot.h
+ * @see eos_progressionsnapshot_types.h
+}
+function EOS_Platform_GetProgressionSnapshotInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Reports Interface.
+ * @return EOS_HReports handle
+ *
+ * @see eos_reports.h
+ * @see eos_reports_types.h
+}
+function EOS_Platform_GetReportsInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Sanctions Interface.
+ * @return EOS_HSanctions handle
+ *
+ * @see eos_sanctions.h
+ * @see eos_sanctions_types.h
+}
+function EOS_Platform_GetSanctionsInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * Get a handle to the Kids Web Service Interface.
+ * @return EOS_HKWS handle
+ *
+ * @see eos_kws.h
+ * @see eos_kws_types.h
+}
+function EOS_Platform_GetKWSInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+
+{
+ * Get a handle to the Custom Invites Interface.
+ * @return EOS_HCustomInvites handle
+ *
+ * @see eos_custominvites.h
+ * @see eos_custominvites_types.h
+}
+function EOS_Platform_GetCustomInvitesInterface(Handle: EOS_HPlatform): Pointer; cdecl; external EOSLIB;
+
+{
+ * This only will return the value set as the override otherwise EOS_NotFound is returned.
+ * This is not currently used for anything internally.
+ *
+ * @param LocalUserId The account to use for lookup if no override exists.
+ * @param OutBuffer The buffer into which the character data should be written.  The buffer must be long enough to hold a string of EOS_COUNTRYCODE_MAX_LENGTH.
+ * @param InOutBufferLength The size of the OutBuffer in characters.
+ *                          The input buffer should include enough space to be null-terminated.
+ *                          When the function returns, this parameter will be filled with the length of the string copied into OutBuffer.
+ *
+ * @return An EOS_EResult that indicates whether the active country code string was copied into the OutBuffer.
+ *         EOS_Success if the information is available and passed out in OutBuffer
+ *         EOS_InvalidParameters if you pass a null pointer for the out parameter
+ *         EOS_NotFound if there is not an override country code for the user.
+ *         EOS_LimitExceeded - The OutBuffer is not large enough to receive the country code string. InOutBufferLength contains the required minimum length to perform the operation successfully.
+ *
+ * @see eos_ecom.h
+ * @see EOS_COUNTRYCODE_MAX_LENGTH
+}
+function EOS_Platform_GetActiveCountryCode(Handle: EOS_HPlatform; LocalUserId: EOS_EpicAccountId; OutBuffer: Pointer; InOutBufferLength: pcint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Get the active locale code that the SDK will send to services which require it.
+ * This returns the override value otherwise it will use the locale code of the given user.
+ * This is used for localization. This follows ISO 639.
+ *
+ * @param LocalUserId The account to use for lookup if no override exists.
+ * @param OutBuffer The buffer into which the character data should be written.  The buffer must be long enough to hold a string of EOS_LOCALECODE_MAX_LENGTH.
+ * @param InOutBufferLength The size of the OutBuffer in characters.
+ *                          The input buffer should include enough space to be null-terminated.
+ *                          When the function returns, this parameter will be filled with the length of the string copied into OutBuffer.
+ *
+ * @return An EOS_EResult that indicates whether the active locale code string was copied into the OutBuffer.
+ *         EOS_Success if the information is available and passed out in OutBuffer
+ *         EOS_InvalidParameters if you pass a null pointer for the out parameter
+ *         EOS_NotFound if there is neither an override nor an available locale code for the user.
+ *         EOS_LimitExceeded - The OutBuffer is not large enough to receive the locale code string. InOutBufferLength contains the required minimum length to perform the operation successfully.
+ *
+ * @see eos_ecom.h
+ * @see EOS_LOCALECODE_MAX_LENGTH
+}
+function EOS_Platform_GetActiveLocaleCode(Handle: EOS_HPlatform; LocalUserId: EOS_EpicAccountId; OutBuffer: Pointer; InOutBufferLength: pcint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Get the override country code that the SDK will send to services which require it.
+ * This is not currently used for anything internally.
+ *
+ * @param OutBuffer The buffer into which the character data should be written.  The buffer must be long enough to hold a string of EOS_COUNTRYCODE_MAX_LENGTH.
+ * @param InOutBufferLength The size of the OutBuffer in characters.
+ *                          The input buffer should include enough space to be null-terminated.
+ *                          When the function returns, this parameter will be filled with the length of the string copied into OutBuffer.
+ *
+ * @return An EOS_EResult that indicates whether the override country code string was copied into the OutBuffer.
+ *         EOS_Success if the information is available and passed out in OutBuffer
+ *         EOS_InvalidParameters if you pass a null pointer for the out parameter
+ *         EOS_LimitExceeded - The OutBuffer is not large enough to receive the country code string. InOutBufferLength contains the required minimum length to perform the operation successfully.
+ *
+ * @see eos_ecom.h
+ * @see EOS_COUNTRYCODE_MAX_LENGTH
+}
+function EOS_Platform_GetOverrideCountryCode(Handle: EOS_HPlatform; OutBuffer: Pointer; InOutBufferLength: pcint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Get the override locale code that the SDK will send to services which require it.
+ * This is used for localization. This follows ISO 639.
+ *
+ * @param OutBuffer The buffer into which the character data should be written.  The buffer must be long enough to hold a string of EOS_LOCALECODE_MAX_LENGTH.
+ * @param InOutBufferLength The size of the OutBuffer in characters.
+ *                          The input buffer should include enough space to be null-terminated.
+ *                          When the function returns, this parameter will be filled with the length of the string copied into OutBuffer.
+ *
+ * @return An EOS_EResult that indicates whether the override locale code string was copied into the OutBuffer.
+ *         EOS_Success if the information is available and passed out in OutBuffer
+ *         EOS_InvalidParameters if you pass a null pointer for the out parameter
+ *         EOS_LimitExceeded - The OutBuffer is not large enough to receive the locale code string. InOutBufferLength contains the required minimum length to perform the operation successfully.
+ *
+ * @see eos_ecom.h
+ * @see EOS_LOCALECODE_MAX_LENGTH
+}
+function EOS_Platform_GetOverrideLocaleCode(Handle: EOS_HPlatform; OutBuffer: Pointer; InOutBufferLength: pcint32): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Set the override country code that the SDK will send to services which require it.
+ * This is not currently used for anything internally.
+ *
+ * @return An EOS_EResult that indicates whether the override country code string was saved.
+ *         EOS_Success if the country code was overridden
+ *         EOS_InvalidParameters if you pass an invalid country code
+ *
+ * @see eos_ecom.h
+ * @see EOS_COUNTRYCODE_MAX_LENGTH
+}
+function EOS_Platform_SetOverrideCountryCode(Handle: EOS_HPlatform; NewCountryCode: PChar): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Set the override locale code that the SDK will send to services which require it.
+ * This is used for localization. This follows ISO 639.
+ *
+ * @return An EOS_EResult that indicates whether the override locale code string was saved.
+ *         EOS_Success if the locale code was overridden
+ *         EOS_InvalidParameters if you pass an invalid locale code
+ *
+ * @see eos_ecom.h
+ * @see EOS_LOCALECODE_MAX_LENGTH
+}
+function EOS_Platform_SetOverrideLocaleCode(Handle: EOS_HPlatform; NewLocaleCode: PChar): EOS_EResult; cdecl; external EOSLIB;
+
+{
+ * Checks if the app was launched through the Epic Launcher, and relaunches it through the Epic Launcher if it wasn't.
+ *
+ * @return An EOS_EResult is returned to indicate success or an error.
+ *
+ * EOS_Success is returned if the app is being restarted. You should quit your process as soon as possible.
+ * EOS_NoChange is returned if the app was already launched through the Epic Launcher, and no action needs to be taken.
+ * EOS_UnexpectedError is returned if the LauncherCheck module failed to initialize, or the module tried and failed to restart the app.
+}
+function EOS_Platform_CheckForLauncherAndRestart(Handle: EOS_HPlatform): EOS_EResult; cdecl; external EOSLIB;

--- a/shared/libs/EOS/eos_types.pas
+++ b/shared/libs/EOS/eos_types.pas
@@ -1,0 +1,88 @@
+type EOS_HPlatform = Pointer;
+
+{ Client credentials. }
+EOS_Platform_ClientCredentials = record
+    { Client ID of the service permissions entry. Set to NULL if no service permissions are used. }
+    ClientId: PChar;
+    { Client secret for accessing the set of permissions. Set to NULL if no service permissions are used. }
+    ClientSecret: PChar;
+end;
+
+{ The most recent version of the EOS_Platform_RTCOptions API. }
+const EOS_PLATFORM_RTCOPTIONS_API_LATEST = 1;
+
+{ Platform RTC options. }
+type EOS_Platform_RTCOptions = record
+    { API Version: Set this to EOS_PLATFORM_RTCOPTIONS_API_LATEST. }
+    ApiVersion: cint32;
+    {
+     * This field is for platform specific initialization if any.
+     *
+     * If provided then the structure will be located in <System>/eos_<System>.h.
+     * The structure will be named EOS_<System>_RTCOptions.
+     }
+    PlatformSpecificOptions: Pointer;
+end;
+
+
+const EOS_COUNTRYCODE_MAX_LENGTH = 4;
+const EOS_COUNTRYCODE_MAX_BUFFER_LEN = (EOS_COUNTRYCODE_MAX_LENGTH + 1);
+const EOS_LOCALECODE_MAX_LENGTH = 9;
+const EOS_LOCALECODE_MAX_BUFFER_LEN = (EOS_LOCALECODE_MAX_LENGTH + 1);
+
+const EOS_PLATFORM_OPTIONS_API_LATEST = 11;
+
+{ Platform Creation Flags used in EOS_Platform_Create }
+
+{ A bit that indicates the SDK is being loaded in a game editor, like Unity or UE4 Play-in-Editor }
+const EOS_PF_LOADING_IN_EDITOR =                $00001;
+{ A bit that indicates the SDK should skip initialization of the overlay, which is used by the in-app purchase flow and social overlay. This bit is implied by EOS_PF_LOADING_IN_EDITOR }
+const EOS_PF_DISABLE_OVERLAY =                  $00002;
+{ A bit that indicates the SDK should skip initialization of the social overlay, which provides an overlay UI for social features. This bit is implied by EOS_PF_LOADING_IN_EDITOR or EOS_PF_DISABLE_OVERLAY }
+const EOS_PF_DISABLE_SOCIAL_OVERLAY =           $00004;
+{ A reserved bit }
+const EOS_PF_RESERVED1 =                        $00008;
+{ A bit that indicates your game would like to opt-in to experimental Direct3D 9 support for the overlay. This flag is only relevant on Windows }
+const EOS_PF_WINDOWS_ENABLE_OVERLAY_D3D9 =      $00010;
+{ A bit that indicates your game would like to opt-in to experimental Direct3D 10 support for the overlay. This flag is only relevant on Windows }
+const EOS_PF_WINDOWS_ENABLE_OVERLAY_D3D10 =     $00020;
+{ A bit that indicates your game would like to opt-in to experimental OpenGL support for the overlay. This flag is only relevant on Windows }
+const EOS_PF_WINDOWS_ENABLE_OVERLAY_OPENGL =    $00040;
+
+{ Platform options for EOS_Platform_Create. }
+type EOS_Platform_Options = record
+    { API Version: Set this to EOS_PLATFORM_OPTIONS_API_LATEST. }
+    ApiVersion: cint32;
+    { A reserved field that should always be nulled. }
+    Reserved: Pointer;
+    { The product ID for the running application, found on the dev portal }
+    ProductId: PChar;
+    { The sandbox ID for the running application, found on the dev portal }
+    SandboxId: PChar;
+    { Set of service permissions associated with the running application }
+    ClientCredentials: EOS_Platform_ClientCredentials;
+    { Set this to EOS_FALSE if the application is running as a client with a local user, otherwise set to EOS_TRUE (e.g. for a dedicated game server) }
+    bIsServer: EOS_Bool;
+    { Used by Player Data Storage and Title Storage. Must be null initialized if unused. 256-bit Encryption Key for file encryption in hexadecimal format (64 hex chars)}
+    EncryptionKey: PChar;
+    { The override country code to use for the logged in user. (EOS_COUNTRYCODE_MAX_LENGTH)}
+    OverrideCountryCode: PChar;
+    { The override locale code to use for the logged in user. This follows ISO 639. (EOS_LOCALECODE_MAX_LENGTH)}
+    OverrideLocaleCode: PChar;
+    { The deployment ID for the running application, found on the dev portal }
+    DeploymentId: PChar;
+    { Platform creation flags, e.g. EOS_PF_LOADING_IN_EDITOR. This is a bitwise-or union of the defined flags. }
+    Flags: cuint64;
+    { Used by Player Data Storage and Title Storage. Must be null initialized if unused. Cache directory path. Absolute path to the folder that is going to be used for caching temporary data. The path is created if it's missing. }
+    CacheDirectory: PChar;
+    {
+     * A budget, measured in milliseconds, for EOS_Platform_Tick to do its work. When the budget is met or exceeded (or if no work is available), EOS_Platform_Tick will return.
+     * This allows your game to amortize the cost of SDK work across multiple frames in the event that a lot of work is queued for processing.
+     * Zero is interpreted as "perform all available work".
+     }
+    TickBudgetInMilliseconds: cuint32;
+    { RTC options. Setting to NULL will disable RTC features (e.g. voice) }
+    RTCOptions: Pointer;
+end;
+
+type PEOS_Platform_Options = ^EOS_Platform_Options;

--- a/shared/libs/EOS/eos_windows.pas
+++ b/shared/libs/EOS/eos_windows.pas
@@ -1,0 +1,6 @@
+const EOS_WINDOWS_RTCOPTIONS_API_LATEST = 1;
+
+type EOS_Windows_RTCOptions = record
+  ApiVersion: cint32;
+  XAudio29DllPath: PChar;
+end;

--- a/shared/libs/EOS/utils/Settings.json
+++ b/shared/libs/EOS/utils/Settings.json
@@ -1,0 +1,9 @@
+{
+	"title"											: "Soldat",
+	"executable"									: "@EOS_EXE_NAME@",
+	"productid"										: "@EOS_PRODUCT_ID@",
+	"sandboxid"										: "@EOS_SANDBOX_ID@",
+	"deploymentid"									: "@EOS_DEPLOYMENT_ID@",
+	"requested_splash"								: "<relative_path_to_splash.png>",
+	"wait_for_game_process_exit"					: "false"
+}

--- a/shared/libs/EOS/utils/anticheat_integritytool.cfg
+++ b/shared/libs/EOS/utils/anticheat_integritytool.cfg
@@ -1,0 +1,105 @@
+#-------------------------------------------
+# Anti-Cheat Integrity Tool Configuration File
+#-------------------------------------------
+#
+config_info:
+{
+    version = 2;
+};
+search_options:
+{  
+	/*
+	 * Size threshold for file hashing in megabytes.
+	 * Any files bigger than the threshold will be excluded
+	 * from the integrity catalog.
+	 *
+	 * To include all files in the integrity catalog, keep the threshold at zero.
+	 */
+	exclude_size_threshold = 0;
+	
+    /*
+     * Paths to ignore.
+     *
+     * Supports both directories and files in simplified UNIX glob style.
+     * Single character ('?') and multicharacter ('*') wildcards are supported, but
+     * '*' can never match more than one directory level.
+     *
+     * Any files that could be different for each user, do not
+     * affect gameplay, or have their integrity verified separately
+     * should be listed here.
+     *
+     * Unity games: This list must contain your Mono\\etc folder.
+     */
+    /*exclude_paths = [
+    ];*/
+    
+    /*
+     * Paths to include.
+     *
+     * Supports both directories and files in simplified UNIX glob style.
+     * Single character ('?') and multicharacter ('*') wildcards are supported, but
+     * '*' can never match more than one directory level.
+     *
+     * If you have only a few files or directories to include this
+     * option may be easier than exclude_paths. Only one of 
+     * exclude_paths or include_paths is supported, never both.
+     *
+     * Note that if you list a file here directly or by wildcard it will
+     * override exclude_extensions, but files inside listed directories will
+     * continue to follow exclude_extensions.
+     */
+    include_paths = [
+        "soldat",
+        "soldat.exe",
+        "*.so",
+        "*.dll",
+        "*.smod"
+    ];
+    
+    /*
+     * Path aliases for remapping.
+     *
+     * If you need to remap specific paths to suit your build system 
+     * put them here. For each ["str_a","str_b"] pair all occurences of "str_a"
+     * in paths will be replaced with "str_b" as the very last step of 
+     * building the hash catalog. All other options specified in this config 
+     * will operate on the actual build time directory structure before any
+     * aliases are applied.
+     */
+    /*alias_paths = (
+        ["game\\bin32release", "game\\bin32"]
+    );*/
+    /*
+     * Files to ignore by extension.
+     * Modify to suit your needs.
+     */
+    exclude_extensions = [
+        ".bak",
+        ".bat",
+        ".bmp",
+        ".cfg",
+        ".db",
+        ".ico",
+        ".inf",
+        ".ini",
+        ".jpg",
+        ".last",
+        ".log",
+        ".manifest",
+        ".mdb",
+        ".pdb",
+        ".png",
+        ".pubkey",
+        ".txt",
+        ".vdf",
+        ".xml",
+        ".sh",
+        ".res",
+        ".eac"
+    ];
+    
+    /*
+     * Do not set unless really needed.
+     */
+    ignore_files_without_extension = false;
+};

--- a/shared/libs/GameNetworkingSockets/GameNetworkingSockets.pas
+++ b/shared/libs/GameNetworkingSockets/GameNetworkingSockets.pas
@@ -1920,8 +1920,15 @@ begin
     raise Exception.Create('GameNetworkingSockets_Init has failed: ' + PChar(ErrorMsg));
   {$ENDIF}
 
+  {$IFDEF STEAM}
+  {$IFDEF SERVER}
+  GameNetworkingSocketsInterface := SteamAPI_SteamGameServerNetworkingSockets_SteamAPI_v011();
+  {$ELSE}
+  GameNetworkingSocketsInterface := SteamAPI_SteamNetworkingSockets_SteamAPI_v011();
+  {$ENDIF}
+  {$ELSE}
   GameNetworkingSocketsInterface := SteamAPI_SteamNetworkingSockets_v009();
-
+  {$ENDIF}
   if GameNetworkingSocketsInterface = nil then
     raise Exception.Create('GameNetworkingSocketsInterface is null');
 end;
@@ -2044,7 +2051,11 @@ end;
 // Utils
 constructor TSteamNetworkingUtils.Init();
 begin
+  {$IFDEF STEAM}
+  GameNetworkingUtilsInterface := SteamAPI_SteamNetworkingUtils_SteamAPI_v004();
+  {$ELSE}
   GameNetworkingUtilsInterface := SteamAPI_SteamNetworkingUtils_v003();
+  {$ENDIF}
   if GameNetworkingUtilsInterface = nil then
     raise Exception.Create('GameNetworkingSocketsInterface is null');
 end;

--- a/shared/libs/SteamWrapper/Steam.pas
+++ b/shared/libs/SteamWrapper/Steam.pas
@@ -4,7 +4,7 @@
 {                                                       }
 {       Copyright (c) 2020 Soldat Team                  }
 {                                                       }
-{       For use with SteamWorks SDK 1.50                }
+{       For use with SteamWorks SDK 1.52                }
 {                                                       }
 {*******************************************************}
 
@@ -376,7 +376,7 @@ function SteamAPI_ISteamParties_DestroyBeacon(SteamInterface: ISteamParties; ulB
 function SteamAPI_ISteamParties_GetBeaconLocationData(SteamInterface: ISteamParties; BeaconLocation: SteamPartyBeaconLocation_t; eData: ESteamPartyBeaconLocationData; pchDataStringOut: PChar; cchDataStringOut: Longint): Boolean; cdecl; external STEAMLIB;
 
 
-function SteamAPI_SteamRemoteStorage_v014(): ISteamRemoteStorage; cdecl; external STEAMLIB;
+function SteamAPI_SteamRemoteStorage_v015(): ISteamRemoteStorage; cdecl; external STEAMLIB;
 
 function SteamAPI_ISteamRemoteStorage_FileWrite(SteamInterface: ISteamRemoteStorage; pchFile: PChar; pvData: Pointer; cubData: int32): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamRemoteStorage_FileRead(SteamInterface: ISteamRemoteStorage; pchFile: PChar; pvData: Pointer; cubDataToRead: int32): int32; cdecl; external STEAMLIB;
@@ -708,8 +708,8 @@ function SteamAPI_ISteamController_TranslateActionOrigin(SteamInterface: ISteamC
 function SteamAPI_ISteamController_GetControllerBindingRevision(SteamInterface: ISteamController; controllerHandle: ControllerHandle_t; pMajor: PInteger; pMinor: PInteger): Boolean; cdecl; external STEAMLIB;
 
 
-function SteamAPI_SteamUGC_v014(): ISteamUGC; cdecl; external STEAMLIB;
-function SteamAPI_SteamGameServerUGC_v014(): ISteamUGC; cdecl; external STEAMLIB;
+function SteamAPI_SteamUGC_v015(): ISteamUGC; cdecl; external STEAMLIB;
+function SteamAPI_SteamGameServerUGC_v015(): ISteamUGC; cdecl; external STEAMLIB;
 
 function SteamAPI_ISteamUGC_CreateQueryUserUGCRequest(SteamInterface: ISteamUGC; unAccountID: AccountID_t; eListType: EUserUGCList; eMatchingUGCType: EUGCMatchingUGCType; eSortOrder: EUserUGCListSortOrder; nCreatorAppID: AppId_t; nConsumerAppID: AppId_t; unPage: uint32): UGCQueryHandle_t; cdecl; external STEAMLIB;
 function SteamAPI_ISteamUGC_CreateQueryAllUGCRequestPage(SteamInterface: ISteamUGC; eQueryType: EUGCQuery; eMatchingeMatchingUGCTypeFileType: EUGCMatchingUGCType; nCreatorAppID: AppId_t; nConsumerAppID: AppId_t; unPage: uint32): UGCQueryHandle_t; cdecl; external STEAMLIB;
@@ -982,8 +982,8 @@ function SteamAPI_ISteamRemotePlay_BGetSessionClientResolution(SteamInterface: I
 function SteamAPI_ISteamRemotePlay_BSendRemotePlayTogetherInvite(SteamInterface: ISteamRemotePlay; steamIDFriend: TSteamID): Boolean; cdecl; external STEAMLIB;
 
 
-function SteamAPI_SteamNetworkingSockets_v009(): ISteamNetworkingSockets; cdecl; external STEAMLIB;
-function SteamAPI_SteamGameServerNetworkingSockets_v009(): ISteamNetworkingSockets; cdecl; external STEAMLIB;
+function SteamAPI_SteamNetworkingSockets_SteamAPI_v011(): ISteamNetworkingSockets; cdecl; external STEAMLIB;
+function SteamAPI_SteamGameServerNetworkingSockets_SteamAPI_v011(): ISteamNetworkingSockets; cdecl; external STEAMLIB;
 
 function SteamAPI_ISteamNetworkingSockets_CreateListenSocketIP(SteamInterface: ISteamNetworkingSockets; localAddress: PSteamNetworkingIPAddr; nOptions: Longint; pOptions: pSteamNetworkingConfigValue_t): HSteamListenSocket; cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingSockets_ConnectByIPAddress(SteamInterface: ISteamNetworkingSockets; address: PSteamNetworkingIPAddr; nOptions: Longint; pOptions: pSteamNetworkingConfigValue_t): HSteamNetConnection; cdecl; external STEAMLIB;
@@ -1034,7 +1034,7 @@ function SteamAPI_ISteamNetworkingCustomSignalingRecvContext_OnConnectRequest(St
 procedure SteamAPI_ISteamNetworkingCustomSignalingRecvContext_SendRejectionSignal(SteamInterface: ISteamNetworkingCustomSignalingRecvContext; identityPeer: PSteamNetworkingIdentity; pMsg: Pointer; cbMsg: Longint); cdecl; external STEAMLIB;
 
 
-function SteamAPI_SteamNetworkingUtils_v003(): ISteamNetworkingUtils; cdecl; external STEAMLIB;
+function SteamAPI_SteamNetworkingUtils_SteamAPI_v004(): ISteamNetworkingUtils; cdecl; external STEAMLIB;
 
 function SteamAPI_ISteamNetworkingUtils_AllocateMessage(SteamInterface: ISteamNetworkingUtils; cbAllocateBuffer: Longint): pSteamNetworkingMessage_t; cdecl; external STEAMLIB;
 procedure SteamAPI_ISteamNetworkingUtils_InitRelayNetworkAccess(SteamInterface: ISteamNetworkingUtils); cdecl; external STEAMLIB;
@@ -1066,15 +1066,16 @@ function SteamAPI_ISteamNetworkingUtils_SetGlobalCallback_SteamRelayNetworkStatu
 function SteamAPI_ISteamNetworkingUtils_SetConfigValue(SteamInterface: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; eScopeType: ESteamNetworkingConfigScope; scopeObj: intptr; eDataType: ESteamNetworkingConfigDataType; pArg: Pointer): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingUtils_SetConfigValueStruct(SteamInterface: ISteamNetworkingUtils; opt: PSteamNetworkingConfigValue_t; eScopeType: ESteamNetworkingConfigScope; scopeObj: intptr): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingUtils_GetConfigValue(SteamInterface: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; eScopeType: ESteamNetworkingConfigScope; scopeObj: intptr; pOutDataType: pESteamNetworkingConfigDataType; var pResult; cbResult: pcsize_t): ESteamNetworkingGetConfigValueResult; cdecl; external STEAMLIB;
-function SteamAPI_ISteamNetworkingUtils_GetConfigValueInfo(SteamInterface: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; pOutName: PPAnsiChar; pOutDataType: pESteamNetworkingConfigDataType; pOutScope: pESteamNetworkingConfigScope; pOutNextValue: pESteamNetworkingConfigValue): Boolean; cdecl; external STEAMLIB;
+function SteamAPI_ISteamNetworkingUtils_GetConfigValueInfo(SteamInterface: ISteamNetworkingUtils; eValue: ESteamNetworkingConfigValue; var pOutName: PAnsiChar; pOutDataType: pESteamNetworkingConfigDataType; pOutScope: pESteamNetworkingConfigScope; pOutNextValue: pESteamNetworkingConfigValue): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingUtils_GetFirstConfigValue(SteamInterface: ISteamNetworkingUtils): ESteamNetworkingConfigValue; cdecl; external STEAMLIB;
 procedure SteamAPI_ISteamNetworkingUtils_SteamNetworkingIPAddr_ToString(SteamInterface: ISteamNetworkingUtils; addr: PSteamNetworkingIPAddr; buf: PChar; cbBuf: uint32; bWithPort: Boolean); cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingUtils_SteamNetworkingIPAddr_ParseString(SteamInterface: ISteamNetworkingUtils; pAddr: pSteamNetworkingIPAddr; pszStr: PChar): Boolean; cdecl; external STEAMLIB;
 procedure SteamAPI_ISteamNetworkingUtils_SteamNetworkingIdentity_ToString(SteamInterface: ISteamNetworkingUtils; identity: PSteamNetworkingIdentity; buf: PChar; cbBuf: uint32); cdecl; external STEAMLIB;
 function SteamAPI_ISteamNetworkingUtils_SteamNetworkingIdentity_ParseString(SteamInterface: ISteamNetworkingUtils; pIdentity: pSteamNetworkingIdentity; pszStr: PChar): Boolean; cdecl; external STEAMLIB;
 
+procedure SteamAPI_SteamNetworkingMessage_t_Release(pIMsg: PSteamNetworkingMessage_t); cdecl; external STEAMLIB;
 
-function SteamAPI_SteamGameServer_v013(): ISteamGameServer; cdecl; external STEAMLIB;
+function SteamAPI_SteamGameServer_v014(): ISteamGameServer; cdecl; external STEAMLIB;
 
 procedure SteamAPI_ISteamGameServer_SetProduct(SteamInterface: ISteamGameServer; pszProduct: PChar); cdecl; external STEAMLIB;
 procedure SteamAPI_ISteamGameServer_SetGameDescription(SteamInterface: ISteamGameServer; pszGameDescription: PChar); cdecl; external STEAMLIB;
@@ -1099,9 +1100,7 @@ procedure SteamAPI_ISteamGameServer_SetKeyValue(SteamInterface: ISteamGameServer
 procedure SteamAPI_ISteamGameServer_SetGameTags(SteamInterface: ISteamGameServer; pchGameTags: PChar); cdecl; external STEAMLIB;
 procedure SteamAPI_ISteamGameServer_SetGameData(SteamInterface: ISteamGameServer; pchGameData: PChar); cdecl; external STEAMLIB;
 procedure SteamAPI_ISteamGameServer_SetRegion(SteamInterface: ISteamGameServer; pszRegion: PChar); cdecl; external STEAMLIB;
-function SteamAPI_ISteamGameServer_SendUserConnectAndAuthenticate(SteamInterface: ISteamGameServer; unIPClient: uint32; pvAuthBlob: Pointer; cubAuthBlobSize: uint32; pSteamIDUser: PSteamID): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamGameServer_CreateUnauthenticatedUserConnection(SteamInterface: ISteamGameServer): TSteamID; cdecl; external STEAMLIB;
-procedure SteamAPI_ISteamGameServer_SendUserDisconnect(SteamInterface: ISteamGameServer; steamIDUser: TSteamID); cdecl; external STEAMLIB;
 function SteamAPI_ISteamGameServer_BUpdateUserData(SteamInterface: ISteamGameServer; steamIDUser: TSteamID; pchPlayerName: PChar; uScore: uint32): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamGameServer_GetAuthSessionTicket(SteamInterface: ISteamGameServer; pTicket: Pointer; cbMaxTicket: Longint; pcbTicket: puint32): HAuthTicket; cdecl; external STEAMLIB;
 function SteamAPI_ISteamGameServer_BeginAuthSession(SteamInterface: ISteamGameServer; pAuthTicket: Pointer; cbAuthTicket: Longint; steamID: TSteamID): EBeginAuthSessionResult; cdecl; external STEAMLIB;
@@ -1114,9 +1113,7 @@ function SteamAPI_ISteamGameServer_GetServerReputation(SteamInterface: ISteamGam
 function SteamAPI_ISteamGameServer_GetPublicIP(SteamInterface: ISteamGameServer): SteamIPAddress_t; cdecl; external STEAMLIB;
 function SteamAPI_ISteamGameServer_HandleIncomingPacket(SteamInterface: ISteamGameServer; pData: Pointer; cbData: Longint; srcIP: uint32; srcPort: uint16): Boolean; cdecl; external STEAMLIB;
 function SteamAPI_ISteamGameServer_GetNextOutgoingPacket(SteamInterface: ISteamGameServer; pOut: Pointer; cbMaxOut: Longint; pNetAdr: puint32; pPort: puint16): Longint; cdecl; external STEAMLIB;
-procedure SteamAPI_ISteamGameServer_EnableHeartbeats(SteamInterface: ISteamGameServer; bActive: Boolean); cdecl; external STEAMLIB;
-procedure SteamAPI_ISteamGameServer_SetHeartbeatInterval(SteamInterface: ISteamGameServer; iHeartbeatInterval: Longint); cdecl; external STEAMLIB;
-procedure SteamAPI_ISteamGameServer_ForceHeartbeat(SteamInterface: ISteamGameServer); cdecl; external STEAMLIB;
+procedure SteamAPI_ISteamGameServer_SetAdvertiseServerActive(SteamInterface: ISteamGameServer; bActive: Boolean); cdecl; external STEAMLIB;
 function SteamAPI_ISteamGameServer_AssociateWithClan(SteamInterface: ISteamGameServer; steamIDClan: TSteamID): SteamAPICall_t; cdecl; external STEAMLIB;
 function SteamAPI_ISteamGameServer_ComputeNewPlayerCompatibility(SteamInterface: ISteamGameServer; steamIDNewPlayer: TSteamID): SteamAPICall_t; cdecl; external STEAMLIB;
 
@@ -1322,9 +1319,7 @@ type
     procedure SetGameTags(GameTags: pAnsiChar);
     procedure SetGameData(GameData: pAnsiChar);
     procedure SetRegion(Region: pAnsiChar);
-    function SendUserConnectAndAuthenticate(ClientIP: uint32; AuthBlob: Pointer; AuthBlobSize: uint32; UserSteamID: pSteamID): Boolean;
     function CreateUnauthenticatedUserConnection(): TSteamID;
-    procedure SendUserDisconnect(steamIDUser: TSteamID);
     function BUpdateUserData(UserID: TSteamID; PlayerName: pAnsiChar; Score: uint32): Boolean;
     function GetAuthSessionTicket(Ticket: Pointer; MaxTicket: Integer; ActualTicketLength: pUint32): uint32;
     function BeginAuthSession(AuthTicket: Pointer; AuthTicketSize: Integer; steamID: TSteamID): EBeginAuthSessionResult;
@@ -1335,9 +1330,7 @@ type
     function GetPublicIP(): SteamIPAddress_t;
     function HandleIncomingPacket(Data: Pointer; DataSize: Integer; SourceIP: uint32; SourcePort: uint16): Boolean;
     function GetNextOutgoingPacket(pOut: Pointer; MaxOutCount: Integer; NetAddress: pUint32; Port: pUint16): Integer;
-    procedure EnableHeartbeats(IsActive: Boolean);
-    procedure SetHeartbeatInterval(HeartbeatInterval: Integer);
-    procedure ForceHeartbeat();
+    procedure SetAdvertiseServerActive(IsActive: Boolean);
     function AssociateWithClan(ClanID: TSteamID): uint64;
     function ComputeNewPlayerCompatibility(NewPlayerID: TSteamID): uint64;
   end;
@@ -1437,7 +1430,7 @@ begin
   if SteamPipeHandle = 0 then
     raise Exception.Create('SteamPipeHandle is null');
 
-  UGC := TSteamUGC.Init(SteamAPI_SteamUGC_v014());
+  UGC := TSteamUGC.Init(SteamAPI_SteamUGC_v015());
   Utils := TSteamUtils.Init(SteamAPI_SteamUtils_v010());
   User := TSteamUser.Init(SteamAPI_SteamUser_v021());
   Screenshots := TSteamScreenshots.Init(SteamAPI_SteamScreenshots_v003());
@@ -1451,9 +1444,9 @@ begin
 
   SteamPipeHandle := SteamGameServer_GetHSteamPipe();
 
-  UGC := TSteamUGC.Init(SteamAPI_SteamGameServerUGC_v014());
+  UGC := TSteamUGC.Init(SteamAPI_SteamGameServerUGC_v015());
   Utils := TSteamUtils.Init(SteamAPI_SteamGameServerUtils_v010());
-  GameServer := TSteamGameServer.Init(SteamAPI_SteamGameServer_v013());
+  GameServer := TSteamGameServer.Init(SteamAPI_SteamGameServer_v014());
   GameServerStats := TSteamGameServerStats.Init(SteamAPI_SteamGameServerStats_v001());
 end;
 
@@ -2020,17 +2013,9 @@ procedure TSteamGameServer.SetRegion(Region: pAnsiChar);
 begin
   SteamAPI_ISteamGameServer_SetRegion(SteamGameServerInterface, Region);
 end;
-function TSteamGameServer.SendUserConnectAndAuthenticate(ClientIP: uint32; AuthBlob: Pointer; AuthBlobSize: uint32; UserSteamID: pSteamID): Boolean;
-begin
-  Result := SteamAPI_ISteamGameServer_SendUserConnectAndAuthenticate(SteamGameServerInterface, ClientIP, AuthBlob, AuthBlobSize, UserSteamID);
-end;
 function TSteamGameServer.CreateUnauthenticatedUserConnection(): TSteamID;
 begin
   Result := SteamAPI_ISteamGameServer_CreateUnauthenticatedUserConnection(SteamGameServerInterface);
-end;
-procedure TSteamGameServer.SendUserDisconnect(steamIDUser: TSteamID);
-begin
-  SteamAPI_ISteamGameServer_SendUserDisconnect(SteamGameServerInterface, steamIDUser);
 end;
 function TSteamGameServer.BUpdateUserData(UserID: TSteamID; PlayerName: pAnsiChar; Score: uint32): Boolean;
 begin
@@ -2072,17 +2057,9 @@ function TSteamGameServer.GetNextOutgoingPacket(pOut: Pointer; MaxOutCount: Inte
 begin
   Result := SteamAPI_ISteamGameServer_GetNextOutgoingPacket(SteamGameServerInterface, pOut, MaxOutCount, NetAddress, Port);
 end;
-procedure TSteamGameServer.EnableHeartbeats(IsActive: Boolean);
+procedure TSteamGameServer.SetAdvertiseServerActive(IsActive: Boolean);
 begin
-  SteamAPI_ISteamGameServer_EnableHeartbeats(SteamGameServerInterface, IsActive);
-end;
-procedure TSteamGameServer.SetHeartbeatInterval(HeartbeatInterval: Integer);
-begin
-  SteamAPI_ISteamGameServer_SetHeartbeatInterval(SteamGameServerInterface, HeartbeatInterval);
-end;
-procedure TSteamGameServer.ForceHeartbeat();
-begin
-  SteamAPI_ISteamGameServer_ForceHeartbeat(SteamGameServerInterface);
+  SteamAPI_ISteamGameServer_SetAdvertiseServerActive(SteamGameServerInterface, IsActive);
 end;
 function TSteamGameServer.AssociateWithClan(ClanID: TSteamID): uint64;
 begin

--- a/shared/network/Net.pas
+++ b/shared/network/Net.pas
@@ -866,6 +866,7 @@ implementation
 
 uses
   {$IFDEF SERVER}Server,{$ELSE}Client,{$ENDIF} Game, TraceLog, Demo,
+  {$IFDEF STEAM}Steam,{$ENDIF}
   {$IFNDEF SERVER}
   NetworkClientSprite, NetworkClientConnection, NetworkClientThing,
   NetworkClientGame, NetworkClientFunctions, NetworkClientHeartbeat,

--- a/shared/network/NetworkClientConnection.pas
+++ b/shared/network/NetworkClientConnection.pas
@@ -58,6 +58,11 @@ begin
     RequestMsg.HaveAntiCheat := ACTYPE_FAE;
   {$ENDIF}
 
+  {$IFDEF ENABLE_EAC}
+  if Assigned(EACClient) then
+    RequestMsg.HaveAntiCheat := ACTYPE_EAC;
+  {$ENDIF}
+
   if RedirectIP <> '' then
   begin
     RequestMsg.Forwarded := 1;
@@ -500,6 +505,9 @@ begin
 
     ANTICHEAT_REJECTED:
       RenderGameInfo(_('Rejected by Anti-Cheat:') + ' ' + Text);
+
+    ANTICHEAT_REQUIRED:
+      RenderGameInfo(_('This server requires Anti-Cheat.'));
   end;
 
   ClientDisconnect;

--- a/shared/network/NetworkServerConnection.pas
+++ b/shared/network/NetworkServerConnection.pas
@@ -94,6 +94,16 @@ begin
   end;
   {$ENDIF}
 
+  {$IFDEF ENABLE_EAC}
+  // Reject clients without anti-cheat if this server requires it
+  if (ac_enable.Value) and (RequestMsg.HaveAntiCheat <> ACTYPE_EAC) then
+  begin
+    State := ANTICHEAT_REQUIRED;
+    ServerSendUnAccepted(NetMessage^.m_conn, State);
+    Exit;
+  end;
+  {$ENDIF}
+
   if IsServerTotallyFull then
     State := SERVER_FULL
   else if IsRemoteAdminIP(Player.IP) then

--- a/shared/network/NetworkServerGame.pas
+++ b/shared/network/NetworkServerGame.pas
@@ -108,6 +108,11 @@ begin
   Sprite[i].Player := DummyPlayer;
   Players.Remove(Player);
 
+  {$IFDEF ENABLE_EAC}
+  if Assigned(EACServer) then
+    EACServer.UnregisterClient(Player);
+  {$ENDIF}
+
   UDP.NetworkingSocket.CloseConnection(NetMessage.m_conn, 0, '', False);
 
   DoBalanceBots(1, Sprite[i].Player.Team);


### PR DESCRIPTION
This change implements [Easy Anti-Cheat](https://www.easy.ac/en-us/) through Epic Online Services. Epic Games has made EAC [free of charge](https://epicgames.com/site/pl/news/epic-online-services-launches-free-in-game-voice-and-easy-anti-cheat) and recently support for [Linux and macOS](https://dev.epicgames.com/en-US/news/epic-online-services-launches-anti-cheat-support-for-linux-mac-and-steam-deck) has been added.

On the client side, [Anti-Cheat interface](https://dev.epicgames.com/docs/services/en-US/GameServices/AntiCheat/index.html) requires a valid identity from [Connect interface](https://dev.epicgames.com/docs/services/en-US/GameServices/Connect/index.html) for authentication purposes. Since "Device ID" is not supported in this case, current implementation uses two other identity providers
- Steam version uses [SteamEncryptedAppTicket](https://partner.steamgames.com/doc/api/SteamEncryptedAppTicket) to validate Steam identity.
- Non-steam version uses OpenID server that returns random credentials.  This is obviously a temporary solution until something better is figured out.

In order to start a protected session, the game client needs to be run through the provided bootstrapper executable (start_protected_game), we also need to hash catalogue files which are used to verify runtime file integrity. There is a CMake target to automate this process.

On the server side, EAC creates a new session for each player and then exchanges data via net code, if EAC detects a violation the player will be kicked or rejected during game request.

# Building
1. Download [C SDK](https://dev.epicgames.com/docs/services/en-US/GameServices/QuickStart/index.html) from [EOS portal](https://dev.epicgames.com/portal/) after signing-in.

2. Create new Product in the EOS portal (you can skip this part and use provided credentials below)
 - Go to Player Moderation tab and click "Download" button to certs for anticheat_integritytool
 -  Go to Anti-Cheat subpage and enable the latest Client Module for each platform
 - Go to Product Settings -> Clients -> Create two clients (Soldat -> policy: GameClient, Soldat Server -> policy: Trusted Server)
 - Go to Product Settings -> Identity Providers
   - Add Steam identity with AppId 480 (SpaceWar) and Encryption Key `ed9386073647cea58b7721490d59ed445723f0f66e7414e1533ba33cd803bdbd`
   - Add OpenID identity with type: UserInfo Endpoint and url: https://soldat-openid.fly.dev/ (this is a mockup server that generates random credentials) 
3. Set environment variables for your product: `EOS_PRODUCT_ID` `EOS_SANDBOX_ID` `EOS_DEPLOYMENT_ID` `EOS_SERVER_ID` `EOS_SERVER_SECRET` `EOS_CLIENT_ID` `EOS_CLIENT_SECRET`


<details>
<summary>Testing credentials:</summary>

```
-DEOS_PRODUCT_ID=8292bf817344454d9f93a2ff2a6e3413
-DEOS_SANDBOX_ID=2c9259344895457ea58a52e9c49ef139 
-DEOS_DEPLOYMENT_ID=e1888a7610dd438694f628f71b06df38
-DEOS_SERVER_ID=xyza7891V67HX6M0b2ylW6klSvwXiF2R
-DEOS_SERVER_ID=xyza7891V67HX6M0b2ylW6klSvwXiF2R
-DEOS_SERVER_SECRET=ezf98C1F8S4i6hW211Qw7IQZ0IIWtjuNUz/TYx/ypOw
-DEOS_CLIENT_ID=xyza7891tAZRyO1fXX4BrJdu6RJ3njh4
-DEOS_CLIENT_SECRET=dQIoeLtbCOWeuccJPVoouPnWXU/2fqpr1UFBN5iac8g
```
[Download eos_certs.zip](https://github.com/Soldat/soldat/files/7601255/eos_certs.zip)
</details>


4. Unzip SDK, unzip EOS_AntiCheatTools-%PLATFORM%-x64-1.2.0.zip in SDK/Tools
5. Build soldat using CMake with 
 `-DBUILD_ANTICHEAT=1`
 `-DEOS_SDK_DIR=`_location of the SDK_
 `-DEOS_ANTICHEAT_TOOLS_DIR=`_location of EOS_AntiCheatTools_
 `-DEOS_CERTS=`_location of anticheat_integritytool certs_

6. (WINDOWS ONLY) install EOS with `EasyAntiCheat_EOS_Setup.exe install <Your ProductId>` or use generated `install_eac.bat` in `bin`
7. Start soldatserver with `bin/soldatserver -ac_loglevel 600`
8. Start soldat with `bin/start_protected_game -join 127.0.0.1 23073 -ac_loglevel 600`

TODO/bugs:
 - On my Arch linux setup, starting the game with `start_protected_game` results in `corrupted size vs. prev_size`. After some debugging (which is quite difficult with anti-cheat enabled) I found that linking to libharfbuzz causes the problem, oddly enough, it started working when I linked against a version compiled without `glib` :cursing_face:
 - Better identity provider for non-steam users is something that needs to implemented
 - Improve build system for EAC