### PR TITLE
Fix empty next map when using /restart on first map

### DIFF
--- a/server/ServerCommands.pas
+++ b/server/ServerCommands.pas
@@ -101,12 +101,7 @@ end;
 
 procedure CommandRestart(Args: array of AnsiString; Sender: Byte);
 begin
-  MapChangeName := Map.Name;
-  MapChangeCounter := MapChangeTime;
-  ServerMapChange(ALL_PLAYERS);  // Inform clients of Map Change
-  {$IFDEF SCRIPT}
-  ScrptDispatcher.OnBeforeMapChange(MapChangeName);
-  {$ENDIF}
+  PrepareMapChange(Map.Name);
 end;
 
 procedure CommandKick(Args: array of AnsiString; Sender: Byte);


### PR DESCRIPTION
Steps to reproduce:
1. Start server
2. Join server as admin
3. Use `/restart` command. It must be executed on first map for the bug to occur

Current result:
Next map is empty, we try to change map to empty string
Expected result:
`/restart` restarts current map

This was caused by setting [MapChangeName](https://github.com/Soldat/soldat/blob/6e01147ddf9504bbbd53b73cea0bb6bf596cdae8/server/ServerCommands.pas#L104) variable, and then reading next map from [MapChange.Name](https://github.com/Soldat/soldat/blob/c304c3912ca7a88461970a859049d217a44c6375/shared/network/NetworkServerGame.pas#L124). I tried changing `MapChangeName := Map.Name` to `MapChange.Name := Map.Name`, but this led to another problem: clients rejoined server after `/restart`, and we don't want that. Then I noticed that we have a function for this exact purpose.

Test cases:
1. Try `/restart` command on first map, as well as following maps. In other words, after joining the server run `/restart`, `/nextmap`, `/restart` and make sure they behave reasonably
2. Try `/restart` after manually changing map with `/map ctf_Laos`
3. Verify that both client and server print a string about next map to their consoles
4. Make sure client doesn't disconnect and reconnect to server after a `/restart`