### PR TITLE
Bugfixes

### DIFF
--- a/3rdparty/pascalscript/Source/uPSCompiler.pas
+++ b/3rdparty/pascalscript/Source/uPSCompiler.pas
@@ -13080,7 +13080,10 @@ end;
 {$IFNDEF PS_NOINTERFACES}
 const
   IUnknown_Guid: TGuid = (D1: 0; d2: 0; d3: 0; d4: ($c0,00,00,00,00,00,00,$46));
+  // @SoldatPatch
+  {$IFNDEF PS_NOIDISPATCH}
   IDispatch_Guid: Tguid = (D1: $20400; D2: $0; D3: $0; D4:($C0, $0, $0, $0, $0, $0, $0, $46));
+  {$ENDIF}
 {$ENDIF}
 
 procedure TPSPascalCompiler.DefineStandardProcedures;

--- a/3rdparty/pascalscript/Source/uPSR_dll.pas
+++ b/3rdparty/pascalscript/Source/uPSR_dll.pas
@@ -77,13 +77,24 @@ begin
   Dispose(p);
 end;
 
+// @SoldatPatch
+{$IFDEF UNIX}
+{$DEFINE UNIX_OR_KYLIX}
+{$ENDIF}
+{$IFDEF KYLIX}
+{$DEFINE UNIX_OR_KYLIX}
+{$ENDIF}
+
 function LoadDll(Caller: TPSExec; P: TPSExternalProcRec; var ErrorCode: LongInt): Boolean;
 var
   s, s2, s3: tbtstring;
   h, i: Longint;
   ph: PLoadedDll;
   dllhandle: THandle;
+  // @SoldatPatch
+  {$IFNDEF UNIX_OR_KYLIX}
   loadwithalteredsearchpath: Boolean;
+  {$ENDIF}
   {$IFNDEF UNIX}
   Filename: String;
   {$ENDIF}
@@ -95,7 +106,10 @@ begin
   h := makehash(s2);
   s3 := copy(s, 1, pos(tbtchar(#0), s)-1);
   delete(s, 1, length(s3)+1);
+  // @SoldatPatch
+  {$IFNDEF UNIX_OR_KYLIX}
   loadwithalteredsearchpath := bytebool(s[3]);
+  {$ENDIF}
   i := 2147483647; // maxint
   dllhandle := 0;
   repeat
@@ -116,12 +130,7 @@ begin
         exit;
       end;
 
-      {$IFDEF UNIX}
-      {$DEFINE UNIX_OR_KYLIX}
-      {$ENDIF}
-      {$IFDEF KYLIX}
-      {$DEFINE UNIX_OR_KYLIX}
-      {$ENDIF}
+      // @SoldatPatch
 
       {$IFDEF UNIX_OR_KYLIX}
       dllhandle := LoadLibrary(PChar(s2));

--- a/client/ClientGame.pas
+++ b/client/ClientGame.pas
@@ -489,7 +489,7 @@ procedure GetMicData;
 var
   AvailableVoice: EVoiceResult;
   AvailableVoiceBytes: Cardinal;
-  VoiceData: array of Byte;
+  VoiceData: array of Byte = Nil;
 begin
   AvailableVoice := SteamAPI.User.GetAvailableVoice(@AvailableVoiceBytes, nil, 0);
 

--- a/client/ControlGame.pas
+++ b/client/ControlGame.pas
@@ -402,7 +402,7 @@ begin
               choose(StrToInt(RMenuState[1]) - 1, ['U', 'M', 'D'])
             ]);
 
-          ChatText := '*' + RMenuState[0] + RMenuState[1] + ChatText;
+          ChatText := '*' + UnicodeString(RMenuState[0]) + UnicodeString(RMenuState[1]) + ChatText;
           ClientSendStringMessage(ChatText, MSGTYPE_RADIO);
           ChatText := '';
           // RadioCooldown := 3;

--- a/client/Sound.pas
+++ b/client/Sound.pas
@@ -556,7 +556,7 @@ var
   State: Integer = 0;
   Chan: Integer;
   i: Byte;
-  BuffersProcessed: LongInt;
+  BuffersProcessed: LongInt = 0;
   VoiceBuffer: ALuint;
   BufferHolder: array[0..64] of ALuint;
 begin

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -831,6 +831,9 @@ begin
   GameNetworkingSockets_Kill();
   {$ENDIF}
 
+  AddLineToLogFile(GameLog, 'PhysFS closing.', ConsoleLogFileName);
+  PhysFS_deinit();
+
   try
     AddLineToLogFile(GameLog, '   End of Log.', ConsoleLogFileName);
     Debug('Updating gamestats');

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -376,7 +376,7 @@ end;
 
 procedure GetCollectionDetails(Callback: PSteamUGCQueryCompleted_t);
 var
-  CollectionItems: array of PublishedFileId_t;
+  CollectionItems: array of PublishedFileId_t = Nil;
   CollectionDetails: SteamUGCDetails_t;
   ItemState: uint32;
   i, j: Integer;
@@ -431,7 +431,6 @@ end;
 function GetWorkshopItemDir(ItemID: PublishedFileId_t): AnsiString;
 var
   FileSizeOnDisk: uint64 = 0;
-  DirSizeOnDisk: uint32 = 0;
   Path: array[0..PATH_MAX] of Char;
   TimeStamp: Cardinal = 0;
 begin
@@ -515,7 +514,6 @@ end;
 procedure ActivateServer;
 var
   i, j: Integer;
-  s: String;
 begin
   MainThreadID := GetThreadID;
 

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -615,7 +615,6 @@ begin
 
   // Create the basic folder structure
   CreateDirIfMissing(UserDirectory + '/configs');
-  CreateDirIfMissing(UserDirectory + '/configs/bots');
   CreateDirIfMissing(UserDirectory + '/demos');
   CreateDirIfMissing(UserDirectory + '/logs');
   CreateDirIfMissing(UserDirectory + '/logs/kills');
@@ -635,8 +634,16 @@ begin
   PHYSFS_CopyFileFromArchive('scripts/README.txt', UserDirectory + '/scripts/README.txt');
   {$ENDIF}
 
-  for s in PHYSFS_GetEnumeratedFiles('configs/bots') do
-    PHYSFS_CopyFileFromArchive('configs/bots/' + s, UserDirectory + '/configs/bots/' + s);
+  // Copy default bots if configs/bots directory is missing.
+  // We don't want to copy default bots on every launch; this allows
+  // server owners to delete some bots without the risk of having them
+  // recreated on next launch.
+  if not DirectoryExists(UserDirectory + '/configs/bots') then
+    if not CreateDir(UserDirectory + '/configs/bots') then
+      WriteLn('Could not create bots directory.')
+    else
+      if not PHYSFS_CopyFilesFromArchiveDirectory('configs/bots', UserDirectory + '/configs/bots') then
+        WriteLn('Could not copy bots from mod archive.');
 
   LoadConfig('server.cfg');
 

--- a/server/ServerCommands.pas
+++ b/server/ServerCommands.pas
@@ -8,7 +8,7 @@ implementation
 
 uses
   // system and delphi units
-  SysUtils, Classes, strutils, dateutils,
+  SysUtils, Classes, dateutils,
 
   // helper units
   Vector, Util, Version,

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -19,20 +19,21 @@ const
 
 type
   {
-    CVAR_IMMUTABLE - can't be changed after set
-    CVAR_ARCHIVE   - save cvar to cfg file
-    CVAR_SPONLY    - only in singleplayer mode
-    CVAR_NOTIFY    - notify players after change
-    CVAR_MODIFIED  - this flag is set after cvar changed initial value
-    CVAR_CLIENT    - client cvar
-    CVAR_SERVER    - server cvar
-    CVAR_SYNC      - sync cvar to client cvar
-    CVAR_SCRIPT    - cvar set by script
-    CVAR_INITONLY  - cvar can be changed only at startup
+    CVAR_IMMUTABLE       - can't be changed after set
+    CVAR_ARCHIVE         - save cvar to cfg file
+    CVAR_SPONLY          - only in singleplayer mode
+    CVAR_NOTIFY          - notify players after change
+    CVAR_MODIFIED        - this flag is set after cvar changed initial value
+    CVAR_CLIENT          - client cvar
+    CVAR_SERVER          - server cvar
+    CVAR_SYNC            - sync cvar to client cvar
+    CVAR_SCRIPT          - cvar set by script
+    CVAR_INITONLY        - cvar can be changed only at startup
+    CVAR_SERVER_INITONLY - cvar can be changed only at startup by the server
   }
   TCvarFlag = (CVAR_IMMUTABLE, CVAR_ARCHIVE, CVAR_SPONLY, CVAR_NOTIFY,
       CVAR_MODIFIED, CVAR_CLIENT, CVAR_SERVER, CVAR_SYNC, CVAR_SCRIPT,
-      CVAR_INITONLY, CVAR_TOSYNC);
+      CVAR_INITONLY, CVAR_SERVER_INITONLY, CVAR_TOSYNC);
   TCvarFlags = set of TCvarFlag;
 
   TCvarBase = class
@@ -364,6 +365,15 @@ begin
     FErrorMessage := 'Can be set only at startup';
     Exit;
   end;
+
+  {$IFDEF SERVER}
+  if (CVAR_SERVER_INITONLY in FFlags) and CvarsInitialized then
+  begin
+    Result := False;
+    FErrorMessage := 'Can be set only by server at startup';
+    Exit;
+  end;
+  {$ENDIF}
 
   if (Value >= FMinValue) and (Value <= FMaxValue) then
   begin
@@ -963,7 +973,7 @@ begin
 
   // Sync vars (todo);
 
-  sv_gamemode := TIntegerCvar.Add('sv_gamemode', 'Sets the gamemode', 3, 3, [CVAR_SERVER, CVAR_SYNC,CVAR_INITONLY], nil, 0, 6); // Restart server
+  sv_gamemode := TIntegerCvar.Add('sv_gamemode', 'Sets the gamemode', 3, 3, [CVAR_SERVER, CVAR_SYNC,CVAR_SERVER_INITONLY], nil, 0, 6); // Restart server
   sv_friendlyfire := TBooleanCvar.Add('sv_friendlyfire', 'Enables friendly fire', False, False, [CVAR_SERVER, CVAR_SYNC], nil);
   sv_timelimit := TIntegerCvar.Add('sv_timelimit', 'Time limit of map', 36000, 36000, [CVAR_SERVER, CVAR_SYNC], nil, 0, MaxInt);
   sv_maxgrenades := TIntegerCvar.Add('sv_maxgrenades', 'Sets the max number of grenades a player can carry', 2, 5, [CVAR_SERVER, CVAR_SYNC], nil, 0, 1);
@@ -972,11 +982,11 @@ begin
   sv_balanceteams := TBooleanCvar.Add('sv_balanceteams', 'Enables/disables team balancing', False, False, [CVAR_SERVER, CVAR_SYNC], nil);
   sv_guns_collide := TBooleanCvar.Add('sv_guns_collide', 'Enables colliding guns', False, False, [CVAR_SERVER, CVAR_SYNC], nil);
   sv_kits_collide := TBooleanCvar.Add('sv_kits_collide', 'Enables colliding kits', False, False, [CVAR_SERVER, CVAR_SYNC], nil);
-  sv_survivalmode := TBooleanCvar.Add('sv_survivalmode', 'Enables survival mode', False, False, [CVAR_SERVER, CVAR_SYNC,CVAR_INITONLY], nil); // Restart server
+  sv_survivalmode := TBooleanCvar.Add('sv_survivalmode', 'Enables survival mode', False, False, [CVAR_SERVER, CVAR_SYNC,CVAR_SERVER_INITONLY], nil); // Restart server
   sv_survivalmode_antispy := TBooleanCvar.Add('sv_survivalmode_antispy', 'Enables anti spy chat in survival mode', False, False, [CVAR_SERVER, CVAR_SYNC], nil);
   sv_survivalmode_clearweapons := TBooleanCvar.Add('sv_survivalmode_clearweapons', 'Cluster Grenades bonus availability', False, False, [CVAR_SERVER, CVAR_SYNC], nil);
-  sv_realisticmode := TBooleanCvar.Add('sv_realisticmode', 'Enables realistic mode', False, False, [CVAR_SERVER, CVAR_SYNC,CVAR_INITONLY], nil); // Restart server
-  sv_advancemode := TBooleanCvar.Add('sv_advancemode', 'Enables advance mode', False, False, [CVAR_SERVER, CVAR_SYNC,CVAR_INITONLY], nil); // Restart server
+  sv_realisticmode := TBooleanCvar.Add('sv_realisticmode', 'Enables realistic mode', False, False, [CVAR_SERVER, CVAR_SYNC,CVAR_SERVER_INITONLY], nil); // Restart server
+  sv_advancemode := TBooleanCvar.Add('sv_advancemode', 'Enables advance mode', False, False, [CVAR_SERVER, CVAR_SYNC,CVAR_SERVER_INITONLY], nil); // Restart server
   sv_advancemode_amount := TIntegerCvar.Add('sv_advancemode_amount', 'Number of kills required in Advance Mode to gain a weapon.', 2, 2, [CVAR_SERVER, CVAR_SYNC], nil, 1, 9999);
   sv_minimap := TBooleanCvar.Add('sv_minimap', 'Enables/disables minimap', False, False, [CVAR_SERVER, CVAR_SYNC], nil);
   sv_advancedspectator := TBooleanCvar.Add('sv_advancedspectator', 'Enables/disables advanced spectator mode', True, True, [CVAR_SERVER, CVAR_SYNC], nil);

--- a/shared/libs/PhysFS/PhysFS.pas
+++ b/shared/libs/PhysFS/PhysFS.pas
@@ -14,7 +14,7 @@ type PHYSFS_Buffer = array of byte;
 
 function PHYSFS_init(argv0: Pchar): LongBool; cdecl; external PHYSFSLIB;
 function PHYSFS_deinit(): LongInt; cdecl; external PHYSFSLIB;
-function PHYSFS_mount(newDir, mountPoint: PChar; appendToPath: LongBool) : LongBool; cdecl; external PHYSFSLIB;
+function PHYSFS_mount(newDir, mountPoint: PChar; appendToPath: LongBool): LongBool; cdecl; external PHYSFSLIB;
 function PHYSFS_openRead(filename: PChar): PHYSFS_File; cdecl; external PHYSFSLIB;
 function PHYSFS_exists(filename: PChar): LongBool; cdecl; external PHYSFSLIB;
 function PHYSFS_eof(pfile: PHYSFS_File): LongBool; cdecl; external PHYSFSLIB;
@@ -23,13 +23,14 @@ function PHYSFS_close(pfile: PHYSFS_File): Int64; cdecl; external PHYSFSLIB;
 function PHYSFS_getLastError(): PChar; cdecl; external PHYSFSLIB;
 function PHYSFS_fileLength(pfile: PHYSFS_File): Int64; cdecl; external PHYSFSLIB;
 function PHYSFS_removeFromSearchPath(oldDir: PChar): LongBool; cdecl; external PHYSFSLIB;
-procedure PHYSFS_freeList(listVar: Pointer); cdecl; external PHYSFSLIB;
+procedure PHYSFS_freeList(listVar: PPChar); cdecl; external PHYSFSLIB;
 function PHYSFS_enumerateFiles(const dir: PChar): PPChar; cdecl; external PHYSFSLIB;
 
 function PHYSFS_readBuffer(Name: PChar): PHYSFS_Buffer;
 function PHYSFS_readAsStream(Name: PChar): TStream;
 procedure PHYSFS_ReadLn(FileHandle: PHYSFS_File; var Line: AnsiString);
 function PHYSFS_CopyFileFromArchive(SourceFile: AnsiString; Destination: AnsiString): Boolean;
+function PHYSFS_CopyFilesFromArchiveDirectory(SourceDirectory: AnsiString; DestinationDirectory: AnsiString): Boolean;
 function PHYSFS_GetEnumeratedFiles(Dir: String): TStringArray;
 
 implementation
@@ -118,6 +119,30 @@ begin
   end;
 
   ArchiveFile.Free;
+end;
+
+function PHYSFS_CopyFilesFromArchiveDirectory(SourceDirectory: AnsiString; DestinationDirectory: AnsiString): Boolean;
+var
+  FileNames: PPChar;
+  i: Integer;
+begin
+  Result := False;
+  FileNames := PHYSFS_enumerateFiles(PChar(SourceDirectory));
+  if FileNames = nil then
+    Exit;
+
+  Result := True;
+  i := 0;
+  while FileNames[i] <> nil do
+  begin
+    if not PHYSFS_CopyFileFromArchive(SourceDirectory + '/' + FileNames[i],
+       DestinationDirectory + '/' + FileNames[i]) then
+      Result := False;
+
+    i += 1;
+  end;
+
+  PHYSFS_freeList(FileNames);
 end;
 
 function PHYSFS_GetEnumeratedFiles(Dir: String): TStringArray;

--- a/shared/network/NetworkClientConnection.pas
+++ b/shared/network/NetworkClientConnection.pas
@@ -484,7 +484,7 @@ begin
       RenderGameInfo(_('Wrong server password'));
 
     BANNED_IP:
-      RenderGameInfo(_('You have been banned on this server. Reason:') + ' ' + Text);
+      RenderGameInfo(_('You have been banned on this server. Reason:') + ' ' + UnicodeString(Text));
 
     SERVER_FULL:
       RenderGameInfo(_('Server is full'));
@@ -499,7 +499,7 @@ begin
       RenderGameInfo(_('This server accepts only Steam players.'));
 
     ANTICHEAT_REJECTED:
-      RenderGameInfo(_('Rejected by Anti-Cheat:') + ' ' + Text);
+      RenderGameInfo(_('Rejected by Anti-Cheat:') + ' ' + UnicodeString(Text));
   end;
 
   ReceivedUnAccepted := True;

--- a/shared/network/NetworkClientGame.pas
+++ b/shared/network/NetworkClientGame.pas
@@ -484,7 +484,7 @@ procedure ClientSendVoiceData(Data: Pointer; DataSize: Word);
 var
   VoiceMsg: PMsg_VoiceData;
   Size: Integer;
-  SendBuffer: array of Byte;
+  SendBuffer: array of Byte = Nil;
 begin
   Size := SizeOf(TMsg_VoiceData) + DataSize;
   SetLength(SendBuffer, Size);
@@ -504,7 +504,7 @@ var
   VoiceMsg: PMsg_VoiceData;
   TextLen: Word;
   VoiceResult: EVoiceResult;
-  AudioData: array of Byte;
+  AudioData: array of Byte = Nil;
   AudioLength: Cardinal;
 begin
   if not cl_voicechat.Value then

--- a/shared/network/NetworkClientMessages.pas
+++ b/shared/network/NetworkClientMessages.pas
@@ -115,7 +115,7 @@ begin
   end;
 
   if (MsgType = MSGTYPE_RADIO) and Sprite[i].IsInSameTeam(Sprite[MySprite]) then
-    PlayRadioSound(StrToIntDef(RadioCommand, -1));
+    PlayRadioSound(StrToIntDef(AnsiString(RadioCommand), -1));
 end;
 
 procedure ClientHandleSpecialMessage(NetMessage: PSteamNetworkingMessage_t);


### PR DESCRIPTION
- Only unpack bots if the `configs/bots` directory doesn't exist. This allows server owners to delete bots without them being added back by the server (credit @rzaba0).
- Add concept of `CVAR_SERVER_INITONLY` for server sync cvars, which need to be set on client, but require server restart for changes to take effect. This is required for `sv_gamemode`, `sv_survivalmode`, `sv_advancemode`, `sv_realisticmode`. TODO: See if these can be set on a per-round basis. Then `CVAR_SERVER_INITONLY` can be removed.
- Clean up warnings.
- Properly call `PhysFS_deinit()` in server.