### PR TITLE
Update to FPC 3.2.2.

### DIFF
--- a/.github/workflows/opensoldat.yml
+++ b/.github/workflows/opensoldat.yml
@@ -16,7 +16,12 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install cmake git fpc libprotobuf-dev protobuf-compiler libssl-dev libsdl2-dev libopenal-dev libphysfs-dev libfreetype6 patchelf
+          sudo apt-get install cmake git libprotobuf-dev protobuf-compiler libssl-dev libsdl2-dev libopenal-dev libphysfs-dev libfreetype6 patchelf
+
+      - name: Install fpc
+        run: |
+          curl -L -o fpc.deb https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%202.2.2/fpc-laz_3.2.2-210709_amd64.deb/download
+          sudo apt-get install ./fpc.deb
 
       - name: Compile opensoldat
         run: |
@@ -86,7 +91,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: C:\fpc
-          key: freepascal
+          key: freepascal-3.2.2
 
       - name: Cache vcpkg
         id: vcpkg-cache
@@ -98,13 +103,12 @@ jobs:
       - name: Download freepascal
         if: steps.fpc.outputs.cache-hit != 'true'
         run: |
-          curl -o C:\fpc32.exe ftp://mirror.freemirror.org/pub/fpc/dist/3.0.4/i386-win32/fpc-3.0.4.i386-win32.exe
-          curl -o C:\fpc64.exe ftp://mirror.freemirror.org/pub/fpc/dist/3.0.4/i386-win32/fpc-3.0.4.i386-win32.cross.x86_64-win64.exe
+          curl -o C:\fpc64.exe ftp://mirror.freemirror.org/pub/fpc/dist/3.2.2/i386-win32/fpc-3.2.2.win32.and.win64.exe
+
 
       - name: Install freepascal
         if: steps.fpc.outputs.cache-hit != 'true'
         run: |
-           C:\fpc32.exe /silent /nocancel /suppressmsgboxes=no
            C:\fpc64.exe /silent /nocancel /suppressmsgboxes=no
         shell: cmd
 
@@ -115,7 +119,7 @@ jobs:
       - name: Build opensoldat
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-          set PATH=%PATH%;C:\fpc\3.0.4\bin\i386-win32
+          set PATH=%PATH%;C:\fpc\3.2.2\bin\i386-win32
           set OPENSSL_ROOT_DIR=C:\vcpkg\installed\x64-windows
           set PHYSFSDIR=C:\vcpkg\installed\x64-windows
           set BUILD_ID=%GITHUB_SHA:~0,8%

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains the source code of the so-called 1.8 version. Compared 
 
 ## Dependencies
 
-- FreePascal 3.0.4
+- FreePascal 3.2.2
 - SDL 2.0.12
 - OpenAL
 - FreeType 2.6.1
@@ -36,11 +36,11 @@ CMake 3.14+ is required.
 
 #### Build steps for Windows
 
-1. Install [freepascal 3.0.4](https://sourceforge.net/projects/freepascal/files/Win32/3.0.4/) (install `fpc-3.0.4.i386-win32.exe` first, and then `fpc-3.0.4.i386-win32.cross.x86_64-win64.exe`)
+1. Install [freepascal 3.2.2](https://sourceforge.net/projects/freepascal/files/Win32/3.2.2/fpc-3.2.2.win32.and.win64.exe/download)
 2. Install [Visual Studio with C++ compiler/build tools](https://visualstudio.microsoft.com/en) and [vcpkg](https://github.com/Microsoft/vcpkg)
 3. Open Developer command prompt for Visual Studio
 4. `vcpkg.exe --triplet x64-windows install sdl2 physfs openssl protobuf freetype openal-soft`
-5. `set PATH=%PATH%;C:\fpc\3.0.4\bin\i386-win32`
+5. `set PATH=%PATH%;C:\fpc\3.2.2\bin\i386-win32`
 6. `set OPENSSL_ROOT_DIR=C:\vcpkg\installed\x64-windows`
 7. `set PHYSFSDIR=C:\vcpkg\installed\x64-windows`
 8. `mkdir build`


### PR DESCRIPTION
Maintaining support for multiple compiler versions is tedious and error-prone, 3.2.2 has been out for a good while now, let's go with it.