### PR TITLE
Small misc fixes #1

### DIFF
--- a/.github/workflows/opensoldat.yml
+++ b/.github/workflows/opensoldat.yml
@@ -139,7 +139,7 @@ jobs:
           mkdir build
           cd build
           export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/opt/openssl@1.1/lib/pkgconfig
-          cmake -DCMAKE_INSTALL_PREFIX=./opensoldat -DOPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) ..
+          cmake -DCMAKE_INSTALL_PREFIX=./opensoldat -DOPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) .. -DCMAKE_BUILD_TYPE="Release"
           make
           make install
 

--- a/client/Client.pas
+++ b/client/Client.pas
@@ -965,6 +965,7 @@ begin
   WriteLogFile(GameLog, ConsoleLogFileName);
 
   CommandCleanup();
+  CvarCleanup();
 
   Halt(0);
 end;

--- a/client/Client.pas
+++ b/client/Client.pas
@@ -964,6 +964,8 @@ begin
 
   WriteLogFile(GameLog, ConsoleLogFileName);
 
+  CommandCleanup();
+
   Halt(0);
 end;
 

--- a/client/Client.pas
+++ b/client/Client.pas
@@ -589,6 +589,8 @@ begin
 
   ParseCommandLine();
 
+  // NOTE: fs_basepath, fs_userpath and fs_portable must be set from command
+  // line, not in client.cfg.
   if fs_portable.Value then
   begin
     UserDirectory := BasePathSDL;
@@ -606,7 +608,8 @@ begin
   Debug('[FS] UserDirectory: ' + UserDirectory);
   Debug('[FS] BaseDirectory: ' + BaseDirectory);
 
-  // Create the basic folder structure
+  // Now that we have UserDirectory and BaseDirectory set, we can create the
+  // basic directory structure and unpack the necessary config files.
   CreateDirIfMissing(UserDirectory + '/configs');
   CreateDirIfMissing(UserDirectory + '/screens');
   CreateDirIfMissing(UserDirectory + '/demos');
@@ -614,6 +617,14 @@ begin
   CreateDirIfMissing(UserDirectory + '/logs/kills');
   CreateDirIfMissing(UserDirectory + '/maps');
   CreateDirIfMissing(UserDirectory + '/mods');
+
+  PHYSFS_CopyFileFromArchive('configs/client.cfg', UserDirectory + '/configs/client.cfg');
+  PHYSFS_CopyFileFromArchive('configs/taunts.cfg', UserDirectory + '/configs/taunts.cfg');
+
+  LoadConfig('client.cfg');
+
+  // NOTE: Code depending on CVars should be run after this line if possible.
+  CvarsInitialized := True;
 
   NewLogFiles;
 
@@ -710,13 +721,6 @@ begin
   {$ENDIF}
 
   LoadInterfaceArchives(UserDirectory + 'custom-interfaces/');
-
-  PHYSFS_CopyFileFromArchive('configs/client.cfg', UserDirectory + '/configs/client.cfg');
-  PHYSFS_CopyFileFromArchive('configs/taunts.cfg', UserDirectory + '/configs/taunts.cfg');
-
-  LoadConfig('client.cfg');
-
-  CvarsInitialized := True;
 
   // these might change so keep a backup to avoid changing the settings file
   ScreenWidth := r_screenwidth.Value;

--- a/client/Client.pas
+++ b/client/Client.pas
@@ -584,9 +584,7 @@ begin
   BasePathSDL := SDL_GetBasePath();
 
   CvarInit();
-
   InitClientCommands();
-
   ParseCommandLine();
 
   // NOTE: fs_basepath, fs_userpath and fs_portable must be set from command
@@ -627,16 +625,6 @@ begin
   CvarsInitialized := True;
 
   NewLogFiles;
-
-  MainConsole.CountMax := Round(15 * _rscala.y);
-  MainConsole.ScrollTickMax := 150;
-  MainConsole.NewMessageWait := 150;
-  MainConsole.AlphaCount := 255;
-  MainConsole.Count := 0;
-  MainConsole.CountMax := Round(ui_console_length.Value * _rscala.y);
-
-  if MainConsole.CountMax > 254 then
-    MainConsole.CountMax := 254;
 
   // TODO remove HWIDs, replace by Fae auth tickets
   HWID := '00000000000';

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -856,6 +856,7 @@ begin
   end;
 
   CommandCleanup();
+  CvarCleanup();
 end;
 
 function LoadMapsList(Filename: string = ''): Boolean;

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -854,6 +854,8 @@ begin
     on e: Exception do
       WriteLn('Error on SHUTDOWN during log writing: ' + e.Message);
   end;
+
+  CommandCleanup();
 end;
 
 function LoadMapsList(Filename: string = ''): Boolean;

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -835,6 +835,8 @@ begin
   GameNetworkingSockets_Kill();
   {$ENDIF}
 
+  FreeAndNil(DummyPlayer);
+
   AddLineToLogFile(GameLog, 'PhysFS closing.', ConsoleLogFileName);
   PhysFS_deinit();
 

--- a/server/opensoldatserver.lpr
+++ b/server/opensoldatserver.lpr
@@ -44,7 +44,7 @@ begin
   {$IFDEF AUTOUPDATER}
   StartAutoUpdater;
   {$ENDIF}
-  RunServer;
-
   DefaultSystemCodePage := CP_UTF8;
+
+  RunServer;
 end.

--- a/server/scriptcore/ScriptCoreInterface.pas
+++ b/server/scriptcore/ScriptCoreInterface.pas
@@ -111,7 +111,7 @@ uses
   NetworkServerMessages, NetworkServerGame,
   Server, Game, Calc, IniFiles, Sprites, fpmasks,
   Math, ScriptDispatcher, Weapons, Things, Command, Bullets,
-  Constants, strutils, Version, RegExpr, Cvar, ServerHelper {$IFDEF RCON}, Rcon{$ENDIF};
+  TraceLog, Constants, strutils, Version, RegExpr, Cvar, ServerHelper {$IFDEF RCON}, Rcon{$ENDIF};
 
 function ExistsFile(FileName: String): Boolean;
 var
@@ -149,8 +149,7 @@ var
 begin
   Ret := Default(TStringArray);
   Split := Default(TStringArray);
-  if log_level.Value = 3 then
-    WriteLn('|| Split();');
+  Trace('|| Split();');
 
   Temp := Source;
   Count := 0;
@@ -218,8 +217,7 @@ var
   NumLines, NumLinesEnc: Integer;
 begin
   Result := '';
-  if log_level.Value = 3 then
-    WriteLn('|| ScriptCore.ReadFile(' + FileName + ');');
+  Trace('|| ScriptCore.ReadFile(' + FileName + ');');
 
   Name := AnsiReplaceStr(FileName, '..', '');
   assignfile(VarFile, UserDirectory + Name);
@@ -441,8 +439,7 @@ function AppendFile(FileName: String; Data: String): Boolean;
 var
   VarFile: TextFile;
 begin
-  if log_level.Value = 3 then
-    WriteLn('|| ScriptCore.AppendFile(' + FileName + ');');
+  Trace('|| ScriptCore.AppendFile(' + FileName + ');');
 
   FileName := AnsiReplaceStr(FileName, '..', '');
   try
@@ -1040,8 +1037,7 @@ function WriteFile(FileName: String; SData: String): Boolean;
 var
   VarFile: TextFile;
 begin
-  if log_level.Value = 3 then
-    WriteLn('|| ScriptCore.WriteFile(' + FileName + ');');
+  Trace('|| ScriptCore.WriteFile(' + FileName + ');');
 
   FileName := AnsiReplaceStr(FileName, '..', '');
   try
@@ -1101,8 +1097,7 @@ begin
   Result := False;
   if not sc_enable.Value then
     Exit;
-  // if log_level.Value = 3 then
-  // WriteLn('|| ScriptCore.SetVal('+Variable+', '+inttostr(Value)+');');
+  // Trace('|| ScriptCore.SetVal('+Variable+', '+inttostr(Value)+');');
 
   VSetInt(Script.GetVariable(UpperCase(Variable)), Value);
   Result := True;
@@ -1113,8 +1108,7 @@ begin
   Result := False;
   if not sc_enable.Value then
     Exit;
-  // if log_level.Value = 3 then
-  // WriteLn('|| ScriptCore.SetString('+Variable+','+Value+');');
+  // Trace('|| ScriptCore.SetString('+Variable+','+Value+');');
 
   VSetString(Script.GetVariable(UpperCase(Variable)), Value);
   Result := True;

--- a/shared/Command.pas
+++ b/shared/Command.pas
@@ -6,6 +6,7 @@ uses
   classes, contnrs, sysutils, variants, Constants;
 
 procedure CommandInit();
+procedure CommandCleanup();
 function ParseInput(Input: String; Sender: Byte = 0): Boolean; overload;
 function LoadConfig(ConfigName: AnsiString): Boolean;
 
@@ -642,6 +643,17 @@ begin
   CommandAdd('netconfig_loglevel', CommandNetLogLevel, 'Set GNS log level', []);
 
   {$ENDIF}
+end;
+
+procedure CommandCleanup();
+var
+  i: Integer;
+begin
+  FreeAndNil(DeferredCommands);
+  if Commands <> Nil then
+    for i := 0 to Commands.Count - 1 do
+      Dispose(PCommand(Commands[i]));
+  FreeAndNil(Commands);
 end;
 
 end.

--- a/shared/Console.pas
+++ b/shared/Console.pas
@@ -35,7 +35,20 @@ type
   end;
 
 implementation
-  uses {$IFDEF SERVER}Server,{$ELSE}Client,{$ENDIF} Game, LogFile, sysutils {$IFDEF SERVER}, Net, NetworkServerMessages {$IFDEF RCON}, Rcon{$ENDIF}{$ENDIF};
+
+uses
+  {$IFDEF SERVER}
+  Server,
+  Net,
+  NetworkServerMessages,
+  {$IFDEF RCON}Rcon,{$ENDIF}
+  {$ELSE}
+  Client,
+  TraceLog,
+  {$ENDIF}
+  Game,
+  LogFile,
+  SysUtils;
 
 procedure TConsole.ScrollConsole;
 var
@@ -119,6 +132,7 @@ begin
   if Count = CountMax then
     ScrollConsole;
   {$ELSE}
+  Debug('[Console] ' + AnsiString(What));
   MainConsole.ConsoleAdd(What, Col);
   BigConsole.ConsoleAdd(What, Col);
   {$ENDIF}

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -762,7 +762,7 @@ begin
 
   fs_localmount := TBooleanCvar.Add('fs_localmount', 'Mount game directory as game mod', False, False, [CVAR_CLIENT, CVAR_INITONLY], nil);
   fs_mod := TStringCvar.Add('fs_mod', 'File name of mod placed in mods directory (without .smod extension)', '', '', [CVAR_INITONLY], nil, 0, 255);
-  fs_portable := TBooleanCvar.Add('fs_portable', 'Enables portable mode', True, True, [CVAR_CLIENT, CVAR_INITONLY], @fs_portableChange);
+  fs_portable := TBooleanCvar.Add('fs_portable', 'Enables portable mode', False, False, [CVAR_CLIENT, CVAR_INITONLY], @fs_portableChange);
   fs_basepath := TStringCvar.Add('fs_basepath', 'Path to base game directory', '', '', [CVAR_INITONLY], @fs_basepathChange, 0, 255);
   fs_userpath := TStringCvar.Add('fs_userpath', 'Path to user game directory', '', '', [CVAR_INITONLY], @fs_userpathChange, 0, 255);
 

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -269,9 +269,6 @@ end;
 
 procedure DumpCvar(Cvar: TCvarBase; Value, DefaultValue: Variant);
 begin
-  // FIXME: Workaround for access violation due to uninitialized log_level
-  if Cvar.Name = 'log_level' then
-    Exit;
   Debug('[CVAR] CvarAdd: ' + Cvar.Name + ' Value: '
       + VarToStr(Value) + ' DefaultValue: ' + VarToStr(DefaultValue) +
       ' FLAGS: 0 ' + ' Description: ' + Cvar.Description);

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -135,6 +135,7 @@ type
   end;
 
 procedure CvarInit();
+procedure CvarCleanup();
 function DumpFlags(Cvar: TCvarBase): AnsiString;
 procedure ResetSyncCvars;
 
@@ -1027,6 +1028,17 @@ begin
   sv_pure := TBooleanCvar.Add('sv_pure', 'Requires clients to use the same game files (.smod) as the server', True, True, [CVAR_SERVER, CVAR_SYNC], nil);
 
   CommandInit();
+end;
+
+procedure CvarCleanup();
+var
+  i: Integer;
+begin
+  FreeAndNil(CvarsSync);
+  if Cvars <> Nil then
+    for i := 0 to Cvars.Count - 1 do
+      TCvarBase(Cvars[i]).Free;
+  FreeAndNil(Cvars);
 end;
 
 end.

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -195,6 +195,18 @@ begin
 end;
 {$ENDIF}
 
+function fs_portableChange(Cvar: TCvarBase; NewValue: Boolean): Boolean;
+begin
+  if (UserDirectory <> '') or (BaseDirectory <> '') then
+  begin
+    Cvar.FErrorMessage := 'fs_portable must be set from the command line';
+    Result := False;
+    Exit;
+  end;
+
+  Result := True;
+end;
+
 function fs_basepathChange(Cvar: TCvarBase; NewValue: String): Boolean;
 begin
   if BaseDirectory <> '' then
@@ -746,7 +758,7 @@ begin
 
   fs_localmount := TBooleanCvar.Add('fs_localmount', 'Mount game directory as game mod', False, False, [CVAR_CLIENT, CVAR_INITONLY], nil);
   fs_mod := TStringCvar.Add('fs_mod', 'File name of mod placed in mods directory (without .smod extension)', '', '', [CVAR_INITONLY], nil, 0, 255);
-  fs_portable := TBooleanCvar.Add('fs_portable', 'Enables portable mode', True, True, [CVAR_CLIENT, CVAR_INITONLY], nil);
+  fs_portable := TBooleanCvar.Add('fs_portable', 'Enables portable mode', True, True, [CVAR_CLIENT, CVAR_INITONLY], @fs_portableChange);
   fs_basepath := TStringCvar.Add('fs_basepath', 'Path to base game directory', '', '', [CVAR_INITONLY], @fs_basepathChange, 0, 255);
   fs_userpath := TStringCvar.Add('fs_userpath', 'Path to user game directory', '', '', [CVAR_INITONLY], @fs_userpathChange, 0, 255);
 

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -195,6 +195,8 @@ begin
 end;
 {$ENDIF}
 
+{$PUSH}
+{$WARN 5024 OFF : Parameter "$1" not used}
 function fs_portableChange(Cvar: TCvarBase; NewValue: Boolean): Boolean;
 begin
   if (UserDirectory <> '') or (BaseDirectory <> '') then
@@ -206,6 +208,7 @@ begin
 
   Result := True;
 end;
+{$POP}
 
 function fs_basepathChange(Cvar: TCvarBase; NewValue: String): Boolean;
 begin

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -1025,7 +1025,7 @@ begin
 
   sv_killlimit := TIntegerCvar.Add('sv_killlimit', 'Game point limit', 10, 10, [CVAR_SERVER, CVAR_SYNC], nil, 0, 9999);
   sv_downloadurl := TStringCvar.Add('sv_downloadurl', 'URL from which clients can download missing assets', '', '', [CVAR_SERVER, CVAR_SYNC], nil, 0, 100);
-  sv_pure := TBooleanCvar.Add('sv_pure', 'Requires clients to use the same game files (.smod) as the server', True, True, [CVAR_SERVER, CVAR_SYNC], nil);
+  sv_pure := TBooleanCvar.Add('sv_pure', 'Requires clients to use the same game files (.smod) as the server', False, False, [CVAR_SERVER, CVAR_SYNC], nil);
 
   CommandInit();
 end;

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -965,13 +965,13 @@ begin
   net_floodingpacketslan := TIntegerCvar.Add('net_floodingpacketslan', 'When running on a LAN, controls how many packets should be considered flooding', 80, 80, [CVAR_SERVER], nil, 0, 100);
   net_floodingpacketsinternet := TIntegerCvar.Add('net_floodingpacketsinternet', 'When running on the Internet, controls how many packets should be considered flooding', 42, 42, [CVAR_SERVER], nil, 0, 100);
 
-  net_t1_snapshot := TIntegerCvar.Add('net_t1_snapshot', 'Maximum number of simultaneous file transfer connections', 35, 35, [CVAR_SERVER], nil, 1, 1000);
-  net_t1_majorsnapshot := TIntegerCvar.Add('net_t1_majorsnapshot', 'Maximum number of simultaneous file transfer connections', 19, 19, [CVAR_SERVER], nil, 1, 1000);
-  net_t1_deadsnapshot := TIntegerCvar.Add('net_t1_deadsnapshot', 'Maximum number of simultaneous file transfer connections', 50, 50, [CVAR_SERVER], nil, 1, 1000);
-  net_t1_heartbeat := TIntegerCvar.Add('net_t1_heartbeat', 'Maximum number of simultaneous file transfer connections', 135, 135, [CVAR_SERVER], nil, 1, 1000);
-  net_t1_delta := TIntegerCvar.Add('net_t1_delta', 'Maximum number of simultaneous file transfer connections', 4, 4, [CVAR_SERVER], nil, 1, 1000);
-  net_t1_ping := TIntegerCvar.Add('net_t1_ping', 'Maximum number of simultaneous file transfer connections', 21, 21, [CVAR_SERVER], nil, 1, 1000);
-  net_t1_thingsnapshot := TIntegerCvar.Add('net_t1_thingsnapshot', 'Maximum number of simultaneous file transfer connections', 31, 31, [CVAR_SERVER], nil, 1, 1000);
+  net_t1_snapshot := TIntegerCvar.Add('net_t1_snapshot', 'How often to send sprite snapshot packets on the internet in ticks (60 ticks = 1 second)', 35, 35, [CVAR_SERVER], nil, 1, 1000);
+  net_t1_majorsnapshot := TIntegerCvar.Add('net_t1_majorsnapshot', 'How often to send major sprite snapshot packets on the internet in ticks (60 ticks = 1 second)', 19, 19, [CVAR_SERVER], nil, 1, 1000);
+  net_t1_deadsnapshot := TIntegerCvar.Add('net_t1_deadsnapshot', 'How often to send dead sprite snapshot packets on the internet in ticks (60 ticks = 1 second)', 50, 50, [CVAR_SERVER], nil, 1, 1000);
+  net_t1_heartbeat := TIntegerCvar.Add('net_t1_heartbeat', 'How often to send heartbeat packets on the internet in ticks (60 ticks = 1 second)', 135, 135, [CVAR_SERVER], nil, 1, 1000);
+  net_t1_delta := TIntegerCvar.Add('net_t1_delta', 'How often to send bot sprite deltas on the internet in ticks (60 ticks = 1 second)', 4, 4, [CVAR_SERVER], nil, 1, 1000);
+  net_t1_ping := TIntegerCvar.Add('net_t1_ping', 'How often to send ping packets on the internet in ticks (60 ticks = 1 second)', 21, 21, [CVAR_SERVER], nil, 1, 1000);
+  net_t1_thingsnapshot := TIntegerCvar.Add('net_t1_thingsnapshot', 'How often to send thing snapshot packets on the internet in ticks (60 ticks = 1 second)', 31, 31, [CVAR_SERVER], nil, 1, 1000);
 
   // Bots cvars
   bots_random_noteam := TIntegerCvar.Add('bots_random_noteam', 'Number of bots in DM, PM and RM modes', 0, 0, [CVAR_SERVER], nil, 0, 32);
@@ -1011,7 +1011,7 @@ begin
   sv_kits_collide := TBooleanCvar.Add('sv_kits_collide', 'Enables colliding kits', False, False, [CVAR_SERVER, CVAR_SYNC], nil);
   sv_survivalmode := TBooleanCvar.Add('sv_survivalmode', 'Enables survival mode', False, False, [CVAR_SERVER, CVAR_SYNC,CVAR_SERVER_INITONLY], nil); // Restart server
   sv_survivalmode_antispy := TBooleanCvar.Add('sv_survivalmode_antispy', 'Enables anti spy chat in survival mode', False, False, [CVAR_SERVER, CVAR_SYNC], nil);
-  sv_survivalmode_clearweapons := TBooleanCvar.Add('sv_survivalmode_clearweapons', 'Cluster Grenades bonus availability', False, False, [CVAR_SERVER, CVAR_SYNC], nil);
+  sv_survivalmode_clearweapons := TBooleanCvar.Add('sv_survivalmode_clearweapons', 'Clear weapons in between survivalmode rounds', False, False, [CVAR_SERVER, CVAR_SYNC], nil);
   sv_realisticmode := TBooleanCvar.Add('sv_realisticmode', 'Enables realistic mode', False, False, [CVAR_SERVER, CVAR_SYNC,CVAR_SERVER_INITONLY], nil); // Restart server
   sv_advancemode := TBooleanCvar.Add('sv_advancemode', 'Enables advance mode', False, False, [CVAR_SERVER, CVAR_SYNC,CVAR_SERVER_INITONLY], nil); // Restart server
   sv_advancemode_amount := TIntegerCvar.Add('sv_advancemode_amount', 'Number of kills required in Advance Mode to gain a weapon.', 2, 2, [CVAR_SERVER, CVAR_SYNC], nil, 1, 9999);

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -735,7 +735,7 @@ begin
   Cvars := TFPHashList.Create;
   CvarsSync := TFPHashList.Create;
 
-  log_level := TIntegerCvar.Add('log_level', 'Sets log level', 0, 0, [], nil, 0, 3);
+  log_level := TIntegerCvar.Add('log_level', 'Sets log level', LEVEL_OFF, LEVEL_OFF, [], nil, LEVEL_OFF, LEVEL_TRACE);
   log_enable := TBooleanCvar.Add('log_enable', 'Enables logging to file', False, False, [], nil);
   log_filesupdate := TIntegerCvar.Add('log_filesupdate', 'How often the log files should be updated', 3600, 3600, [], nil, 0, MaxInt);
   {$IFDEF SERVER}

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -734,7 +734,7 @@ begin
 
   log_level := TIntegerCvar.Add('log_level', 'Sets log level', LEVEL_OFF, LEVEL_OFF, [], nil, LEVEL_OFF, LEVEL_TRACE);
   log_enable := TBooleanCvar.Add('log_enable', 'Enables logging to file', False, False, [], nil);
-  log_filesupdate := TIntegerCvar.Add('log_filesupdate', 'How often the log files should be updated', 3600, 3600, [], nil, 0, MaxInt);
+  log_filesupdate := TIntegerCvar.Add('log_filesupdate', 'How often the log files should be updated in ticks (60 ticks = 1 second)', 3600, 3600, [], nil, 0, MaxInt);
   {$IFDEF SERVER}
   log_timestamp := TBooleanCvar.Add('log_timestamp', 'Enables/Disables timestamps in console', False, False, [CVAR_SERVER], nil);
   {$ENDIF}

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -745,12 +745,12 @@ begin
   {$ENDIF}
 
   fs_localmount := TBooleanCvar.Add('fs_localmount', 'Mount game directory as game mod', False, False, [CVAR_CLIENT, CVAR_INITONLY], nil);
-  fs_mod := TStringCvar.Add('fs_mod', 'File name of mod placed in mods directory (without .smod extension)', '', '', [CVAR_CLIENT, CVAR_INITONLY], nil, 0, 255);
+  fs_mod := TStringCvar.Add('fs_mod', 'File name of mod placed in mods directory (without .smod extension)', '', '', [CVAR_INITONLY], nil, 0, 255);
   fs_portable := TBooleanCvar.Add('fs_portable', 'Enables portable mode', True, True, [CVAR_CLIENT, CVAR_INITONLY], nil);
-  fs_basepath := TStringCvar.Add('fs_basepath', 'Path to base game directory', '', '', [CVAR_CLIENT, CVAR_INITONLY], @fs_basepathChange, 0, 255);
-  fs_userpath := TStringCvar.Add('fs_userpath', 'Path to user game directory', '', '', [CVAR_CLIENT, CVAR_INITONLY], @fs_userpathChange, 0, 255);
+  fs_basepath := TStringCvar.Add('fs_basepath', 'Path to base game directory', '', '', [CVAR_INITONLY], @fs_basepathChange, 0, 255);
+  fs_userpath := TStringCvar.Add('fs_userpath', 'Path to user game directory', '', '', [CVAR_INITONLY], @fs_userpathChange, 0, 255);
 
-  demo_autorecord := TBooleanCvar.Add('demo_autorecord', 'Auto record demos', False, False, [CVAR_CLIENT], nil);
+  demo_autorecord := TBooleanCvar.Add('demo_autorecord', 'Auto record demos', False, False, [], nil);
 
   {$IFNDEF SERVER}
   // Render Cvars

--- a/shared/LogFile.pas
+++ b/shared/LogFile.pas
@@ -108,7 +108,7 @@ begin
   if Length(S) < 1 then
     Exit;
 
-  if log_level.Value = 0 then
+  if log_level.Value = LEVEL_OFF then
     Exit;
 
   S2 := FormatDateTime('yy/mm/dd', Date);
@@ -124,7 +124,7 @@ begin
     LogLock.Release;
   end;
 
-  if log_level.Value > 1 then
+  if log_level.Value >= LEVEL_TRACE then
     WriteLogFile(F, Name);
 end;
 
@@ -235,7 +235,7 @@ begin
     Inc(j);
     ConsoleLogFileName := Format('%slogs/consolelog-%s-%.2d.txt', [UserDirectory, S2, j]);
   end;
-  if log_level.Value = 0 then
+  if log_level.Value = LEVEL_OFF then
     ConsoleLogFileName := UserDirectory + 'logs/consolelog.txt';
 
   NewLogFile(GameLog, ConsoleLogFileName);

--- a/shared/mechanics/Things.pas
+++ b/shared/mechanics/Things.pas
@@ -1111,16 +1111,7 @@ begin
         if Tex1 = 0 then
           Exit;
 
-        if log_level.Value = 1 then
-        begin
-          if not StaticType then
-            GfxDrawSprite(T^[Tex1], _p.x, _p.y, _ra.x, _ra.y, -Roto)
-          else
-            GfxDrawSprite(T^[Tex1], _p.x, _p.y, _ra.x, _ra.y, -Roto, RGBA($FFFFFF, 115));
-        end else
-        begin
-          GfxDrawSprite(T^[Tex1], _p.x, _p.y, _ra.x, _ra.y, -Roto);
-        end;
+        GfxDrawSprite(T^[Tex1], _p.x, _p.y, _ra.x, _ra.y, -Roto);
 
         if Tex2 > 0 then
           GfxDrawSprite(T^[Tex2], _p.x, _p.y, _ra.x, _ra.y, -Roto);

--- a/shared/network/NetworkUtils.pas
+++ b/shared/network/NetworkUtils.pas
@@ -55,12 +55,12 @@ procedure StringToArray(var c: array of Char; s: string);
 implementation
 
 uses
-  {$IFDEF SERVER}Server,{$ELSE}Client,{$ENDIF} Net, Game,
   {$IFDEF SERVER}
-  BanSystem, TraceLog;
+  Server, BanSystem,
   {$ELSE}
-  GameMenus;
+  Client, GameMenus,
   {$ENDIF}
+  Net, Game, TraceLog;
 
 {$IFNDEF SERVER}
 procedure PlayRadioSound(RadioID: Byte);
@@ -153,7 +153,7 @@ begin
     Dropped := ' - DROPPED (wrong size <> ' + IntToStr(ValidSize) + ')';
     Result := False;
   end;
-  if log_level.Value > 1 then
+  if log_level.Value >= LEVEL_TRACE then
     MainConsole.Console('[NET] Received Packet (' + IntToStr(PacketId) +
       ') Size:' + IntToStr(ReceiveSize) + Dropped, DEBUG_MESSAGE_COLOR);
 end;
@@ -168,7 +168,7 @@ begin
     Dropped := ' - DROPPED (wrong size, expected at least ' + IntToStr(ValidSize) + ')';
     Result := False;
   end;
-  if log_level.Value > 1 then
+  if log_level.Value >= LEVEL_TRACE then
     MainConsole.Console('[NET] Received Packet (' + IntToStr(PacketId) +
       ') Size:' + IntToStr(ReceiveSize) + Dropped, DEBUG_MESSAGE_COLOR);
 end;


### PR DESCRIPTION
- Remove `log_level.Value = 3` weirdness, use log level constants rigorously.
  - There was some old ScriptCore1/2 (however it was called) code left lying around using `log_level` 3, but it looked like `Trace` calls would do just fine.
- Remove test code to change opacity of weapons which aren't being held. Doesn't look that good.
- Actually set `DefaultSystemCodePage` before running the server.
- Remove workaround for uninitialized `log_level`, `Debug` now checks if `log_level` is assigned.
- Add message/comment explaining that `log_filesupdate` is measured in ticks.
- Consistently don't use `CVAR_CLIENT` flag on shared cvars.
- Run `client.cfg` before loading mod, add clarifying comment about `fs_basepath`, `fs_userpath` and `fs_portable` being set in command line.
  - As suggesed in https://github.com/opensoldat/opensoldat/pull/114#issuecomment-1187729605.
- Only allow setting `fs_portable` from the command line.
- Fix unused variable warning in `fs_portableChange`.
- Don't needlessly initialize `MainConsole`. It is properly initialized later, and there is actually no need to set any of it's variables due to zero-initialization of globals. This zero-initialization behavior is relied on for `BigConsole`, anyways.
- `Debug` console messages to stdout. Useful for seeing messages printed to console before graphics, or the global console variables, are initialized.
- Clean up command memory.
- Clean up cvar memory.
- Make `fs_portable` default to false. The default behavior without passing `fs_basepath` or `fs_userpath` is actually the same. This just makes it less confusing for people trying to adjust `fs_basepath` or `fs_userpath` for the first time. `fs_portable` can still stick around as an off switch for the other 2.
- Make `sv_pure` default to false. Rejecting anyone with a mod should not be default behavior.
- Fix some Cvar descriptions.
- Fix macOS CI.
  - A recent version of protobuf broke our CI. This ostensibly happened because we linked a debug version of GNS against a release version of protobuf, so they were compiled with different flags (`NDEBUG` preprocessor definition), and it wound up violating the C++ ODR. However I would say it is just more protobuf ABI insanity, because they place Google's interests above their users'. However, when the offending version of protobuf reached homebrew, and everyone's builds broke, they promptly put out a new version of protobuf with a fix. Soon enough it will be in package managers. But, we should really be building the macOS build in release mode anyways...
- Free `DummyPlayer`.