### PR TITLE
Use official GitHub CLI for CD.

### DIFF
--- a/.github/workflows/opensoldat.yml
+++ b/.github/workflows/opensoldat.yml
@@ -1,10 +1,10 @@
 on: [push, pull_request, workflow_dispatch]
-name: opensoldat
+name: OpenSoldat
 jobs:
   linux:
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout opensoldat code
+      - name: Checkout OpenSoldat code
         uses: actions/checkout@v2
 
       - name: Checkout launcher code
@@ -20,10 +20,10 @@ jobs:
 
       - name: Install fpc
         run: |
-          curl -L -o fpc.deb https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%202.2.2/fpc-laz_3.2.2-210709_amd64.deb/download
+          curl -L -o ./fpc.deb https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%202.2.2/fpc-laz_3.2.2-210709_amd64.deb/download
           sudo apt-get install ./fpc.deb
 
-      - name: Compile opensoldat
+      - name: Compile OpenSoldat
         run: |
           export BUILD_ID=${GITHUB_SHA::8}
 
@@ -41,13 +41,13 @@ jobs:
           cd ..
 
           cmake .. -DBUILD_CLIENT=0 \
-                   -DCMAKE_INSTALL_PREFIX=./opensoldatserver \
+                   -DCMAKE_INSTALL_PREFIX=./OpenSoldatServer \
                    -DCMAKE_BUILD_TYPE=Release \
                    -DCMAKE_INSTALL_LIBDIR="." \
                    -DCMAKE_INSTALL_BINDIR="." \
                    -DCMAKE_INSTALL_DATADIR="."
           make install
-          cd opensoldatserver
+          cd OpenSoldatServer
           ../../.github/workflows/copy-libs.sh . .
 
       - name: Build launcher
@@ -60,7 +60,7 @@ jobs:
       # We use .tar to preserve file permissions
       - name: Tar files
         run: |
-          tar -cvf opensoldatserver.tar -C build opensoldatserver
+          tar -cvf OpenSoldatServer-linux-x64.tar -C build OpenSoldatServer
 
       - name: Upload game build
         uses: actions/upload-artifact@v2
@@ -72,12 +72,12 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: linux-server-build
-          path: opensoldatserver.tar
+          path: OpenSoldatServer-linux-x64.tar
 
   windows:
     runs-on: windows-latest
     steps:
-      - name: Checkout opensoldat code
+      - name: Checkout OpenSoldat code
         uses: actions/checkout@v2
 
       - name: Checkout launcher code
@@ -105,7 +105,6 @@ jobs:
         run: |
           curl -o C:\fpc64.exe ftp://mirror.freemirror.org/pub/fpc/dist/3.2.2/i386-win32/fpc-3.2.2.win32.and.win64.exe
 
-
       - name: Install freepascal
         if: steps.fpc.outputs.cache-hit != 'true'
         run: |
@@ -116,7 +115,7 @@ jobs:
         run: |
           vcpkg.exe --triplet x64-windows install sdl2 physfs openssl protobuf freetype openal-soft
 
-      - name: Build opensoldat
+      - name: Build OpenSoldat
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           set PATH=%PATH%;C:\fpc\3.2.2\bin\i386-win32
@@ -125,9 +124,14 @@ jobs:
           set BUILD_ID=%GITHUB_SHA:~0,8%
           mkdir build
           cd build
-          cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX=..\launcher\opensoldat -DCROSS_WINDOWS_64=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake"  -DSDL2_BUILDING_LIBRARY=1 ..
+          cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX=..\launcher\opensoldat -DCROSS_WINDOWS_64=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" -DSDL2_BUILDING_LIBRARY=1 ..
           nmake
           nmake install
+
+          cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX=.\OpenSoldatServer-win32-x64 -DCROSS_WINDOWS_64=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" -DSDL2_BUILDING_LIBRARY=1 -DBUILD_CLIENT=0 ..
+          nmake
+          nmake install
+
         shell: cmd
 
       - name: Build launcher
@@ -141,6 +145,11 @@ jobs:
           name: windows-build
           path: launcher/out/make/zip/win32/x64/
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: OpenSoldatServer-win32-x64
+          path: build/OpenSoldatServer-win32-x64
+
   macos:
     runs-on: macos-latest
     steps:
@@ -153,20 +162,20 @@ jobs:
         run: |
           brew install openssl@1.1 protobuf fpc cmake sdl2 physfs freetype2
 
-      - name: Compile opensoldat
+      - name: Compile OpenSoldat
         run: |
           export BUILD_ID=${GITHUB_SHA::8}
           mkdir build
           cd build
           export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/opt/openssl@1.1/lib/pkgconfig
-          cmake -DCMAKE_INSTALL_PREFIX=./opensoldat -DOPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) .. -DCMAKE_BUILD_TYPE="Release"
+          cmake -DCMAKE_INSTALL_PREFIX=./OpenSoldat-macos-x64 -DOPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) .. -DCMAKE_BUILD_TYPE="Release"
           make
           make install
 
       - uses: actions/upload-artifact@v2
         with:
-          name: macos-build
-          path: build/opensoldat
+          name: OpenSoldat-macos-x64
+          path: build/OpenSoldat-macos-x64
 
   continuous:
     runs-on: ubuntu-latest
@@ -181,16 +190,20 @@ jobs:
 
       - name: Zip build dirs back together
         run: |
-          zip -r macos-build.zip macos-build
+          zip -r OpenSoldat-macos-x64.zip OpenSoldat-macos-x64
+          zip -r OpenSoldatServer-win32-x64.zip OpenSoldatServer-win32-x64
 
       - name: Upload release
-        uses: softprops/action-gh-release@fe9a9bd3295828558c7a3c004f23f3bf77d155b2
-        with:
-          tag_name: continuous
-          files: |
-            windows-build/*.zip
-            macos-build.zip
-            linux-build/*.zip
-            linux-server-build/*.tar
-          body: OpenSoldat 1.8 alpha dev build
-          name: OpenSoldat 1.8 alpha dev build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch --tags
+          if git rev-parse continuous &>/dev/null; then
+            gh release delete continuous --yes
+            git tag --delete continuous
+            git push --delete origin continuous
+          fi
+
+          git tag continuous
+          git push --tags origin continuous
+          gh release create continuous windows-build/*.zip OpenSoldatServer-win32-x64.zip OpenSoldat-macos-x64.zip linux-build/*.zip linux-server-build/*.tar --notes "OpenSoldat 1.8 alpha dev build" --title "OpenSoldat 1.8 alpha dev build"


### PR DESCRIPTION
- Use official GitHub CLI for CD. The softprops action has been officially recommended by GitHub for a while now, but it is somewhat lacking in features, is infrequently updated, and recently has been having trouble with our repo. The official CLI tool `gh` can meet our needs just fine, so let's use it.
- Some more opensoldat -> OpenSoldat changes
- Rename some release artifacts to include target platform and architecture.
- Upload Windows OpenSoldatServer build.