### PR TITLE
Fix access violations on commands

### DIFF
--- a/client/ClientCommands.pas
+++ b/client/ClientCommands.pas
@@ -277,6 +277,11 @@ end;
 
 procedure CommandDemoTick(Args: array of AnsiString; Sender: Byte);
 begin
+  if Length(Args) <= 1 then
+  begin
+    MainConsole.Console('Usage: ' + Args[0] + ' "tick"', GAME_MESSAGE_COLOR);
+    Exit;
+  end;
   if Args[0] = 'demo_tick' then
     DemoPlayer.Position(StrToIntDef(Args[1], 0))
   else

--- a/client/ClientCommands.pas
+++ b/client/ClientCommands.pas
@@ -282,6 +282,11 @@ begin
     MainConsole.Console('Usage: ' + Args[0] + ' "tick"', GAME_MESSAGE_COLOR);
     Exit;
   end;
+  if not DemoPlayer.Active then
+  begin
+    MainConsole.Console('You are not playing a demo', WARNING_MESSAGE_COLOR);
+    Exit;
+  end;
   if Args[0] = 'demo_tick' then
     DemoPlayer.Position(StrToIntDef(Args[1], 0))
   else

--- a/client/ClientCommands.pas
+++ b/client/ClientCommands.pas
@@ -239,14 +239,14 @@ begin
   end;
   if not Sprite[MySprite].IsSpectator then
   begin
-    MainConsole.Console('You are not a spectator', WARNING_MESSAGE_COLOR);
+    MainConsole.Console('You are not a spectator', DEBUG_MESSAGE_COLOR);
     Exit;
   end;
   InputId := StrToIntDef(Args[1], -1);
   if (InputId < 0) or (InputId > MAX_SPRITES) then
   begin
     MainConsole.Console('Invalid id value. Must be in range [0, ' + IntToStr(MAX_SPRITES) + ']',
-    WARNING_MESSAGE_COLOR);
+    DEBUG_MESSAGE_COLOR);
     Exit;
   end;
   CameraFollowSprite := InputId;
@@ -284,7 +284,7 @@ begin
   end;
   if not DemoPlayer.Active then
   begin
-    MainConsole.Console('You are not playing a demo', WARNING_MESSAGE_COLOR);
+    MainConsole.Console('You are not playing a demo', DEBUG_MESSAGE_COLOR);
     Exit;
   end;
   if Args[0] = 'demo_tick' then

--- a/client/ClientCommands.pas
+++ b/client/ClientCommands.pas
@@ -229,14 +229,27 @@ begin
 end;
 
 procedure CommandSwitchCam(Args: array of AnsiString; Sender: Byte);
+var
+  InputId: LongInt;
 begin
   if Length(Args) <= 1 then
   begin
     MainConsole.Console('Usage: switchcam "id"', GAME_MESSAGE_COLOR);
     Exit;
   end;
-  if Sprite[MySprite].IsSpectator then
-    CameraFollowSprite := StrToIntDef(Args[1], 0);
+  if not Sprite[MySprite].IsSpectator then
+  begin
+    MainConsole.Console('You are not a spectator', WARNING_MESSAGE_COLOR);
+    Exit;
+  end;
+  InputId := StrToIntDef(Args[1], -1);
+  if (InputId < 0) or (InputId > MAX_SPRITES) then
+  begin
+    MainConsole.Console('Invalid id value. Must be in range [0, ' + IntToStr(MAX_SPRITES) + ']',
+    WARNING_MESSAGE_COLOR);
+    Exit;
+  end;
+  CameraFollowSprite := InputId;
 end;
 
 procedure CommandSwitchCamFlag(Args: array of AnsiString; Sender: Byte);

--- a/shared/Command.pas
+++ b/shared/Command.pas
@@ -86,13 +86,13 @@ begin
     Exit;
   end;
   AliasName := Args[1];
-  if (TCvarBase.Find(AliasName) <> nil) and (CommandFind(AliasName) <> nil) then
+  if (TCvarBase.Find(AliasName) <> nil) or (CommandFind(AliasName) <> nil) then
   begin
     MainConsole.Console('Cannot use this alias name because it''s already used', DEBUG_MESSAGE_COLOR);
     Exit;
   end;
   CommandAdd(AliasName, CommandExecuteAlias, Args[2], [CMD_ALIAS]);
-  MainConsole.Console('New alias: Args[1] with command: ' + Args[2], GAME_MESSAGE_COLOR);
+  MainConsole.Console('New alias: ' + Args[1] + ' with command ' + Args[2], GAME_MESSAGE_COLOR);
 end;
 
 procedure CommandExecuteAlias(Args: array of AnsiString; Sender: Byte);

--- a/shared/Command.pas
+++ b/shared/Command.pas
@@ -59,7 +59,7 @@ procedure CommandToggle(Args: array of AnsiString; Sender: Byte);
 var
   ACvar: TCvarBase;
 begin
-  if Length(Args) = 1 then
+  if Length(Args) < 4 then
   begin
     MainConsole.Console('Usage: toggle "cvarname" "value" "value2"', GAME_MESSAGE_COLOR);
     Exit;

--- a/shared/Command.pas
+++ b/shared/Command.pas
@@ -80,7 +80,7 @@ procedure CommandAlias(Args: array of AnsiString; Sender: Byte);
 var
   AliasName: AnsiString;
 begin
-  if Length(Args) = 1 then
+  if Length(Args) < 3 then
   begin
     MainConsole.Console('Usage: alias "name" "command"', GAME_MESSAGE_COLOR);
     Exit;


### PR DESCRIPTION
Set of fixes for access violations that occur when using commands in game. These access violations cause the game to close, and they affect both debug and release builds.

**How to test the changes?**
Start a local server, and join it with client. Then follow the list below.

**`/switchcam`**
It had problems when passing an id with values smaller than 0 and greater than 32. When in spectator team, try executing `/switchcam -1` or `/switchcam 100`. Make sure the game doesn't terminate, and verify that you receive some feedback when you provide wrong parameters to `/switchcam`, or when you call it while you're not a spectator.

**`/demo_tick` and `/demo_tick_r`**
These commands had 2 problems:
- Calling them without an argument caused access violation
- Calling them with a valid argument while we're in game and not viewing a demo caused access violation

Try executing `/demo_tick`, `/demo_tick_r`, `/demo_tick 5` and `/demo_tick_r 5` while you're inside the game. Verify that the game doesn't quit with access violation. Note that demo playback (`./soldat -join demo_name 0`) might have its own set of problems, and `/demo_tick` and `/demo_tick_r` might need additional validation, but that's outside the scope of this PR.

**`/toggle`**
It had problems when calling it without required parameters. It caused access violation when cvar's name was correct, but 2nd and 3rd arguments were missing. Try using `/toggle sv_pure` and `/toggle sv_pure 1` and make sure the game doesn't close.

**`/alias`**
It caused access violation when calling it with only 1 argument, and it had a bug when checking if alias' name is already used. Try using `/alias x`, `/alias snd_volume screenshot` and `/alias echo screenshot`. Make sure that game doesn't close, and verify that you receive correct feedback in console about alias name being already used (`snd_volume` is a valid cvar name, and `echo` is a valid command, so aliasing them should fail).