### PR TITLE
Destroy DownloadThread after successful downloads

### DIFF
--- a/client/FileClient.pas
+++ b/client/FileClient.pas
@@ -21,16 +21,16 @@ type
       FDownloadPos: Int64;
       FDownloadSize: Int64;
       Client: TFPHTTPClient;
-    protected
-      procedure Execute; override;
+
       procedure SetStatus;
       procedure SetError;
-
-    public
-      constructor Create(DownloadURL: String; Name: String; CheckSum: TSHA1Digest);
       procedure DoProgress(Sender: TObject; Const ContentLength, CurrentPos : Int64);
       procedure OnFinished;
       procedure DummySync;
+    protected
+      procedure Execute; override;
+    public
+      constructor Create(DownloadURL: String; Name: String; CheckSum: TSHA1Digest);
       procedure CancelDownload;
       destructor Destroy; override;
   end;


### PR DESCRIPTION
When debugging, I noticed that `TDownloadThread` instances were not destroyed properly, and they kept running until the game terminated. This was caused by the fact that `JoinServer` was called with `Synchronize`, but `JoinServer` has an infinite loop, which prevented the download thread from terminating cleanly.

Fixes were inspired by [this question](https://stackoverflow.com/questions/42280937/delphi-queue-and-synchronize), and implementation of `DummySync` was stolen from [here](https://stackoverflow.com/a/40034987/1037511).

To test these changes, I recommend setting a breakpoint in `TDownloadThread.Destroy` to make sure the destructor gets called after downloading a file. If you're using Lazarus, go to `View > Debug Windows > Threads`. Make sure that the count of threads doesn't keep increasing on successful file downloads.
Step by step:
1. Make builds of server and client in separate folders
2. Add [test.zip](https://github.com/Soldat/soldat/files/8457344/test.zip) and [2nd_test.zip](https://github.com/Soldat/soldat/files/8457346/2nd_test.zip) to server's `maps` folder. Make sure you rename `*.zip` to `*.smap`
3. Edit server's `configs/mapslist.txt` file by adding `test` and `2nd_test` as first 2 maps
4. Run the client with a debugger, and make sure DownloadThread is destroyed after downloading files, as described above

 I haven't tested this on Windows, maybe it's worth checking how it behaves there.