### PR TITLE
Fix arguments with spaces

### DIFF
--- a/shared/Command.pas
+++ b/shared/Command.pas
@@ -645,6 +645,7 @@ begin
   for i := Low(DeferredCommands) To High(DeferredCommands) do
   begin
     ParseInput(DeferredCommands[i].Command, DeferredCommands[i].Values);
+    DeferredCommands[i].Values.Free;
   end;
   SetLength(DeferredCommands, 0);
 end;
@@ -677,7 +678,7 @@ var
 begin
   for i := Low(DeferredCommands) to High(DeferredCommands) do
     DeferredCommands[i].Values.Free;
-  FreeAndNil(DeferredCommands);
+  SetLength(DeferredCommands, 0);
   if Commands <> Nil then
     for i := 0 to Commands.Count - 1 do
       Dispose(PCommand(Commands[i]));


### PR DESCRIPTION
This one should fix issue #122. It does so by keeping the arguments separately in a TStringList instead of breaking things up using a space as a delimiter.

I overloaded `ParseInput` so that it can take both a command as string and values as TStringList just one long string as it originally was. This ensures that existing code that uses `ParseInput` internally continues to work.

Hope this is ok! :)