### PR TITLE
Fix access violations when pressing escape

### DIFF
--- a/client/ControlGame.pas
+++ b/client/ControlGame.pas
@@ -306,7 +306,7 @@ begin
   if KeyMods = KM_NONE then case KeyCode of
     SDL_SCANCODE_ESCAPE: begin
       if not ShouldRenderFrames then
-        ShutDown;
+        GameLoopRun := False;
     end;
     SDL_SCANCODE_PAGEDOWN: begin
       if FragsMenuShow then

--- a/client/Gfx.pas
+++ b/client/Gfx.pas
@@ -1604,7 +1604,8 @@ end;
 procedure RemoveNode(f: PFont; i: Integer);
 begin
   Dec(f.NodesSize);
-  Move(f.Nodes[i + 1], f.Nodes[i], (f.NodesSize - i) * sizeof(TFontNode));
+  if i < f.NodesSize then
+    Move(f.Nodes[i + 1], f.Nodes[i], (f.NodesSize - i) * sizeof(TFontNode));
 end;
 
 function RegionFits(f: PFont; i, w, h: Integer; var y: Integer): Boolean;


### PR DESCRIPTION
This PR fixes 2 bugs, both occurring when pressing escape in client.

### Bug 1
A range error occurs when pressing escape after a successful map download.
**Steps to reproduce**:
1. Build client and server in different folders
2. Add [test.smap.zip](https://github.com/Soldat/soldat/files/8458947/test.smap.zip) file to server's `maps` folder and rename it to `test.smap`
3. Edit server's `configs/mapslist.txt` by setting "test" as first map
4. Start server
5. Join game with client - `test.smap` should be downloaded
6. Join any team. For some reason, this bug doesn't occur if you press escape without joining a team
7. Press escape

**Current result**:
Client raises a range error exception and terminates
**Expected result**:
Client doesn't quit, we display the classic escape menu with 4 options

The range error occurs when we try to render 'Default keys (shown for first 3 game runs)' text, so when testing verify that it is displayed correctly in escape menu.
I didn't try to find out what's the underlying problem behind this bug. I mean, escape menu displays correctly if client doesn't have to download the map, so why does it break when we do download it?

### Bug 2
An access violation occurs when quitting the game after pressing escape in menu with grey background and white text. Many steps to reproduce this are possible.
**Steps to reproduce**:
1. Start client by joining a server that doesn't exist - `./soldat -join 127.0.0.1 24074`
2. Press escape when game is displaying a grey background with white text telling you that you can press escape to quit

**Current result**:
Client encounters an access violation when quitting
**Expected result**:
Client quits cleanly

This was caused by calling `ShutDown` twice - once when handling key presses, and once in `finalization` block of Client unit.