### PR TITLE
Update `UserDirectory` and `BaseDirectory` cased off cvars

### DIFF
--- a/client/Client.pas
+++ b/client/Client.pas
@@ -341,7 +341,7 @@ var
 begin
   if PHYSFS_Exists(PChar(ModDir + 'txt/weaponnames.txt')) then
     Prefix := ModDir
-  else 
+  else
     Prefix := '';
 
   MainConsole.Console(_('Loading Weapon Names from') + WideString(' ' + Prefix + 'txt/weaponnames.txt'), DEBUG_MESSAGE_COLOR);
@@ -578,6 +578,7 @@ var
   BasePathSDL: PChar;
   UserPathSDL: PChar;
   i: Integer;
+  s: String;
 begin
   ExeName := ParamStr(0);
   UserPathSDL := SDL_GetPrefPath('OpenSoldat', 'OpenSoldat');
@@ -605,10 +606,25 @@ begin
   end
   else
   begin
-    if fs_userpath.Value = '' then
-      UserDirectory := UserPathSDL;
-    if fs_basepath.Value = '' then
-      BaseDirectory := BasePathSDL;
+    UserDirectory := UserPathSDL;
+    if fs_userpath.Value <> '' then
+    begin
+      s := ExpandFileName(fs_userpath.Value);
+      if DirectoryExists(s) then
+        UserDirectory := IncludeTrailingPathDelimiter(s)
+      else
+        Debug('[FS] Warning: Specified fs_userpath directory ''' + fs_userpath.Value + ''' does not exist.');
+    end;
+
+    BaseDirectory := BasePathSDL;
+    if fs_basepath.Value <> '' then
+    begin
+      s := ExpandFileName(fs_basepath.Value);
+      if DirectoryExists(s) then
+        BaseDirectory := IncludeTrailingPathDelimiter(s)
+      else
+        Debug('[FS] Warning: Specified fs_basepath directory ''' + fs_basepath.Value + ''' does not exist.');
+    end;
   end;
 
   Debug('[FS] UserDirectory: ' + UserDirectory);

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -514,6 +514,7 @@ end;
 procedure ActivateServer;
 var
   i, j: Integer;
+  s: String;
 begin
   MainThreadID := GetThreadID;
 
@@ -570,10 +571,25 @@ begin
 
   // NOTE: fs_basepath and fs_userpath must be set from command line, not in
   // server.cfg.
-  if fs_basepath.Value = '' then
-    BaseDirectory := ExtractFilePath(ParamStr(0));
-  if fs_userpath.Value = '' then
-    UserDirectory := ExtractFilePath(ParamStr(0));
+  UserDirectory := ExtractFilePath(ParamStr(0));
+  if fs_userpath.Value <> '' then
+  begin
+    s := ExpandFileName(fs_userpath.Value);
+    if DirectoryExists(s) then
+      UserDirectory := IncludeTrailingPathDelimiter(s)
+    else
+      Debug('[FS] Warning: Specified fs_userpath directory ''' + fs_userpath.Value + ''' does not exist.');
+  end;
+
+  BaseDirectory := ExtractFilePath(ParamStr(0));
+  if fs_basepath.Value <> '' then
+  begin
+    s := ExpandFileName(fs_basepath.Value);
+    if DirectoryExists(s) then
+      BaseDirectory := IncludeTrailingPathDelimiter(s)
+    else
+      Debug('[FS] Warning: Specified fs_basepath directory ''' + fs_basepath.Value + ''' does not exist.');
+  end;
 
   Debug('[FS] UserDirectory: ' + UserDirectory);
   Debug('[FS] BaseDirectory: ' + BaseDirectory);


### PR DESCRIPTION
Also allows setting `fs_userpath` and `fs_basepath` as relative directories (was not possible in the server). Closes #121.