### PR TITLE
Fix unresponsive client after a file download failure

### DIFF
--- a/client/FileClient.pas
+++ b/client/FileClient.pas
@@ -49,7 +49,7 @@ begin
   FFilename := AnsiReplaceStr(Name, '..', '');
   FChecksum := Checksum;
   OnTerminate := DoOnTerminate;
-  FreeOnTerminate := False;
+  FreeOnTerminate := True;
 end;
 
 procedure TDownloadThread.CancelDownload;
@@ -136,7 +136,6 @@ begin
   if DownloadRetry = 1 then
     if FStatus = 1 then
       JoinServer;
-  FreeAndNil(DownloadThread);
 end;
 {$pop}
 


### PR DESCRIPTION
I noticed that client stops responding if it can't download a map from server.

Steps to reproduce:
1. Build client and server in separate folders (Lazarus or Makefile recommended)
2. In server's `configs/server.cfg` add `sv_downloadurl "http://thisdomainnamedoesnotexist.xyz/"` as new line. This will trigger an error when client's download thread will try to connect
3. Rename attached [test.zip](https://github.com/Soldat/soldat/files/8420216/test.zip) file to `test.smap`, and add it to server's `maps` folder. This is just Arena2 under a different name
4. Add `test` as first map in server's `configs/mapslist.txt`
5. Start server
6. Join game with client

Current result:
Client can't download file, which makes client stop responding. Soldat doesn't respond to any user input, and must be killed manually. Depending on your system, a message box created with SDL could have appeared, telling you about failed download.

Expected result:
Client doesn't stop responding, despite a failed download. Player should be able to press escape key to quit game, as displayed on screen (grey background with white text)

According to my debugging, this was caused by `FreeAndNil(DownloadThread)`. Execution seemed to never return to main thread after an exception in DownloadThread