### PR TITLE
Fix GNS userdata race condition

### DIFF
--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -720,7 +720,7 @@ begin
 
   fs_localmount := TBooleanCvar.Add('fs_localmount', 'Mount game directory as game mod', False, False, [CVAR_CLIENT, CVAR_INITONLY], @CommandLineOnlyChange);
   fs_mod := TStringCvar.Add('fs_mod', 'File name of mod placed in mods directory (without .smod extension)', '', '', [CVAR_INITONLY], nil, 0, 255);
-  fs_portable := TBooleanCvar.Add('fs_portable', 'Enables portable mode', False, False, [CVAR_CLIENT, CVAR_INITONLY], @CommandLineOnlyChange);
+  fs_portable := TBooleanCvar.Add('fs_portable', 'Enables portable mode', True, True, [CVAR_CLIENT, CVAR_INITONLY], @CommandLineOnlyChange);
   fs_basepath := TStringCvar.Add('fs_basepath', 'Path to base game directory', '', '', [CVAR_INITONLY], @CommandLineOnlyChange, 0, 255);
   fs_userpath := TStringCvar.Add('fs_userpath', 'Path to user game directory', '', '', [CVAR_INITONLY], @CommandLineOnlyChange, 0, 255);
 

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -198,11 +198,11 @@ end;
 
 {$PUSH}
 {$WARN 5024 OFF : Parameter "$1" not used}
-function fs_portableChange(Cvar: TCvarBase; NewValue: Boolean): Boolean;
+function CommandLineOnlyChange(Cvar: TCvarBase; NewValue: Boolean): Boolean;
 begin
   if (UserDirectory <> '') or (BaseDirectory <> '') then
   begin
-    Cvar.FErrorMessage := 'fs_portable must be set from the command line';
+    Cvar.FErrorMessage := Cvar.Name + ' must be set from the command line';
     Result := False;
     Exit;
   end;
@@ -210,48 +210,6 @@ begin
   Result := True;
 end;
 {$POP}
-
-function fs_basepathChange(Cvar: TCvarBase; NewValue: String): Boolean;
-begin
-  if BaseDirectory <> '' then
-  begin
-    Cvar.FErrorMessage := 'fs_basepath must be set from the command line';
-    Result := False;
-    Exit;
-  end;
-
-  if DirectoryExists(NewValue) then
-  begin
-    BaseDirectory := IncludeTrailingPathDelimiter(NewValue);
-    Result := True;
-  end
-  else
-  begin
-    Cvar.FErrorMessage := 'The specified path does not exist';
-    Result := False;
-  end;
-end;
-
-function fs_userpathChange(Cvar: TCvarBase; NewValue: String): Boolean;
-begin
-  if UserDirectory <> '' then
-  begin
-    Cvar.FErrorMessage := 'fs_userpath must be set from the command line';
-    Result := False;
-    Exit;
-  end;
-
-  if DirectoryExists(NewValue) then
-  begin
-    UserDirectory := IncludeTrailingPathDelimiter(NewValue);
-    Result := True;
-  end
-  else
-  begin
-    Cvar.FErrorMessage := 'The specified path does not exist';
-    Result := False;
-  end;
-end;
 
 function sv_gravityChange(Cvar: TCvarBase; NewValue: Single): Boolean;
 begin
@@ -760,11 +718,11 @@ begin
     {$ENDIF}
   {$ENDIF}
 
-  fs_localmount := TBooleanCvar.Add('fs_localmount', 'Mount game directory as game mod', False, False, [CVAR_CLIENT, CVAR_INITONLY], nil);
+  fs_localmount := TBooleanCvar.Add('fs_localmount', 'Mount game directory as game mod', False, False, [CVAR_CLIENT, CVAR_INITONLY], @CommandLineOnlyChange);
   fs_mod := TStringCvar.Add('fs_mod', 'File name of mod placed in mods directory (without .smod extension)', '', '', [CVAR_INITONLY], nil, 0, 255);
-  fs_portable := TBooleanCvar.Add('fs_portable', 'Enables portable mode', False, False, [CVAR_CLIENT, CVAR_INITONLY], @fs_portableChange);
-  fs_basepath := TStringCvar.Add('fs_basepath', 'Path to base game directory', '', '', [CVAR_INITONLY], @fs_basepathChange, 0, 255);
-  fs_userpath := TStringCvar.Add('fs_userpath', 'Path to user game directory', '', '', [CVAR_INITONLY], @fs_userpathChange, 0, 255);
+  fs_portable := TBooleanCvar.Add('fs_portable', 'Enables portable mode', False, False, [CVAR_CLIENT, CVAR_INITONLY], @CommandLineOnlyChange);
+  fs_basepath := TStringCvar.Add('fs_basepath', 'Path to base game directory', '', '', [CVAR_INITONLY], @CommandLineOnlyChange, 0, 255);
+  fs_userpath := TStringCvar.Add('fs_userpath', 'Path to user game directory', '', '', [CVAR_INITONLY], @CommandLineOnlyChange, 0, 255);
 
   demo_autorecord := TBooleanCvar.Add('demo_autorecord', 'Auto record demos', False, False, [], nil);
 


### PR DESCRIPTION
- Fix for #116 (credit @rzaba0, merging now rather than waiting for launcher changes)
- Only allow fs_localmount to be set from the command line, use a common change function for such cvars.
- Fix race condition with unset/stale GNS connection userdata (see https://github.com/ValveSoftware/GameNetworkingSockets/issues/217#issuecomment-1026050564).
  - Worth noting that this doesn't affect incoming messages, only connection state change callbacks.
- Also let me sneak in a change to make `fs_portable` default to true again. I thought the default behavior, without passing `fs_basepath` or `fs_userpath` would be the same, but it wasn't, it broke some stuff, and was less intuitive. Let's revert it.