### PR TITLE
Fix /mercy command

### DIFF
--- a/shared/mechanics/Control.pas
+++ b/shared/mechanics/Control.pas
@@ -1336,7 +1336,7 @@ begin
                 PlaySound(SFX_DEAD_HIT, SpriteParts.Pos[SpriteC.Num], Sprite[SpriteC.Num].GattlingSoundChannel);
 
               if SpriteC.Num = MySprite then
-                ClientSendStringMessage('/KILL', SpriteC.Num);
+                ClientSendStringMessage('kill', MSGTYPE_CMD);
               {$ENDIF}
               Inc(SpriteC.BodyAnimation.CurrFrame);
 


### PR DESCRIPTION
Steps to reproduce:
1. Start server
2. Join any team other than spectator
3. Type `/mercy` command

Current result:
Mercy animation is played, but command doesn't kill player. Instead, player automatically sends "/KILL" to chat.

Expected result:
Mercy animation is played, then we use `/kill` command correctly