### PR TITLE
Scriptcore memory cleanup + misc.

### DIFF
--- a/3rdparty/pascalscript/Source/uPSRuntime.pas
+++ b/3rdparty/pascalscript/Source/uPSRuntime.pas
@@ -12519,6 +12519,8 @@ begin
       FDataPtr := nil;
     end;
     FCapacity := 0;
+    // @SoldatPatch
+    Exit;
   end;
   GetMem(p, Value);
   if FDataPtr <> nil then

--- a/server/Main.pas
+++ b/server/Main.pas
@@ -67,14 +67,11 @@ end;
 // The linux server can be killed with
 // 'kill -TERM(15) <pid>' or 'kill -QUIT(3) <pid>' and
 // it will clean itself up, instead of forcing you to use 'KILL -KILL(9) <pid>'
-type
-  TSigActionType = PSigActionRec;
-
 var
-  FSIGTERM, FSIGTERMOLD: TSigActionType;  // Place holders for the SIG Actions
-  FSIGQUIT, FSIGQUITOLD: TSigActionType;
-  FSIGINT,  FSIGINTOLD:  TSigActionType;
-  FSIGPIPE, FSIGPIPEOLD: TSigActionType;
+  FSIGTERM, FSIGTERMOLD: SigActionRec; // Place holders for the SIG Actions
+  FSIGQUIT, FSIGQUITOLD: SigActionRec;
+  FSIGINT,  FSIGINTOLD:  SigActionRec;
+  FSIGPIPE, FSIGPIPEOLD: SigActionRec;
 
 procedure HandleSig(Signal: Longint); cdecl;
 begin
@@ -105,86 +102,74 @@ end;
 procedure SetSigHooks;
 begin
   // Get the SIGTERM signal
-  New(FSIGTERM);
-  New(FSIGTERMOLD);
+  FillChar(FSIGTERM.Sa_Mask, SizeOf(FSIGTERM.sa_mask), #0);
+  FillChar(FSIGTERMOLD.Sa_Mask, SizeOf(FSIGTERMOLD.sa_mask), #0);
 
-  FillChar(FSIGTERM^.Sa_Mask, SizeOf(FSIGTERM^.sa_mask), #0);
-  FillChar(FSIGTERMOLD^.Sa_Mask, SizeOf(FSIGTERMOLD^.sa_mask), #0);
-
-  FSIGTERM^.sa_Handler := SigActionHandler(@HandleSig);
-  FSIGTERM^.Sa_Flags := 0;
+  FSIGTERM.sa_Handler := SigActionHandler(@HandleSig);
+  FSIGTERM.Sa_Flags := 0;
 
   {$IFDEF Linux}  // Linux specific
-  FSIGTERM^.Sa_Restorer := nil;
+  FSIGTERM.Sa_Restorer := nil;
   {$ENDIF}
 
-  if fpSigAction(SIGTERM, FSIGTERM, FSIGTERMOLD) <> 0 then
+  if fpSigAction(SIGTERM, @FSIGTERM, @FSIGTERMOLD) <> 0 then
     raise Exception.Create('SIGAction failed');
 
   // Get the SIGINT signal
-  New(FSIGINT);
-  New(FSIGINTOLD);
+  FillChar(FSIGINT.Sa_Mask, SizeOf(FSIGINT.Sa_Mask), #0);
+  FillChar(FSIGINTOLD.Sa_Mask, SizeOf(FSIGINTOLD.Sa_Mask), #0);
 
-  FillChar(FSIGINT^.Sa_Mask, SizeOf(FSIGINT^.Sa_Mask), #0);
-  FillChar(FSIGINTOLD^.Sa_Mask, SizeOf(FSIGINTOLD^.Sa_Mask), #0);
-
-  FSIGINT^.sa_Handler := SigActionHandler(@HandleSig);
-  FSIGINT^.Sa_Flags := 0;
+  FSIGINT.sa_Handler := SigActionHandler(@HandleSig);
+  FSIGINT.Sa_Flags := 0;
 
   {$IFDEF Linux}  // Linux specific
-  FSIGINT^.Sa_Restorer := nil;
+  FSIGINT.Sa_Restorer := nil;
   {$ENDIF}
 
-  if fpSigAction(SIGINT, FSIGINT, FSIGINTOLD) <> 0 then
+  if fpSigAction(SIGINT, @FSIGINT, @FSIGINTOLD) <> 0 then
     raise Exception.Create('SIGAction failed');
 
   // Get the SIGQUIT signal
-  New(FSIGQUIT);
-  New(FSIGQUITOLD);
+  FillChar(FSIGQUIT.Sa_Mask, SizeOf(FSIGQUIT.sa_mask), #0);
+  FillChar(FSIGQUITOLD.Sa_Mask, SizeOf(FSIGQUITOLD.sa_mask), #0);
 
-  FillChar(FSIGQUIT^.Sa_Mask, SizeOf(FSIGQUIT^.sa_mask), #0);
-  FillChar(FSIGQUITOLD^.Sa_Mask, SizeOf(FSIGQUITOLD^.sa_mask), #0);
-
-  FSIGQUIT^.sa_Handler := SigActionHandler(@HandleSig);
-  FSIGQUIT^.Sa_Flags := 0;
+  FSIGQUIT.sa_Handler := SigActionHandler(@HandleSig);
+  FSIGQUIT.Sa_Flags := 0;
 
   {$IFDEF Linux}  // Linux specific
-  FSIGQUIT^.Sa_Restorer := nil;
+  FSIGQUIT.Sa_Restorer := nil;
   {$ENDIF}
 
-  if fpSigAction(SIGQUIT, FSIGQUIT, FSIGQUITOLD) <> 0 then
+  if fpSigAction(SIGQUIT, @FSIGQUIT, @FSIGQUITOLD) <> 0 then
     raise Exception.Create('SIGAction failed');
 
   // Get the SIGPIPE signal
-  New(FSIGPIPE);
-  New(FSIGPIPEOLD);
+  FillChar(FSIGPIPE.Sa_Mask, SizeOf(FSIGPIPE.sa_mask), #0);
+  FillChar(FSIGPIPEOLD.Sa_Mask, SizeOf(FSIGPIPEOLD.sa_mask), #0);
 
-  FillChar(FSIGPIPE^.Sa_Mask, SizeOf(FSIGPIPE^.sa_mask), #0);
-  FillChar(FSIGPIPEOLD^.Sa_Mask, SizeOf(FSIGPIPEOLD^.sa_mask), #0);
-
-  FSIGPIPE^.sa_Handler := SigActionHandler(@HandleSig);
-  FSIGPIPE^.Sa_Flags := 0;
+  FSIGPIPE.sa_Handler := SigActionHandler(@HandleSig);
+  FSIGPIPE.Sa_Flags := 0;
 
   {$IFDEF Linux}  // Linux specific
-  FSIGPIPEOLD^.Sa_Restorer := nil;
+  FSIGPIPEOLD.Sa_Restorer := nil;
   {$ENDIF}
 
-  if fpSigAction(SIGPIPE, FSIGPIPE, FSIGPIPEOLD) <> 0 then
+  if fpSigAction(SIGPIPE, @FSIGPIPE, @FSIGPIPEOLD) <> 0 then
     raise Exception.Create('SIGAction failed');
 end;
 
 procedure ClearSigHooks;
 begin
-  if fpSigAction(SIGTERM,  FSIGTERMOLD, nil) <> 0 then
+  if fpSigAction(SIGTERM, @FSIGTERMOLD, nil) <> 0 then
     raise Exception.Create('SIGAction failed');
 
-  if fpSigAction(SIGINT,  FSIGINTOLD, nil) <> 0 then
+  if fpSigAction(SIGINT, @FSIGINTOLD, nil) <> 0 then
     raise Exception.Create('SIGAction failed');
 
-  if fpSigAction(SIGQUIT,  FSIGQUITOLD, nil) <> 0 then
+  if fpSigAction(SIGQUIT, @FSIGQUITOLD, nil) <> 0 then
     raise Exception.Create('SIGAction failed');
 
-  if fpSigAction(SIGPIPE,  FSIGPIPEOLD, nil) <> 0 then
+  if fpSigAction(SIGPIPE, @FSIGPIPEOLD, nil) <> 0 then
     raise Exception.Create('SIGAction failed');
 end;
 {$ENDIF}

--- a/server/scriptcore/ScriptCore3.pas
+++ b/server/scriptcore/ScriptCore3.pas
@@ -85,7 +85,6 @@ type
     FDebug: Boolean;
     FGameMod: Boolean;
     FSpawnPoint: TScriptSpawnPointAPI;
-    FCore: TScriptCore3API;
     FFile: TScriptFileAPI;
 
     FOnWeaponChangeNewPrimary: TScriptWeaponChange;
@@ -337,7 +336,6 @@ begin
   Self.FUnit := TScriptUnitAPI.Create(Self);
   Self.FMap := TScriptMapAPI.Create(Self);
   Self.FSpawnPoint := TScriptSpawnPointAPI.Create(Self);
-  Self.FCore := TScriptCore3API.Create(Self);
   Self.FFile := TScriptFileAPI.Create(Self);
 
   // Workaround for OnWeaponChange: It needs 2 new objects,

--- a/server/scriptcore/ScriptCore3.pas
+++ b/server/scriptcore/ScriptCore3.pas
@@ -297,9 +297,14 @@ begin
     FunctionName := Func.ExportName;
   if Assigned(Self.FUnit.ScriptUnit.OnException) then
   begin
-    try
-      TPascalDebugger(Sender).GetPosition(UnitName, Col, Row, ProcNo, Position);
-    except
+    if Self.Debug then
+    begin
+      try
+        TPascalDebugger(Sender).GetPosition(UnitName, Col, Row, ProcNo, Position);
+      except
+        on e: Exception do
+          Self.WriteInfo('Exception trying to get debug info: ' + e.Message);
+      end;
     end;
     try
       Self.CallEvent(Self.FUnit.ScriptUnit.OnException,

--- a/server/scriptcore/ScriptGame.pas
+++ b/server/scriptcore/ScriptGame.pas
@@ -117,6 +117,7 @@ type
     function GetBanLists: TScriptBanLists;
   public
     constructor Create;
+    destructor Destroy; override;
     procedure Shutdown;
     procedure StartVoteKick(ID: Byte; Reason: string);
     procedure StartVoteMap(Name: string);
@@ -180,6 +181,7 @@ type
     FGame: TScriptGame;
   public
     constructor Create(ScriptCore3: TScript);
+    destructor Destroy; override;
     procedure CompilerRegister(Compiler: TPascalCompiler); override;
     procedure RuntimeRegisterApi(Exec: TPascalExec); override;
     procedure RuntimeRegisterVariables(Exec: TPascalExec); override;
@@ -519,6 +521,17 @@ begin
     Self.FTeams[i] := TScriptTeam.Create(i);
   Self.FMapsList := TScriptMapsList.Create;
   Self.FBanLists := TScriptBanLists.Create;
+end;
+
+destructor TScriptGame.Destroy;
+var
+  i: Integer;
+begin
+  for i := Low(Self.FTeams) to High(Self.FTeams) do
+    Self.FTeams[i].Free;
+  Self.FMapsList.Free;
+  Self.FBanLists.Free;
+  inherited;
 end;
 
 procedure TScriptGame.Shutdown;
@@ -907,6 +920,12 @@ end;
 constructor TScriptGameAPI.Create(ScriptCore3: TScript);
 begin
   inherited Create(ScriptCore3);
+end;
+
+destructor TScriptGameAPI.Destroy;
+begin
+  FreeAndNil(Self.FGame);
+  inherited;
 end;
 
 procedure TScriptGameAPI.CompilerRegister(Compiler: TPascalCompiler);

--- a/server/scriptcore/ScriptGlobal.pas
+++ b/server/scriptcore/ScriptGlobal.pas
@@ -41,6 +41,7 @@ type
     FGlobal: TScriptGlobal;
   public
     constructor Create(Script: TScript);
+    destructor Destroy; override;
     procedure CompilerRegister(Compiler: TPascalCompiler); override;
     procedure RuntimeRegisterApi(Exec: TPascalExec); override;
     procedure RuntimeRegisterVariables(Exec: TPascalExec); override;
@@ -73,6 +74,12 @@ constructor TScriptGlobalAPI.Create(Script: TScript);
 begin
   inherited Create(Script);
   Self.FGlobal := TScriptGlobal.Create;
+end;
+
+destructor TScriptGlobalAPI.Destroy;
+begin
+  FreeAndNil(Self.FGlobal);
+  inherited;
 end;
 
 procedure TScriptGlobalAPI.CompilerRegister(Compiler: TPascalCompiler);

--- a/server/scriptcore/ScriptMap.pas
+++ b/server/scriptcore/ScriptMap.pas
@@ -49,6 +49,7 @@ type
     function GetName: string;
   public
     constructor Create;
+    destructor Destroy; override;
     function GetFlag(ID: Integer): TScriptActiveFlag;
     function RayCast(x1, y1, x2, y2: Single; Player: Boolean = False;
       Flag: Boolean = False; Bullet: Boolean = True; CheckCollider: Boolean = False;
@@ -80,6 +81,7 @@ type
     FMap: TScriptMap;
   public
     //constructor Create(ScriptCore3: TScript);
+    destructor Destroy; override;
     procedure CompilerRegister(Compiler: TPascalCompiler); override;
     procedure RuntimeRegisterApi(Exec: TPascalExec); override;
     procedure RuntimeRegisterVariables(Exec: TPascalExec); override;
@@ -103,6 +105,20 @@ begin
   for I := 1 to MAX_SPAWNPOINTS do
     Self.FSpawnpoints[I] :=
       TScriptActiveSpawnPoint.CreateActive(I, Map.SpawnPoints[I]);
+end;
+
+destructor TScriptMap.Destroy;
+var
+  i: Integer;
+begin
+  for i := Low(Self.FObjects) to High(Self.FObjects) do
+    Self.FObjects[i].Free;
+  for i := Low(Self.FBullets) to High(Self.FBullets) do
+    Self.FBullets[i].Free;
+  for i := Low(Self.FSpawnpoints) to High(Self.FSpawnpoints) do
+    Self.FSpawnpoints[i].Free;
+  for i := Low(Self.FLastFlagObjs) to High(Self.FLastFlagObjs) do
+    Self.FLastFlagObjs[i].Free;
 end;
 
 function TScriptMap.GetObject(ID: Byte): TScriptActiveObject;
@@ -364,6 +380,12 @@ end;
 procedure OnAfterMapWriteHelper(Self: TScriptMap; const Result: TOnAfterMapChange);
 begin
   Self.OnAfterMapChange := Result;
+end;
+
+destructor TScriptMapAPI.Destroy;
+begin
+  FreeAndNil(FMap);
+  inherited;
 end;
 
 procedure TScriptMapAPI.CompilerRegister(Compiler: TPascalCompiler);

--- a/server/scriptcore/ScriptMath.pas
+++ b/server/scriptcore/ScriptMath.pas
@@ -48,6 +48,7 @@ type
   private
     FMath: TScriptMath;
   public
+    destructor Destroy; override;
     procedure CompilerRegister(Compiler: TPascalCompiler); override;
     procedure RuntimeRegisterApi(Exec: TPascalExec); override;
     procedure RuntimeRegisterVariables(Exec: TPascalExec); override;
@@ -208,6 +209,11 @@ end;
 procedure ScriptMathGetPiHelper(Self: TScriptMath; var Result: Extended);
 begin
   Result := Self.Pi;
+end;
+
+destructor TScriptMathAPI.Destroy;
+begin
+  FreeAndNil(Self.FMath);
 end;
 
 procedure TScriptMathAPI.CompilerRegister(Compiler: TPascalCompiler);

--- a/server/scriptcore/ScriptObject.pas
+++ b/server/scriptcore/ScriptObject.pas
@@ -104,7 +104,7 @@ end;
 
 destructor TScriptNewObject.Destroy;
 begin
-  Freemem(Self.FObj, SizeOf(TThing));
+  Dispose(Self.FObj);
 end;
 
 procedure TScriptNewObject.SetStyle(Style: Byte);

--- a/server/scriptcore/ScriptPlayer.pas
+++ b/server/scriptcore/ScriptPlayer.pas
@@ -173,6 +173,7 @@ type
     function GetDummy: Boolean;
   public
     constructor Create;
+    destructor Destroy; override;
     property Name: string read GetName write SetName;
     property Team: Byte read GetTeam write SetTeam;
     property Health: Single read GetHealth write SetHealth;
@@ -378,13 +379,17 @@ begin
   Self.FSpritePtr^.Brain.WaypointTimeoutCounter := WAYPOINTTIMEOUT;
 end;
 
+destructor TScriptNewPlayer.Destroy;
+begin
+  Self.FSpritePtr^.Player.Free;
+  Dispose(Self.FSpritePtr);
+  Inherited;
+end;
+
 destructor TScriptPlayer.Destroy;
 begin
-  if Self.FSpritePtr <> nil then
-    Self.FSpritePtr^.Player.Free;
   Self.FPrimary.Free;
   Self.FSecondary.Free;
-  FreeMem(Self.FSpritePtr, SizeOf(TSprite));
 end;
 
 function TScriptPlayer.GetSprite: TSprite;

--- a/server/scriptcore/ScriptPlayer.pas
+++ b/server/scriptcore/ScriptPlayer.pas
@@ -2399,7 +2399,7 @@ begin
     RegisterPropertyHelper(@ScriptPlayerGetDummy, @ScriptPlayerSetDummy, 'Dummy');
   end;
 
-  with Exec.AddClass(TScriptPlayer, 'TNewPlayer') do
+  with Exec.AddClass(TScriptNewPlayer, 'TNewPlayer') do
   begin
     RegisterConstructor(@TScriptNewPlayer.Create, 'Create');
     RegisterMethod(@TScriptNewPlayer.Free, 'Free');
@@ -2427,7 +2427,7 @@ begin
     RegisterPropertyHelper(@ScriptNewPlayerGetDummy, @ScriptNewPlayerSetDummy, 'Dummy');
   end;
 
-  with Exec.AddClass(TScriptPlayer, 'TActivePlayer') do
+  with Exec.AddClass(TScriptActivePlayer, 'TActivePlayer') do
   begin
     RegisterMethod(@TScriptActivePlayer.Ban, 'Ban');
     RegisterMethod(@TScriptActivePlayer.Say, 'Say');

--- a/server/scriptcore/ScriptPlayers.pas
+++ b/server/scriptcore/ScriptPlayers.pas
@@ -53,6 +53,7 @@ type
     FPlayers: TScriptPlayers;
 
   public
+    destructor Destroy; override;
     procedure CompilerRegister(Compiler: TPascalCompiler); override;
     procedure RuntimeRegisterApi(Exec: TPascalExec); override;
     procedure RuntimeRegisterVariables(Exec: TPascalExec); override;
@@ -83,10 +84,10 @@ end;
 
 destructor TScriptPlayers.Destroy;
 var
-  I: Byte;
+  i: Integer;
 begin
-  for I := 1 to MAX_SPRITES do
-    FPlayers[I].Free;
+  for i := Low(FPlayers) to High(FPlayers) do
+    FPlayers[i].Free;
   FActivePlayers.Free;
 end;
 
@@ -237,6 +238,12 @@ procedure ActivePlayerListCountHelper(Self: TFPGList<TScriptActivePlayer>;
   var Result: Integer);
 begin
   Result := Self.Count;
+end;
+
+destructor TScriptPlayersAPI.Destroy;
+begin
+  FreeAndNil(FPlayers);
+  inherited;
 end;
 
 procedure TScriptPlayersAPI.CompilerRegister(Compiler: TPascalCompiler);

--- a/server/scriptcore/ScriptSpawnPoint.pas
+++ b/server/scriptcore/ScriptSpawnPoint.pas
@@ -102,7 +102,7 @@ end;
 
 destructor TScriptNewSpawnPoint.Destroy;
 begin
-  Freemem(Self.FSpawnPoint, SizeOf(TMapSpawnPoint));
+  Dispose(Self.FSpawnPoint);
 end;
 
 constructor TScriptActiveSpawnPoint.CreateActive(ID: Byte; var Spawn: TMapSpawnPoint);

--- a/server/scriptcore/ScriptUnit.pas
+++ b/server/scriptcore/ScriptUnit.pas
@@ -56,6 +56,7 @@ type
     FUnit: TScriptUnit;
   public
     constructor Create(Script: TScript);
+    destructor Destroy; override;
     procedure CompilerRegister(Compiler: TPascalCompiler); override;
     procedure RuntimeRegisterApi(Exec: TPascalExec); override;
     procedure RuntimeRegisterVariables(Exec: TPascalExec); override;
@@ -119,6 +120,12 @@ constructor TScriptUnitAPI.Create(Script: TScript);
 begin
   inherited Create(Script);
   Self.FUnit := TScriptUnit.Create(Script);
+end;
+
+destructor TScriptUnitAPI.Destroy;
+begin
+  FreeAndNil(Self.FUnit);
+  inherited;
 end;
 
 procedure TScriptUnitAPI.CompilerRegister(Compiler: TPascalCompiler);

--- a/server/scriptcore/ScriptWeapon.pas
+++ b/server/scriptcore/ScriptWeapon.pas
@@ -101,7 +101,7 @@ end;
 
 destructor TScriptNewWeapon.Destroy;
 begin
-  Freemem(Self.FWeapon, SizeOf(TGun));
+  Dispose(Self.FWeapon);
 end;
 
 constructor TScriptWeaponChange.Create;
@@ -113,7 +113,7 @@ end;
 
 destructor TScriptWeaponChange.Destroy;
 begin
-  Freemem(Self.FWeapon, SizeOf(TGun));
+  Dispose(Self.FWeapon);
 end;
 
 procedure TScriptWeaponChange.SetAmmo(Ammo: Byte);

--- a/server/scriptcore/test/bft/bft.pas
+++ b/server/scriptcore/test/bft/bft.pas
@@ -22,7 +22,7 @@
 //
 
 const
-  COMMANDS_COLOR = $FF9966;
+  COMMANDS_COLOR        = $FF9966;
   INFO_CONSOLE_COLOR    = $EEEEEE;
   TEST_CONSOLE_COLOR    = $AAAAFF;
   PASS_CONSOLE_COLOR    = $88FF88;
@@ -508,7 +508,6 @@ var
   VPos, VVel: TVector;
   NewPlayer: TNewPlayer;
   NewObject: TNewMapObject;
-  //Primary, Secondary: TNewWeapon;
   CheckPlayer, LastBot: TActivePlayer;
 begin
   SLog('==========================================================', INFO);

--- a/shared/Demo.pas
+++ b/shared/Demo.pas
@@ -456,4 +456,12 @@ begin
   {$ENDIF}
 end;
 
+finalization
+begin
+  DemoRecorder.Free;
+  {$IFNDEF SERVER}
+  DemoPlayer.Free;
+  {$ENDIF}
+end;
+
 end.

--- a/shared/network/Net.pas
+++ b/shared/network/Net.pas
@@ -1551,7 +1551,7 @@ begin
   if FPollGroup <> k_HSteamNetPollGroup_Invalid then
     NetworkingSockets.DestroyPollGroup(FPollGroup);
 
-  Players.Clear;
+  Players.Free;
 
   Inherited;
 end;


### PR DESCRIPTION
- Clean up ScriptCore3 memory, fix a few leaks.
- Some other smaller stuff like freeing `DemoRecorder`, `DemoPlayer`, `Players`.

Just some steps towards getting a totally clean bill of health from valgrind.