### PR TITLE
Launcher CI Prep

### DIFF
--- a/.github/workflows/copy-libs.sh
+++ b/.github/workflows/copy-libs.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# Script to copy all necessary libraries for OpenSoldat client and server.
+# Possibly `LD_LIBRARY_PATH`, pass the directory where the binaries are located,
+# and the destination for the libraries.
+
+set -eux
+
+die() {
+    echo "$@"
+    exit 1
+}
+
+if [ $# -ne 2 ]; then
+  die "$0 <binary_path> <library_output_path>"
+fi
+
+binary_path="$(readlink -f "$1")"
+library_output_path="$(readlink -f "$2")"
+
+# Download list of libraries that shouldn't be embedded in the package
+lib_blacklist="$(curl https://raw.githubusercontent.com/AppImage/pkg2appimage/master/excludelist \
+  | sed "s|#.*||" \
+  | sed "s|\+|\\\+|g" \
+  | grep -E -v '^$' \
+  | tr '\n' '|')"
+lib_blacklist="${lib_blacklist%?}"
+
+find "$binary_path" -type f \( -executable -or -name "*.so*" \) -exec ldd {} + \
+  | grep "=> /" | awk '{print $3}' \
+  | grep -v "$binary_path" \
+  | grep -E -v "($lib_blacklist)" \
+  | sort -u \
+  | xargs install -Dm 644 -t "$library_output_path"

--- a/.github/workflows/copy-libs.sh
+++ b/.github/workflows/copy-libs.sh
@@ -28,7 +28,7 @@ lib_blacklist="${lib_blacklist%?}"
 
 find "$binary_path" -type f \( -executable -or -name "*.so*" \) -exec ldd {} + \
   | grep "=> /" | awk '{print $3}' \
-  | grep -v "$binary_path" \
+  | grep -v "$(git rev-parse --show-toplevel)" \
   | grep -E -v "($lib_blacklist)" \
   | sort -u \
   | xargs install -Dm 644 -t "$library_output_path"

--- a/.github/workflows/opensoldat.yml
+++ b/.github/workflows/opensoldat.yml
@@ -26,10 +26,6 @@ jobs:
           make install
           cd opensoldat
           ../../.github/workflows/copy-libs.sh . .
-          # Some libraries with absolute paths in .ELF DT_RUNPATH need to be patched unfortunately...
-          if ls libpulse\.* 2>&1 1>/dev/null; then
-            patchelf --remove-rpath libpulse\.*
-          fi
           cd ..
 
           cmake .. -DBUILD_CLIENT=0 \

--- a/.github/workflows/opensoldat.yml
+++ b/.github/workflows/opensoldat.yml
@@ -1,7 +1,7 @@
 on: [push, pull_request, workflow_dispatch]
 name: opensoldat
 jobs:
-  linux-build-smoke:
+  linux:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -17,53 +17,36 @@ jobs:
           export BUILD_ID=${GITHUB_SHA::8}
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=./opensoldat -DCMAKE_BUILD_TYPE=Release
+          cmake .. -DCMAKE_INSTALL_PREFIX=./opensoldat \
+                   -DCMAKE_BUILD_TYPE=Release \
+                   -DCMAKE_INSTALL_LIBDIR="." \
+                   -DCMAKE_INSTALL_BINDIR="." \
+                   -DCMAKE_INSTALL_DATADIR="."
           make
           make install
-          cmake .. -DBUILD_CLIENT=0 -DCMAKE_INSTALL_PREFIX=./opensoldatserver -DCMAKE_BUILD_TYPE=Release
+          cd opensoldat
+          ../../.github/workflows/copy-libs.sh . .
+          cd ..
+
+          cmake .. -DBUILD_CLIENT=0 \
+                   -DCMAKE_INSTALL_PREFIX=./opensoldatserver \
+                   -DCMAKE_BUILD_TYPE=Release \
+                   -DCMAKE_INSTALL_LIBDIR="." \
+                   -DCMAKE_INSTALL_BINDIR="." \
+                   -DCMAKE_INSTALL_DATADIR="."
           make install
+          cd opensoldatserver
+          ../../.github/workflows/copy-libs.sh . .
 
-  appimage:
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/upload-artifact@v2
         with:
-          fetch-depth: 0 # Otherwise `git describe --tags` doesn't work
+          name: linux-build
+          path: build/opensoldat/
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install cmake git fpc libprotobuf-dev protobuf-compiler libssl-dev libsdl2-dev libopenal-dev libphysfs-dev libfreetype6
-
-      - name: Compile opensoldat
-        run: |
-          export BUILD_ID=${GITHUB_SHA::8}
-          mkdir build
-          cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=./opensoldat/AppDir -DCMAKE_BUILD_TYPE=Release
-          make
-          make install
-          make clean
-          cmake .. -DBUILD_CLIENT=0 -DCMAKE_INSTALL_PREFIX=./opensoldatserver/AppDir -DCMAKE_BUILD_TYPE=Release
-          make install
-
-      - name: Build AppImages
-        run: |
-          ./.github/workflows/make-appimage.sh build/opensoldat client
-          ./.github/workflows/make-appimage.sh build/opensoldatserver server
-
-      - name: Upload client AppImage
-        uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v2
         with:
-          name: appimages
-          path: build/opensoldat/*.AppImage
-
-      - name: Upload server AppImage
-        uses: actions/upload-artifact@v2
-        with:
-          name: appimages
-          path: build/opensoldatserver/*.AppImage
+          name: linux-server-build
+          path: build/opensoldatserver/
 
   windows:
     runs-on: windows-latest
@@ -151,7 +134,7 @@ jobs:
   continuous:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop'
-    needs: [appimage, windows, macos]
+    needs: [windows, macos]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -164,14 +147,6 @@ jobs:
           zip -r windows-build.zip windows-build
           zip -r macos-build.zip macos-build
 
-      - name: Chmod and zip AppImages
-        run: |
-          cd appimages
-          chmod u+x *.AppImage
-          zip linux-appimage.zip opensoldat-*.AppImage
-          zip linux-server-only-appimage.zip opensoldatserver-*.AppImage
-          mv linux-appimage.zip linux-server-only-appimage.zip ..
-
       - name: Upload release
         uses: softprops/action-gh-release@fe9a9bd3295828558c7a3c004f23f3bf77d155b2
         with:
@@ -179,7 +154,5 @@ jobs:
           files: |
             windows-build.zip
             macos-build.zip
-            linux-appimage.zip
-            linux-server-only-appimage.zip
           body: OpenSoldat 1.8 alpha dev build
           name: OpenSoldat 1.8 alpha dev build

--- a/.github/workflows/opensoldat.yml
+++ b/.github/workflows/opensoldat.yml
@@ -158,6 +158,7 @@ jobs:
         run: |
           zip -r windows-build.zip windows-build
           zip -r macos-build.zip macos-build
+          zip -r linux-server-build.zip linux-server-build
 
       - name: Upload release
         uses: softprops/action-gh-release@fe9a9bd3295828558c7a3c004f23f3bf77d155b2
@@ -166,5 +167,6 @@ jobs:
           files: |
             windows-build.zip
             macos-build.zip
+            linux-server-build.zip
           body: OpenSoldat 1.8 alpha dev build
           name: OpenSoldat 1.8 alpha dev build

--- a/.github/workflows/opensoldat.yml
+++ b/.github/workflows/opensoldat.yml
@@ -38,15 +38,23 @@ jobs:
           cd opensoldatserver
           ../../.github/workflows/copy-libs.sh . .
 
-      - uses: actions/upload-artifact@v2
+      # We use .tar to preserve file permissions
+      - name: Tar files
+        run: |
+          tar -cvf opensoldat.tar -C build opensoldat
+          tar -cvf opensoldatserver.tar -C build opensoldatserver
+
+      - name: Upload game build
+        uses: actions/upload-artifact@v2
         with:
           name: linux-build
-          path: build/opensoldat/
+          path: opensoldat.tar
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload server-only build
+        uses: actions/upload-artifact@v2
         with:
           name: linux-server-build
-          path: build/opensoldatserver/
+          path: opensoldatserver.tar
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/opensoldat.yml
+++ b/.github/workflows/opensoldat.yml
@@ -2,7 +2,7 @@ on: [push, pull_request, workflow_dispatch]
 name: opensoldat
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -10,7 +10,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install cmake git fpc libprotobuf-dev protobuf-compiler libssl-dev libsdl2-dev libopenal-dev libphysfs-dev libfreetype6
+          sudo apt-get install cmake git fpc libprotobuf-dev protobuf-compiler libssl-dev libsdl2-dev libopenal-dev libphysfs-dev libfreetype6 patchelf
 
       - name: Compile opensoldat
         run: |
@@ -26,6 +26,10 @@ jobs:
           make install
           cd opensoldat
           ../../.github/workflows/copy-libs.sh . .
+          # Some libraries with absolute paths in .ELF DT_RUNPATH need to be patched unfortunately...
+          if ls libpulse\.* 2>&1 1>/dev/null; then
+            patchelf --remove-rpath libpulse\.*
+          fi
           cd ..
 
           cmake .. -DBUILD_CLIENT=0 \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ if(UNIX)
     set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
   else()
     set(CMAKE_INSTALL_RPATH
-      "$ORIGIN/../${target_library_install_dir}/:$ORIGIN/:${target_full_library_install_dir}"
+      "$ORIGIN/../${target_library_install_dir}/:$ORIGIN/"
     )
     set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ if(UNIX)
     set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
   else()
     set(CMAKE_INSTALL_RPATH
-      "$ORIGIN/../${target_library_install_dir}/:$ORIGIN/"
+      "$ORIGIN/../${target_library_install_dir}/:$ORIGIN/:${target_full_library_install_dir}"
     )
     set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,8 @@ if(UNIX)
     set(CMAKE_INSTALL_NAME_DIR "@executable_path/../Frameworks")
     set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
   else()
-    # We need to use RPATH, not RUNPATH
+    # On Linux, we need to use RPATH instead of RUNPATH, so our settings can
+    # apply recursively to all shared library dependencies.
     add_flag_append(CMAKE_Pascal_FLAGS "-k--disable-new-dtags")
     set(CMAKE_INSTALL_RPATH
       "$ORIGIN/../${target_library_install_dir}/:$ORIGIN/"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,10 @@ if(UNIX)
     set(CMAKE_INSTALL_NAME_DIR "@executable_path/../Frameworks")
     set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
   else()
+    # We need to use RPATH, not RUNPATH
+    add_flag_append(CMAKE_Pascal_FLAGS "-k--disable-new-dtags")
     set(CMAKE_INSTALL_RPATH
-      "$ORIGIN/../${target_library_install_dir}/:$ORIGIN/:${target_full_library_install_dir}"
+      "$ORIGIN/../${target_library_install_dir}/:$ORIGIN/"
     )
     set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
   endif()


### PR DESCRIPTION
We won't be distributing the game as a standalone app anymore, but instead it will come along with a launcher. With this change, distributing the game executables themselves as AppImages makes less sense. This PR changes the CI to upload artifacts in a format more useful for the launcher.