### PR TITLE
Idle server

### DIFF
--- a/server/Server.pas
+++ b/server/Server.pas
@@ -153,6 +153,7 @@ var
   sv_antimassflag: TBooleanCvar;
   sv_healthcooldown: TIntegerCvar;
   sv_teamcolors: TBooleanCvar;
+  sv_pauseonidle: TBooleanCvar;
 
   net_port: TIntegerCvar;
   net_ip: TStringCvar;

--- a/server/ServerLoop.pas
+++ b/server/ServerLoop.pas
@@ -38,6 +38,12 @@ begin
     AdminServer.ProcessCommands();
   {$ENDIF}
 
+  if sv_pauseonidle.Value and ((PlayersNum - BotsNum) <= 0) then
+  begin
+    Sleep(100);
+    Exit;
+  end;
+
   for MainControl := 1 to (Ticktime - ticktimeLast) do
   begin  // frame rate independant code
     ticks := ticks + 1;

--- a/server/ServerLoop.pas
+++ b/server/ServerLoop.pas
@@ -37,6 +37,9 @@ begin
   if AdminServer <> nil then
     AdminServer.ProcessCommands();
   {$ENDIF}
+  {$IFDEF STEAM}
+  RunManualCallbacks();
+  {$ENDIF}
 
   if sv_pauseonidle.Value and ((PlayersNum - BotsNum) <= 0) then
   begin
@@ -58,14 +61,10 @@ begin
     ScrptDispatcher.OnClockTick();
     {$ENDIF}
 
-    {$IFDEF STEAM}
-    RunManualCallbacks();
-    {$ENDIF}
     // Flood Nums Cancel
     if MainTickCounter mod 1000 = 0 then
       for j := 1 to MAX_FLOODIPS do
         FloodNum[j] := 0;
-
 
     // Warnings Cancel
     if MainTickCounter mod (MINUTE * 5) = 0 then

--- a/server/ServerLoop.pas
+++ b/server/ServerLoop.pas
@@ -60,6 +60,10 @@ begin
     RunManualCallbacks();
     {$ENDIF}
 
+    {$IFDEF SCRIPT}
+    ScrptDispatcher.OnIdle();
+    {$ENDIF}
+
     Sleep(100);
     Exit;
   end;

--- a/server/ServerLoop.pas
+++ b/server/ServerLoop.pas
@@ -40,9 +40,6 @@ begin
   if AdminServer <> nil then
     AdminServer.ProcessCommands();
   {$ENDIF}
-  {$IFDEF STEAM}
-  RunManualCallbacks();
-  {$ENDIF}
 
   // Run every 60 seconds
   if (GetTickCount64 - LastMinuteTick) >= 60000 then
@@ -59,6 +56,10 @@ begin
 
   if sv_pauseonidle.Value and ((PlayersNum - BotsNum) <= 0) then
   begin
+    {$IFDEF STEAM}
+    RunManualCallbacks();
+    {$ENDIF}
+
     Sleep(100);
     Exit;
   end;
@@ -75,6 +76,10 @@ begin
 
     {$IFDEF SCRIPT}
     ScrptDispatcher.OnClockTick();
+    {$ENDIF}
+
+    {$IFDEF STEAM}
+    RunManualCallbacks();
     {$ENDIF}
 
     // Flood Nums Cancel

--- a/server/ServerLoop.pas
+++ b/server/ServerLoop.pas
@@ -20,6 +20,9 @@ uses
   NetworkServerGame, NetworkServerSprite, NetworkServerThing,
   NetworkServerConnection, NetworkServerHeartbeat;
 
+var
+  LastMinuteTick: QWord = 0;
+
 procedure AppOnIdle;
 var
   MainControl: Integer;
@@ -40,6 +43,14 @@ begin
   {$IFDEF STEAM}
   RunManualCallbacks();
   {$ENDIF}
+
+  // Run every 60 seconds
+  if (GetTickCount64 - LastMinuteTick) >= 60000 then
+  begin
+    LastMinuteTick := GetTickCount64;
+    if sv_lobby.Value then
+        LobbyThread := TLobbyThread.Create;
+  end;
 
   if sv_pauseonidle.Value and ((PlayersNum - BotsNum) <= 0) then
   begin
@@ -459,12 +470,6 @@ begin
 
     if MainTickCounter mod (SECOND * 30) = 0 then
       DropIP := '';  // Clear temporary firewall IP
-
-    if MainTickCounter mod MINUTE = 0 then
-    begin
-      if sv_lobby.Value then
-          LobbyThread := TLobbyThread.Create;
-    end;
 
     // *BAN*
     // Ban Timers v2

--- a/server/ServerLoop.pas
+++ b/server/ServerLoop.pas
@@ -49,7 +49,12 @@ begin
   begin
     LastMinuteTick := GetTickCount64;
     if sv_lobby.Value then
-        LobbyThread := TLobbyThread.Create;
+      LobbyThread := TLobbyThread.Create;
+
+    // *BAN*
+    // Ban Timers v2
+    UpdateIPBanList;
+    UpdateHWBanList;
   end;
 
   if sv_pauseonidle.Value and ((PlayersNum - BotsNum) <= 0) then
@@ -470,14 +475,6 @@ begin
 
     if MainTickCounter mod (SECOND * 30) = 0 then
       DropIP := '';  // Clear temporary firewall IP
-
-    // *BAN*
-    // Ban Timers v2
-    if MainTickCounter mod MINUTE = 0 then
-    begin
-      UpdateIPBanList;
-      UpdateHWBanList;
-    end;
 
     if MainTickCounter mod MINUTE = 0 then
       for j := 1 to MAX_SPRITES do

--- a/server/scriptcore/Script.pas
+++ b/server/scriptcore/Script.pas
@@ -58,6 +58,7 @@ type
     // EVENTS
     procedure OnActivateServer; virtual;
     procedure OnClockTick; virtual;
+    procedure OnIdle; virtual;
     // procedure OnScriptShutdown(ServerShutdown: Boolean); virtual;
 
     function OnRequestGame(Ip, Hw: string; Port: Word; State: Byte;
@@ -125,6 +126,10 @@ begin
 end;
 
 procedure TScript.OnClockTick;
+begin
+end;
+
+procedure TScript.OnIdle;
 begin
 end;
 {$PUSH}

--- a/server/scriptcore/ScriptCore.pas
+++ b/server/scriptcore/ScriptCore.pas
@@ -54,6 +54,7 @@ type
     function CallFunc(const Params: array of Variant; FuncName: string;
       DefaultReturn: Variant): Variant; override;
     procedure OnClockTick; override;
+    procedure OnIdle; override;
     //procedure OnScriptShutdown(ServerShutdown: Boolean);
 
     function OnRequestGame(Ip, Hw: string; Port: Word; State: Byte;
@@ -286,6 +287,12 @@ begin
       if Self.FErrorCount > 0 then
         Self.FErrorCount := Self.FErrorCount - 1;
   end;
+end;
+
+procedure TScriptCore.OnIdle;
+begin
+  if not Self.FDisabled then
+    Self.CallFunc([], 'OnIdle', 0);
 end;
 
 //procedure OnScriptShutdown(ServerShutdown: Boolean);

--- a/server/scriptcore/ScriptCore3.pas
+++ b/server/scriptcore/ScriptCore3.pas
@@ -113,6 +113,7 @@ type
       const Params: array of Variant): Variant; overload;
     // EVENTS
     procedure OnClockTick; override;
+    procedure OnIdle; override;
     function OnRequestGame(Ip, Hw: string; Port: Word; State: Byte;
       Forwarded: Boolean; Password: string): Integer; override;
     function OnBeforeJoinTeam(Id, Team, OldTeam: Byte): ShortInt; override;
@@ -602,6 +603,24 @@ begin
         (Self.FGame.Game.TickThreshold <> 0) and (MainTickCounter mod
         Self.FGame.Game.TickThreshold = 0) then
         Self.CallEvent(Self.FGame.Game.OnClockTick, [MainTickCounter]);
+    except
+      on e: Exception do
+        Self.HandleException(e);
+    end;
+  finally
+    Self.Lock.Release;
+  end;
+end;
+
+procedure TScriptCore3.OnIdle;
+begin
+  try
+    Self.Lock.Acquire;
+    try
+      if Assigned(Self.FAdapter) then
+        Self.FAdapter.OnIdle;
+      if Assigned(Self.FGame.Game.OnIdle) then
+        Self.CallEvent(Self.FGame.Game.OnIdle, []);
     except
       on e: Exception do
         Self.HandleException(e);

--- a/server/scriptcore/ScriptCoreAPIAdapter.pas
+++ b/server/scriptcore/ScriptCoreAPIAdapter.pas
@@ -28,6 +28,7 @@ type
 
     // EVENTS
     procedure OnClockTick;
+    procedure OnIdle;
 
     function OnRequestGame(Ip: string; Port: Word; State: Byte;
       Forwarded: Boolean; Password: string): Integer;
@@ -419,6 +420,12 @@ begin
   if not Self.Disabled and (Self.AppOnIdleTimer > 0) and
     (MainTickCounter mod Self.AppOnIdleTimer = 0) then
     Self.FScript.CallFunc([MainTickCounter], 'AppOnIdle', 0);
+end;
+
+procedure TScriptCoreAPIAdapter.OnIdle;
+begin
+  if not Self.Disabled then
+    Self.FScript.CallFunc([], 'OnIdle', 0);
 end;
 
 function TScriptCoreAPIAdapter.OnRequestGame(Ip: string; Port: Word;

--- a/server/scriptcore/ScriptDispatcher.pas
+++ b/server/scriptcore/ScriptDispatcher.pas
@@ -130,6 +130,7 @@ type
 
     procedure OnActivateServer; override;
     procedure OnClockTick; override;
+    procedure OnIdle; override;
     // procedure OnScriptShutdown(ServerShutdown: Boolean);
 
     function OnRequestGame(Ip, Hw: string; Port: Word; State: Byte;
@@ -434,6 +435,20 @@ begin
     Self.DoLock;
     for I := Self.FScripts.Count - 1 downto 0 do
       TScript(Self.FScripts[I]).OnClockTick;
+  finally
+    Self.ProcessUnregisterQueue;
+    Self.DoUnlock;
+  end;
+end;
+
+procedure TScriptDispatcher.OnIdle;
+var
+  I: Integer;
+begin
+  try
+    Self.DoLock;
+    for I := Self.FScripts.Count - 1 downto 0 do
+      TScript(Self.FScripts[I]).OnIdle;
   finally
     Self.ProcessUnregisterQueue;
     Self.DoUnlock;

--- a/server/scriptcore/ScriptGame.pas
+++ b/server/scriptcore/ScriptGame.pas
@@ -35,6 +35,7 @@ uses
 
 type
   TOnClockTick = procedure(Ticks: Integer) of object;
+  TOnIdle = procedure() of object;
   TOnJoin = procedure(Player: TScriptActivePlayer; Team: TScriptTeam) of object;
   TOnLeave = procedure(Player: TScriptActivePlayer; Kicked: Boolean) of object;
   TOnRequest = function(Ip, Hw: string; Port: Word; State: Byte;
@@ -51,6 +52,7 @@ type
     FMapsList: TScriptMapsList;
     FBanLists: TScriptBanLists;
     FOnClockTick: TOnClockTick;
+    FOnIdle: TOnIdle;
     FOnJoin: TOnJoin;
     FOnLeave: TOnLeave;
     FOnRequest: TOnRequest;
@@ -166,6 +168,7 @@ type
     property ScriptMapsList: TScriptMapsList read GetMapsList;
     property ScriptBanLists: TScriptBanLists read GetBanLists;
     property OnClockTick: TOnClockTick read FOnClockTick write FOnClockTick;
+    property OnIdle: TOnIdle read FOnIdle write FOnIdle;
     property OnJoin: TOnJoin read FOnJoin write FOnJoin;
     property OnLeave: TOnLeave read FOnLeave write FOnLeave;
     property OnRequest: TOnRequest read FOnRequest write FOnRequest;
@@ -837,6 +840,16 @@ begin
   Self.OnClockTick := Result;
 end;
 
+procedure OnIdleReadHelper(Self: TScriptGame; var Result: TOnIdle);
+begin
+  Result := Self.OnIdle;
+end;
+
+procedure OnIdleWriteHelper(Self: TScriptGame; const Result: TOnIdle);
+begin
+  Self.OnIdle := Result;
+end;
+
 procedure OnRequestReadHelper(Self: TScriptGame; var Result: TOnRequest);
 begin
   Result := Self.OnRequest;
@@ -933,6 +946,7 @@ var
   AClass: TPascalCompiletimeClass;
 begin
   Compiler.AddType('TOnClockTickEvent', 'procedure(Ticks: Integer)');
+  Compiler.AddType('TOnIdleEvent', 'procedure()');
   Compiler.AddType('TOnJoinGameEvent', 'procedure(Player: TActivePlayer; Team: TTeam)');
   Compiler.AddType('TOnLeaveGameEvent',
     'procedure(Player: TActivePlayer; Kicked: Boolean)');
@@ -992,6 +1006,7 @@ begin
     RegisterProperty('MapsList', 'TMapsList', iptR);
     RegisterProperty('BanLists', 'TBanLists', iptR);
     RegisterProperty('OnClockTick', 'TOnClockTickEvent', iptRW);
+    RegisterProperty('OnIdle', 'TOnIdleEvent', iptRW);
     RegisterProperty('OnJoin', 'TOnJoinGameEvent', iptRW);
     RegisterProperty('OnLeave', 'TOnLeaveGameEvent', iptRW);
     RegisterProperty('OnRequest', 'TOnRequestEvent', iptRW);
@@ -1072,6 +1087,8 @@ begin
     RegisterPropertyHelper(@BanListsReadHelper, nil, 'BanLists');
     RegisterEventPropertyHelper(@OnClockTickReadHelper, @OnClockTickWriteHelper,
       'OnClockTick');
+    RegisterEventPropertyHelper(@OnIdleReadHelper, @OnIdleWriteHelper,
+      'OnIdle');
     RegisterEventPropertyHelper(@OnRequestReadHelper, @OnRequestWriteHelper,
       'OnRequest');
     RegisterEventPropertyHelper(@OnJoinReadHelper, @OnJoinWriteHelper, 'OnJoin');

--- a/server/scriptcore/test/bft/bft.pas
+++ b/server/scriptcore/test/bft/bft.pas
@@ -243,6 +243,13 @@ begin
   SLog('==========================================================', INFO);
 end;
 
+procedure MyOnIdle();
+begin
+  SLog('==========================================================', INFO);
+  SLog('OnIdle', INFO);
+  SLog('==========================================================', INFO);
+end;
+
 procedure MyOnBeforeMapChange(Map: String);
 begin
   SLog('==========================================================', INFO);
@@ -800,6 +807,7 @@ begin
   Result := 'Unknown failure';
 
   Game.OnClockTick := @MyOnClockTick;
+  Game.OnIdle := @MyOnIdle;
   Map.OnBeforeMapChange := @MyOnBeforeMapChange;
   Map.OnAfterMapChange := @MyOnAfterMapChange;
   Game.OnRequest := @MyOnRequest;

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -907,6 +907,7 @@ begin
   sv_antimassflag := TBooleanCvar.Add('sv_antimassflag', '', True, True, [CVAR_SERVER], nil);
   sv_healthcooldown := TIntegerCvar.Add('sv_healthcooldown', 'Amount of time (in seconds) a player needs to wait before he''s able to pick up a second medikit. Use 0 to disable', 2, 2, [CVAR_SERVER], nil, 0, 100);
   sv_teamcolors := TBooleanCvar.Add('sv_teamcolors', 'Overwrites shirt color in team games', True, True, [CVAR_SERVER], nil);
+  sv_pauseonidle := TBooleanCvar.Add('sv_pauseonidle', 'Pauses the server when no human players are connected', True, True, [CVAR_SERVER], nil);
 
   // Network cvars
   net_port := TIntegerCvar.Add('net_port', 'The port your server runs on, and player have to connect to', 23073, 23073, [CVAR_SERVER], nil, 0, 65535);


### PR DESCRIPTION
This PR is for issue #126. It will pause a server when no human players are connected. While paused, the server will still:
* Listen for players joining and resume game play.
* Make the required Steam callbacks at 10 Hz (this can be increased by decreasing the value used in the `Sleep` I added). Frequency increases to normal (60 Hz?) when no longer idle.
* Update the ban lists so that bans still expire while the server is paused.

Paused means that bots don't move, round timers don't run, scripts don't run, and stats aren't updated.

This behaviour is governed by a new CVar called `sv_pauseonidle` which defaults to `true`. When set to false, the server will keep running as before. This can be useful for funky scripts or doing stuff with bots.

I tested recording as well which seems to work as expected.

I think I caught everything, but obviously, I need a second look at this! Also, let me know if you'd still want the `OnIdle` event for scripts. I'm kind of assuming that setting `sv_pauseonidle` to `false` would take care of scripts wanting to keep running, but I might be missing edge cases here.