### PR TITLE
Small misc fixes #2

### DIFF
--- a/3rdparty/pascalscript/Source/uPSCompiler.pas
+++ b/3rdparty/pascalscript/Source/uPSCompiler.pas
@@ -13080,7 +13080,7 @@ end;
 {$IFNDEF PS_NOINTERFACES}
 const
   IUnknown_Guid: TGuid = (D1: 0; d2: 0; d3: 0; d4: ($c0,00,00,00,00,00,00,$46));
-  // @SoldatPatch
+  // @OpenSoldatPatch
   {$IFNDEF PS_NOIDISPATCH}
   IDispatch_Guid: Tguid = (D1: $20400; D2: $0; D3: $0; D4:($C0, $0, $0, $0, $0, $0, $0, $46));
   {$ENDIF}

--- a/3rdparty/pascalscript/Source/uPSR_dll.pas
+++ b/3rdparty/pascalscript/Source/uPSR_dll.pas
@@ -77,7 +77,7 @@ begin
   Dispose(p);
 end;
 
-// @SoldatPatch
+// @OpenSoldatPatch
 {$IFDEF UNIX}
 {$DEFINE UNIX_OR_KYLIX}
 {$ENDIF}
@@ -91,7 +91,7 @@ var
   h, i: Longint;
   ph: PLoadedDll;
   dllhandle: THandle;
-  // @SoldatPatch
+  // @OpenSoldatPatch
   {$IFNDEF UNIX_OR_KYLIX}
   loadwithalteredsearchpath: Boolean;
   {$ENDIF}
@@ -106,7 +106,7 @@ begin
   h := makehash(s2);
   s3 := copy(s, 1, pos(tbtchar(#0), s)-1);
   delete(s, 1, length(s3)+1);
-  // @SoldatPatch
+  // @OpenSoldatPatch
   {$IFNDEF UNIX_OR_KYLIX}
   loadwithalteredsearchpath := bytebool(s[3]);
   {$ENDIF}
@@ -130,7 +130,7 @@ begin
         exit;
       end;
 
-      // @SoldatPatch
+      // @OpenSoldatPatch
 
       {$IFDEF UNIX_OR_KYLIX}
       dllhandle := LoadLibrary(PChar(s2));

--- a/3rdparty/pascalscript/Source/uPSRuntime.pas
+++ b/3rdparty/pascalscript/Source/uPSRuntime.pas
@@ -3565,11 +3565,28 @@ end;
 function PSGetAnsiChar(Src: Pointer; aType: TPSTypeRec): tbtchar;
 var Res : tbtString;
 begin
-  Res := PSGetAnsiString(Src,aType);
-  if Length(Res) > 0 then
-    Result := Res[{$IFDEF DELPHI2009UP}Low(Res){$ELSE}1{$ENDIF}]
+  // @OpenSoldatPatch
+  case aType.BaseType of
+    btU8: Result := tbtchar(tbtu8(Src^));
+    btS8: Result := tbtchar(tbts8(Src^));
+    btU16: Result := tbtchar(tbtu16(Src^));
+    btS16: Result := tbtchar(tbts16(Src^));
+    btU32: Result := tbtchar(tbtu32(Src^));
+    btS32: Result := tbtchar(tbts32(Src^));
+    {$IFNDEF PS_NOINT64}
+    btS64: Result := tbtchar(tbts64(Src^));
+    {$ENDIF}
+    btChar: Result := tbtchar(tbtchar(Src^));
+    {$IFNDEF PS_NOWIDESTRING}
+    btWideChar: Result := tbtchar(tbtwidechar(Src^));
+    {$ENDIF}
   else
-    Result := #0;
+    Res := PSGetAnsiString(Src,aType);
+    if Length(Res) > 0 then
+      Result := Res[{$IFDEF DELPHI2009UP}Low(Res){$ELSE}1{$ENDIF}]
+    else
+      Result := #0;
+  end;
 end;
 
 function PSGetAnsiString(Src: Pointer; aType: TPSTypeRec): tbtString;
@@ -12519,7 +12536,7 @@ begin
       FDataPtr := nil;
     end;
     FCapacity := 0;
-    // @SoldatPatch
+    // @OpenSoldatPatch
     Exit;
   end;
   GetMem(p, Value);

--- a/client/Sound.pas
+++ b/client/Sound.pas
@@ -443,7 +443,7 @@ begin
 
   // decrease volume if grenade effect
   if (GrenadeEffectTimer > 0) and (SampleNum <> SFX_HUM) then
-    Dist := (Dist + 10) * (GrenadeEffectTimer div 7);
+    Dist := Dist + ((1.0 - Dist) * (Sqrt(GrenadeEffectTimer / 280)));
 
   if Dist > 1 then
     Exit;

--- a/server/ServerCommands.pas
+++ b/server/ServerCommands.pas
@@ -315,17 +315,15 @@ end;
 
 procedure CommandSay(Args: array of AnsiString; Sender: Byte);
 var
-  Name: String;
+  i: Integer;
+  Msg: String = '';
 begin
-  if Length(Args) = 1 then
+  for i := 1 to High(Args) do
+    Msg := Msg + Args[i] + ' ';
+  if Length(Msg) < 1 then
     Exit;
 
-  Name := Args[1];
-
-  if Length(Name) < 1 then
-    Exit;
-
-  ServerSendStringMessage(WideString(Name), ALL_PLAYERS, 255, MSGTYPE_PUB);
+  ServerSendStringMessage(WideString(Msg), ALL_PLAYERS, 255, MSGTYPE_PUB);
 end;
 
 procedure CommandKill(Args: array of AnsiString; Sender: Byte);

--- a/server/scriptcore/test/bft/bft.pas
+++ b/server/scriptcore/test/bft/bft.pas
@@ -948,7 +948,6 @@ var
 begin
   Result := 'Unknown failure';
 
-
   if StrToInt('420') <> 420 then
   begin
     Result := 'StrToInt';
@@ -1330,7 +1329,6 @@ begin
     Result := 'TStringList.Move';
     Exit;
   end;
-
 
   // 1: 'Uiop' 'Asdf'
   MyStringList.Delete(0);
@@ -1832,13 +1830,110 @@ begin
   Exit;
   {$ENDIF}
 
+  {$IFDEF NOT_DEFINED}
+  Result := 'Defines 3';
+  Exit;
+  {$ENDIF}
+
+  Result := '';
+end;
+
+//
+// CompilerAndRuntimeTest utils.
+//
+
+function ReturnsByte: Byte;
+begin
+  Result := 65;
+end;
+
+function ReturnsShortInt: ShortInt;
+begin
+  Result := 66;
+end;
+
+function ReturnsWord: Word;
+begin
+  Result := 67;
+end;
+
+function ReturnsSmallInt: SmallInt;
+begin
+  Result := 68;
+end;
+
+function ReturnsLongWord: LongWord;
+begin
+  Result := 69;
+end;
+
+function ReturnsInteger: Integer;
+begin
+  Result := 70;
+end;
+
+function ReturnsInt64: Int64;
+begin
+  Result := 71;
+end;
+
+function CompilerAndRuntimeTest: String;
+var
+  c: Char;
+begin
+  Result := 'Unknown failure';
+
+  // Issue #133: Implicit conversions to char.
+  c := Chr(ReturnsByte());
+  if c <> #65 then
+  begin
+    Result := 'Byte to Char implicit conversion';
+    Exit;
+  end;
+  c := Chr(ReturnsShortInt());
+  if c <> #66 then
+  begin
+    Result := 'ShortInt to Char implicit conversion';
+    Exit;
+  end;
+  c := Chr(ReturnsWord());
+  if c <> #67 then
+  begin
+    Result := 'Word to Char implicit conversion';
+    Exit;
+  end;
+  c := Chr(ReturnsSmallInt());
+  if c <> #68 then
+  begin
+    Result := 'SmallInt to Char implicit conversion';
+    Exit;
+  end;
+  c := Chr(ReturnsLongWord());
+  if c <> #69 then
+  begin
+    Result := 'LongWord to Char implicit conversion';
+    Exit;
+  end;
+  c := Chr(ReturnsInteger());
+  if c <> #70 then
+  begin
+    Result := 'Integer to Char implicit conversion';
+    Exit;
+  end;
+  c := Chr(ReturnsInt64());
+  if c <> #71 then
+  begin
+    Result := 'Int64 to Char implicit conversion';
+    Exit;
+  end;
+
   Result := '';
 end;
 
 procedure RunAllTests;
 var
   i, FailCount: Integer;
-  Tests: Array[0..6] of TTest;
+  Tests: Array[0..7] of TTest;
 begin
   // Register tests.
   Tests[0].Name := 'BanLists'; // ScriptBanLists.pas
@@ -1855,6 +1950,8 @@ begin
   Tests[5].Fn := @EventsTest;
   Tests[6].Name := 'Defines'; // Defines
   Tests[6].Fn := @DefinesTest;
+  Tests[7].Name := 'CompilerAndRuntime'; // PascalScript regression tests
+  Tests[7].Fn := @CompilerAndRuntimeTest;
 
   // Run tests.
   for i := Low(Tests) to High(Tests) do

--- a/shared/network/NetworkServerMessages.pas
+++ b/shared/network/NetworkServerMessages.pas
@@ -107,7 +107,7 @@ begin
   if MsgType = MSGTYPE_CMD then
   begin
     {$IFDEF SCRIPT}
-    if ScrptDispatcher.OnPlayerCommand(Player.SpriteNum, AnsiString(cs)) then
+    if ScrptDispatcher.OnPlayerCommand(Player.SpriteNum, '/' + AnsiString(cs)) then
       Exit;
     {$ENDIF}
     MainConsole.Console(cs + '(' + WideString(Player.IP) +

--- a/shared/network/NetworkServerMessages.pas
+++ b/shared/network/NetworkServerMessages.pas
@@ -52,7 +52,6 @@ begin
       if Sprite[i].Active and (Sprite[i].Player.ControlMethod = HUMAN) then
         if (ToNum = 0) or (i = ToNum) then
         begin
-        if not ((From = 255) and (ToNum = 0)) then // TODO: Simplify it.
           if (not ((MsgType = MSGTYPE_TEAM) or (MsgType = MSGTYPE_RADIO)) or (From = 255)) or
             (((MsgType = MSGTYPE_TEAM) or (MsgType = MSGTYPE_RADIO)) and Sprite[From].IsInSameTeam(Sprite[i])) then
             UDP.SendData(PChatMessage^, Size, Sprite[i].Player.peer, k_nSteamNetworkingSend_Reliable)


### PR DESCRIPTION
- Support implicit casting from integer types to `Char` in PascalScript Runtime. The PascalScript compiler happily accepts all integer types so the runtime should as well. #133 
- Fix `CommandSay`. It was broken by a special case in `ServerSendStringMessage`. I couldn't find any reason for it so I just removed it. #132 
- Add back prefix to player commands for SC3 backwards compatibility. #134 
- Fix grenade ear ringing effect. #129 