### PR TITLE
Hide net debug messages when log_level < 1

### DIFF
--- a/shared/network/Net.pas
+++ b/shared/network/Net.pas
@@ -1050,8 +1050,9 @@ begin
     WriteLn('[NET] Invalid connection handle');
     Exit;
   end;
-  Debug('[NET] Received SteamNetConnectionStatusChangedCallback_t ' +
-    ToStr(pInfo^, TypeInfo(SteamNetConnectionStatusChangedCallback_t)));
+  {$IFDEF DEVELOPMENT}
+  Debug('[NET] Received SteamNetConnectionStatusChangedCallback_t ' + ToStr(pInfo^, TypeInfo(SteamNetConnectionStatusChangedCallback_t)));
+  {$ENDIF}
   // Make sure it's for us
   if pInfo.m_hConn = FPeer then
   begin
@@ -1345,8 +1346,9 @@ var
   TempIP: TIPString;
 begin
   TempIP := Default(TIPString);
-  Debug('[NET] Received SteamNetConnectionStatusChangedCallback_t ' +
-    ToStr(pInfo^, TypeInfo(SteamNetConnectionStatusChangedCallback_t)));
+  {$IFDEF DEVELOPMENT}
+  Debug('[NET] Received SteamNetConnectionStatusChangedCallback_t ' + ToStr(pInfo^, TypeInfo(SteamNetConnectionStatusChangedCallback_t)));
+  {$ENDIF}
   case pInfo.m_info.m_eState of
     k_ESteamNetworkingConnectionState_None:
     begin

--- a/shared/network/Net.pas
+++ b/shared/network/Net.pas
@@ -887,7 +887,7 @@ end;
 {$WARN 5024 OFF : Parameter "$1" not used}
 procedure DebugNet(nType: ESteamNetworkingSocketsDebugOutputType; pszMsg: PChar); cdecl;
 begin
-  WriteLn('[NET DEBUG] ' + pszMsg);
+  Debug('[NET DEBUG] ' + pszMsg);
 end;
 {$POP}
 
@@ -1050,9 +1050,8 @@ begin
     WriteLn('[NET] Invalid connection handle');
     Exit;
   end;
-  {$IFDEF DEVELOPMENT}
-  WriteLn('[NET] Received SteamNetConnectionStatusChangedCallback_t ', ToStr(pInfo^, TypeInfo(SteamNetConnectionStatusChangedCallback_t)));
-  {$ENDIF}
+  Debug('[NET] Received SteamNetConnectionStatusChangedCallback_t ' +
+    ToStr(pInfo^, TypeInfo(SteamNetConnectionStatusChangedCallback_t)));
   // Make sure it's for us
   if pInfo.m_hConn = FPeer then
   begin
@@ -1075,7 +1074,7 @@ begin
       end;
       k_ESteamNetworkingConnectionState_Connecting:
       begin
-        WriteLn('[NET] Connection request from: ' + PChar(pInfo.m_info.m_szConnectionDescription));
+        WriteLn('[NET] Connecting to: ' + PChar(pInfo.m_info.m_szConnectionDescription));
       end;
       k_ESteamNetworkingConnectionState_Connected:
       begin
@@ -1346,9 +1345,8 @@ var
   TempIP: TIPString;
 begin
   TempIP := Default(TIPString);
-  {$IFDEF DEVELOPMENT}
-  WriteLn('[NET] Received SteamNetConnectionStatusChangedCallback_t ', ToStr(pInfo^, TypeInfo(SteamNetConnectionStatusChangedCallback_t)));
-  {$ENDIF}
+  Debug('[NET] Received SteamNetConnectionStatusChangedCallback_t ' +
+    ToStr(pInfo^, TypeInfo(SteamNetConnectionStatusChangedCallback_t)));
   case pInfo.m_info.m_eState of
     k_ESteamNetworkingConnectionState_None:
     begin


### PR DESCRIPTION
Client and server used to print some messages, that in my opinion belong to debug log level. Networking logs may need some more fixes in the future (inconsistencies across `TClientNetwork` and `TServerNetwork`, [NET] vs [Net] vs [NET DEBUG], printing some messages twice with `WriteLn` and `Debug` (for example "Connecting to")), but I don't think it's high priority right now. I was mostly concerned about spam that made it harder to follow logs in console.

There's also a small fix for client-only log when connecting to server.

To test, try running both client and server and observe the logs. There shouldn't be any debug messages about networking. Then compare the output when setting `log_level` cvar to 1 (`./soldat -log_level 1`)