### PR TITLE
Fix range error when spectator presses right mouse button

### DIFF
--- a/client/ClientGame.pas
+++ b/client/ClientGame.pas
@@ -420,7 +420,8 @@ end;
 
 function GetCameraTarget(Backwards: Boolean = False): Byte;
 var
-  NewCam, NumLoops: Byte;
+  NewCam: ShortInt;
+  NumLoops: Byte;
   ValidCam: Boolean;
 begin
   ValidCam := False;


### PR DESCRIPTION
Steps to reproduce:
1. Start server
2. Join as spectator
3. Click right mouse button

Current result:
Client encounters a range error and terminates
Expected result:
Client doesn't terminate, we try to find a valid target player to follow with camera

This is caused by an attempt to decrease a Byte variable when its value is 0.
So, I've changed type to ShortInt. It looks like we never go beyond 32 (MAX_SPRITES) anyway, so we don't need full Byte range.

Tests:
I recommend testing with, as well as without bots in game. Try clicking both left and right mouse buttons to compare behavior.
1. Start server
2. Join as spectator
3. Click left and right mouse buttons, and try going into freecam (press W)
4. `/addbot1 Admiral` `/addbot1 Kruger` `/addbot1 Sniper`
5. Repeat step 3
6. Kick bots one by one while repeating step 3

Game shouldn't terminate, and behavior should be consistent on left and right mouse buttons.