### PR TITLE
Add /listplayers command for server

### DIFF
--- a/server/ServerCommands.pas
+++ b/server/ServerCommands.pas
@@ -927,8 +927,8 @@ var
   i: Integer;
   PlayerType: AnsiString;
 begin
-  MainConsole.Console('[ TYPE] Player name (K/D) [Team]', SERVER_MESSAGE_COLOR, Sender);
-  MainConsole.Console('--------------------------------', SERVER_MESSAGE_COLOR, Sender);
+  MainConsole.Console('[ TYPE] Player name              (K/D) [Team]', SERVER_MESSAGE_COLOR, Sender);
+  MainConsole.Console('---------------------------------------------', SERVER_MESSAGE_COLOR, Sender);
   for i := 1 to MAX_PLAYERS do
     if SortedPlayers[i].PlayerNum > 0 then
     begin
@@ -939,7 +939,7 @@ begin
           PlayerType := 'HUMAN'
       else
         PlayerType := ' BOT ';
-      MainConsole.Console(Format('[%5s] %s (%d/%d) [%d]', [
+      MainConsole.Console(Format('[%-5s] %-24s (%d/%d) [%d]', [
                                                             PlayerType,
                                                             Sprite[SortedPlayers[i].PlayerNum].Player.Name,
                                                             Sprite[SortedPlayers[i].PlayerNum].Player.Kills,

--- a/server/ServerCommands.pas
+++ b/server/ServerCommands.pas
@@ -922,6 +922,33 @@ begin
   DemoRecorder.StopRecord;
 end;
 
+procedure CommandListPlayers(Args: array of AnsiString; Sender: Byte);
+var
+  i: Integer;
+  PlayerType: AnsiString;
+begin
+  MainConsole.Console('[ TYPE] Player name (K/D) [Team]', SERVER_MESSAGE_COLOR, Sender);
+  MainConsole.Console('--------------------------------', SERVER_MESSAGE_COLOR, Sender);
+  for i := 1 to MAX_PLAYERS do
+    if SortedPlayers[i].PlayerNum > 0 then
+    begin
+      if Sprite[SortedPlayers[i].PlayerNum].Player.ControlMethod = HUMAN then
+        if Sprite[SortedPlayers[i].PlayerNum].Player.Team = 5 then
+          PlayerType := 'SPECT'
+        else
+          PlayerType := 'HUMAN'
+      else
+        PlayerType := ' BOT ';
+      MainConsole.Console(Format('[%5s] %s (%d/%d) [%d]', [
+                                                            PlayerType,
+                                                            Sprite[SortedPlayers[i].PlayerNum].Player.Name,
+                                                            Sprite[SortedPlayers[i].PlayerNum].Player.Kills,
+                                                            Sprite[SortedPlayers[i].PlayerNum].Player.Deaths,
+                                                            Sprite[SortedPlayers[i].PlayerNum].Player.Team
+                                                          ]), SERVER_MESSAGE_COLOR, Sender);
+    end;
+end;
+
 {$POP}
 
 procedure InitServerCommands();
@@ -981,6 +1008,7 @@ begin
   CommandAdd('votemap', CommandVotemap, 'votemap', [CMD_PLAYERONLY]);
   CommandAdd('record', CommandRecord, 'record demo', [CMD_ADMINONLY]);
   CommandAdd('stop', CommandStop, 'stop recording demo', [CMD_ADMINONLY]);
+  CommandAdd('listplayers', CommandListPlayers, 'list all current players', [CMD_ADMINONLY]);
 
   {$IFDEF SCRIPT}
   CommandAdd('recompile', CommandRecompile, 'Recompile all or specific script', [CMD_ADMINONLY]);


### PR DESCRIPTION
This PR adds a new admin command called `/listplayers`. It's handy for when connecting through a remote admin session. I didn't see an existing command to do something similar, but it's entirely possible I missed that.

The idea was to have something similar to what a client sees when pressing F1, but getting this information through a telnet session for admin purposes.