### PR TITLE
Fix ghost bots

### DIFF
--- a/server/scriptcore/ScriptPlayer.pas
+++ b/server/scriptcore/ScriptPlayer.pas
@@ -1137,7 +1137,7 @@ end;
 
 procedure TScriptActivePlayer.ChangeTeam(NewTeam: Byte; JoinType: TJoinType);
 begin
-    if not Self.Active then
+  if not Self.Active then
     Exit;
   if NewTeam > 5 then
     raise EArgumentException.Create('Team parameter must be 0-5');
@@ -1225,11 +1225,7 @@ end;
 
 procedure TScriptActivePlayer.SetTeam(Team: Byte);
 begin
-  if not Self.Active then
-    Exit;
-  if Team > 5 then
-    raise EArgumentException.Create('Team parameter must be 0-5');
-  Self.FSpritePtr^.ChangeTeam(Team, True);
+  Self.ChangeTeam(Team, TJoinNormal);
 end;
 
 function TScriptActivePlayer.GetVelX: Single;

--- a/server/scriptcore/test/bft/bft.pas
+++ b/server/scriptcore/test/bft/bft.pas
@@ -515,7 +515,8 @@ var
   VPos, VVel: TVector;
   NewPlayer: TNewPlayer;
   NewObject: TNewMapObject;
-  CheckPlayer, LastBot: TActivePlayer;
+  ActivePlayer, LastBot: TActivePlayer;
+  NewTeam: Integer;
 begin
   SLog('==========================================================', INFO);
   SLog('OnSpeak event called:', INFO);
@@ -599,14 +600,14 @@ begin
       Player.SetVelocity(10.0, -20.0);
     Player.GiveBonus(1);
 
-    CheckPlayer := Players.GetByName(Player.Name);
-    if CheckPlayer.ID = Player.ID then
+    ActivePlayer := Players.GetByName(Player.Name);
+    if ActivePlayer.ID = Player.ID then
       SLog('Found by name', PASS)
     else
       SLog('Not found by name.', FAILURE);
 
-    CheckPlayer := Players.GetByIP(Player.IP);
-    if CheckPlayer.ID = Player.ID then
+    ActivePlayer := Players.GetByIP(Player.IP);
+    if ActivePlayer.ID = Player.ID then
       SLog('Found by IP', PASS)
     else
       SLog('Not found by IP.', FAILURE);
@@ -624,8 +625,12 @@ begin
     NewPlayer.Chain := 0;
     NewPlayer.Dummy := False;
     NewPlayer.ChatFrequency := 3;
-    Players.Add(NewPlayer, TJoinNormal);
+    ActivePlayer := Players.Add(NewPlayer, TJoinNormal);
     NewPlayer.Free;
+
+    NewTeam := 1 + (TestCount mod 2)
+    ActivePlayer.ChangeTeam(NewTeam, TJoinSilent);
+    ActivePlayer.Team := NewTeam;
 
     LastBot := Players.GetByName('bot' + IntToStr(TestCount));
 

--- a/server/scriptcore/test/bft/bft.pas
+++ b/server/scriptcore/test/bft/bft.pas
@@ -883,6 +883,35 @@ begin
   Result := '';
 end;
 
+// Currently this test exists just to check adding a bot at script launch time.
+function PlayerTest: String;
+var
+  NewPlayer: TNewPlayer;
+  ActivePlayer: TActivePlayer;
+begin
+  Result := 'Unknown failure';
+
+  NewPlayer := TNewPlayer.Create;
+  NewPlayer.Name := 'botlaunch';
+  NewPlayer.Team := 1;
+  NewPlayer.Health := 50.0;
+  NewPlayer.ShirtColor := $00FFFF;
+  NewPlayer.PantsColor := $FFFFFF;
+  NewPlayer.SkinColor := $DDAAAA;
+  NewPlayer.HairColor := $FFFF00;
+  NewPlayer.HairStyle := 1;
+  NewPlayer.Headgear := 20;
+  NewPlayer.Chain := 0;
+  NewPlayer.Dummy := False;
+  NewPlayer.ChatFrequency := 3;
+  ActivePlayer := Players.Add(NewPlayer, TJoinNormal);
+  NewPlayer.Free;
+
+  ActivePlayer.Team := 2;
+
+  Result := '';
+end;
+
 function BanListsTest: String;
 var
   i: Integer;
@@ -1938,7 +1967,7 @@ end;
 procedure RunAllTests;
 var
   i, FailCount: Integer;
-  Tests: Array[0..7] of TTest;
+  Tests: Array[0..8] of TTest;
 begin
   // Register tests.
   Tests[0].Name := 'BanLists'; // ScriptBanLists.pas
@@ -1951,12 +1980,14 @@ begin
   Tests[3].Fn := @FileAPITest;
   Tests[4].Name := 'Math'; // ScriptMath.pas
   Tests[4].Fn := @MathTest;
-  Tests[5].Name := 'Events'; // Events
-  Tests[5].Fn := @EventsTest;
-  Tests[6].Name := 'Defines'; // Defines
-  Tests[6].Fn := @DefinesTest;
-  Tests[7].Name := 'CompilerAndRuntime'; // PascalScript regression tests
-  Tests[7].Fn := @CompilerAndRuntimeTest;
+  Tests[6].Name := 'Events'; // Events
+  Tests[6].Fn := @EventsTest;
+  Tests[5].Name := 'Player'; // ScriptPlayer.pas
+  Tests[5].Fn := @PlayerTest;
+  Tests[7].Name := 'Defines'; // Defines
+  Tests[7].Fn := @DefinesTest;
+  Tests[8].Name := 'CompilerAndRuntime'; // PascalScript regression tests
+  Tests[8].Fn := @CompilerAndRuntimeTest;
 
   // Run tests.
   for i := Low(Tests) to High(Tests) do

--- a/shared/mechanics/Sprites.pas
+++ b/shared/mechanics/Sprites.pas
@@ -263,7 +263,7 @@ begin
   Result := i;
 
   // replace player object
-  if Sprite[i].Player <> nil then
+  if (Sprite[i].Player <> nil) and (Sprite[i].Player <> Player) then
   begin
     Sprite[i].Player.SpriteNum := 0;
     if Sprite[i].IsPlayerObjectOwner then


### PR DESCRIPTION
- Fix ghost bots. They were a result of freeing a bot's own `TPlayer` object when changing teams.
- Fix issue with creating bots on script launch by reordering server initialization. This makes the order in which things happen slightly less intuitive so I added some comments explaining what is happening. I think that's enough in this case.
- Add some basic BFT tests for the above functionality.