### PR TITLE
Small misc fixes #4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ install(
 if(ADD_ASSETS)
   install(
     DIRECTORY ${EXECUTABLE_OUTPUT_PATH}/
-    # FIXME: should be target_data_install_dir, but unsupported by opensoldat
+    # FIXME: should be target_data_install_dir, but unsupported by OpenSoldat
     # (needs wrapper script or some equivalent global config)
     DESTINATION "${target_binary_install_dir}"
     FILES_MATCHING

--- a/client/Client.pas
+++ b/client/Client.pas
@@ -40,7 +40,7 @@ uses
   // anti-cheat units
   {$IFDEF ENABLE_FAE}FaeClient,{$ENDIF}
 
-  // opensoldat units
+  // OpenSoldat units
   Sprites, Anims, PolyMap, Net, LogFile, Sound, GetText,
   NetworkClientConnection, GameMenus, Demo, Console,
   Weapons, Constants, Game, GameRendering;

--- a/client/Gfx.pas
+++ b/client/Gfx.pas
@@ -418,6 +418,7 @@ type
 
 var
   GfxContext: record
+    GameGLContext: TSDL_GLContext;
     MajorVersion: Integer;
     ShaderProgram: GLuint;
     MatrixLoc: GLint;
@@ -667,11 +668,11 @@ var
 begin
   Result := True;
 
-  GameGLContext := SDL_GL_CreateContext(Wnd);
+  GfxContext.GameGLContext := SDL_GL_CreateContext(Wnd);
   InitOpenGL();
   ReadImplementationProperties();
   ReadExtensions();
-  SDL_GL_MakeCurrent(GameWindow, GameGLContext);
+  SDL_GL_MakeCurrent(GameWindow, GfxContext.GameGLContext);
   Version := glGetString(GL_VERSION);
   i := Pos('.', Version);
   //FIXME: Not compatible with opengl ES

--- a/client/Input.pas
+++ b/client/Input.pas
@@ -43,7 +43,6 @@ var
   KeyStatus: array [0..512] of Boolean;
   Binds: array of TBind;
   GameWindow : PSDL_Window;
-  GameGLContext: TSDL_GLContext;
 
 implementation
 

--- a/server/Main.pas
+++ b/server/Main.pas
@@ -29,7 +29,7 @@ var
   CtrlCHit: Boolean = False;
 
 {$IFDEF MSWINDOWS}
-// The windows server needs a hook to make opensoldatserver exit normally
+// The windows server needs a hook to make OpenSoldatServer exit normally
 function ConsoleHandlerRoutine(CtrlType: DWORD): BOOL; stdcall;
 begin
   Result := False;
@@ -187,7 +187,7 @@ procedure RunServer;
 begin
   if IsRoot then
   begin
-    WriteLn('You are running opensoldatserver as root! Don''t do that! ' +
+    WriteLn('You are running OpenSoldatServer as root! Don''t do that! ' +
       'There are not many valid' + #10 +
       'reasons for this and it can, in theory, cause great damage!');
     Exit;
@@ -197,7 +197,7 @@ begin
       Exit;
 
     WriteLn('You have been warned.' + #10 +
-      'Hit CTRL+C now if you don''t want to run opensoldatserver as root.' + #10 +
+      'Hit CTRL+C now if you don''t want to run OpenSoldatServer as root.' + #10 +
       'OpenSoldatServer will start in 30 seconds.');
     Sleep(30000);}
   end;

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -48,7 +48,7 @@ uses
 procedure ActivateServer;
 function AddBotPlayer(Name: string; team: Integer): Byte;
 procedure StartServer;
-function LoadMapsList(filename: string = ''): Boolean;
+function LoadMapsList(Filename: string = ''): Boolean;
 procedure LoadWeapons(filename: string);
 procedure ShutDown;
 procedure NextMap;
@@ -879,21 +879,23 @@ begin
   CvarCleanup();
 end;
 
-function LoadMapsList(Filename: string = ''): Boolean;
+function LoadMapsList(Filename: String = ''): Boolean;
 var
   i: Integer;
   MapsListPath: String;
 begin
-  if Filename.IsEmpty then
+  if Filename.IsEmpty() then
     Filename := sv_maplist.Value;
   if not Filename.EndsWith('.txt') then
     Filename := Filename + '.txt';
+
   MapsListPath := UserDirectory + 'configs/' + Filename;
 
   if FileExists(MapsListPath) then
   begin
     Result := True;
     MapsList.LoadFromFile(MapsListPath);
+
     i := 1;
     while i < MapsList.Count do
     begin
@@ -904,8 +906,10 @@ begin
       end;
       Inc(i);
     end;
-    sv_maplist.SetValue(Filename);
-  end else
+
+    MainConsole.Console('Loaded maps list: ' + Filename, CLIENT_MESSAGE_COLOR)
+  end
+  else
   begin
     Result := False;
     MainConsole.Console('Maps list file not found: configs/' + Filename, WARNING_MESSAGE_COLOR);

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -38,7 +38,7 @@ uses
 
   FileServer, LobbyClient,
 
-  // opensoldat units
+  // OpenSoldat units
   Steam, Net, NetworkUtils,
   NetworkServerSprite, NetworkServerConnection, NetworkServerGame,
   ServerCommands, PhysFS, Console, ServerHelper,
@@ -700,7 +700,7 @@ begin
   begin
     SteamAPI.Utils.SetWarningMessageHook(@SteamWarning);
 
-    // TODO: opensoldat on steam
+    // TODO: OpenSoldat on steam
     SteamAPI.GameServer.SetModDir(PChar('Soldat'));
     SteamAPI.GameServer.SetProduct(PChar('Soldat'));
     SteamAPI.GameServer.SetGameDescription(PChar('Soldat'));
@@ -1189,7 +1189,7 @@ begin
     ScrptDispatcher.Launch();
   {$ENDIF}
 
-  // Now that event handlers have been assigned, run `OnAftermapChange` from
+  // Now that event handlers have been assigned, run `OnAfterMapChange` from
   // loading the initial map, and spawn stuff.
   {$IFDEF SCRIPT}
   ScrptDispatcher.OnAfterMapChange(Map.Name);

--- a/server/ServerCommands.pas
+++ b/server/ServerCommands.pas
@@ -423,13 +423,9 @@ var
   Name: String;
 begin
   if Length(Args) > 1 then
-    Name := Args[1]
+    sv_maplist.SetValue(Args[1])
   else
-    Name := sv_maplist.Value; // We only set it for better feedback in console.
-  if LoadMapsList(Name) then
-    MainConsole.Console('Loaded maps list: ' + Name, CLIENT_MESSAGE_COLOR, Sender)
-  else
-    MainConsole.Console('Could not find maps list: ' + Name, DEBUG_MESSAGE_COLOR, Sender);
+    sv_maplist.SetValue(sv_maplist.Value);
 end;
 
 procedure CommandPm(Args: array of AnsiString; Sender: Byte);

--- a/server/ServerCommands.pas
+++ b/server/ServerCommands.pas
@@ -419,8 +419,6 @@ begin
 end;
 
 procedure CommandLoadlist(Args: array of AnsiString; Sender: Byte);
-var
-  Name: String;
 begin
   if Length(Args) > 1 then
     sv_maplist.SetValue(Args[1])

--- a/server/scriptcore/ScriptCoreAPIAdapter.pas
+++ b/server/scriptcore/ScriptCoreAPIAdapter.pas
@@ -401,7 +401,7 @@ begin
     Exec.SetValue('ServerVersion', DEDVERSION);
     Exec.SetValue('ServerPort', net_port.Value);
     Exec.SetValue('ServerIP', ServerIP);
-    // FScripts.Dir holds full path from opensoldatserver folder, so scripts/Name/,
+    // FScripts.Dir holds full path from OpenSoldatServer folder, so scripts/Name/,
     // not just Name, hence Copy(9, Length - 9), where 9 = Length('scripts/') + 1
     // and Max - 9 because we need to substract Length('scripts/')
     // and 1 to remove '/' at the end

--- a/server/scriptcore/ScriptCoreInterface.pas
+++ b/server/scriptcore/ScriptCoreInterface.pas
@@ -24,7 +24,7 @@ uses
   Vector,
   // pascal script
   uPSComponent, uPSRuntime,
-  // opensoldat
+  // OpenSoldat
   PascalCore;
 
 // Scriptcore functions

--- a/server/scriptcore/ScriptFileAPI.pas
+++ b/server/scriptcore/ScriptFileAPI.pas
@@ -452,7 +452,7 @@ begin
     // to normalize slashes for further functions (expand function does it).
     // Though since they don't fall into scope of permission check...
     0: Result := True;
-    // Level 1 sandbox, restrict to opensoldatserver's folder
+    // Level 1 sandbox, restrict to OpenSoldatServer's folder
     1:
     begin
       Result := UserDirectory = Copy(FilePath, 1, Length(UserDirectory));
@@ -477,7 +477,7 @@ begin
   end;
 
   // Since some API functions allow to show the path (the normalized one),
-  // relativise it to hide opensoldatserver's folder absolute path
+  // relativise it to hide OpenSoldatServer's folder absolute path
   if Result then
     FilePath := ExtractRelativepath(UserDirectory, FilePath);
 end;

--- a/server/scriptcore/ScriptMapsList.pas
+++ b/server/scriptcore/ScriptMapsList.pas
@@ -81,7 +81,7 @@ end;
 
 procedure TScriptMapsList.SetCurrentMapId(NewNum: Integer);
 begin
-  if NewNum < MapsList.Count then
+  if (NewNum >= 0) and (NewNum < MapsList.Count) then
     MapIndex := NewNum;
 end;
 

--- a/server/scriptcore/ScriptMapsList.pas
+++ b/server/scriptcore/ScriptMapsList.pas
@@ -68,7 +68,10 @@ end;
 
 function TScriptMapsList.GetMap(Num: Integer): string;
 begin
-  Result := MapsList[Num];
+  if Num >= MapsList.Count then
+    Result := ''
+  else
+    Result := MapsList[Num];
 end;
 
 function TScriptMapsList.GetCurrentMapId: Integer;
@@ -78,7 +81,8 @@ end;
 
 procedure TScriptMapsList.SetCurrentMapId(NewNum: Integer);
 begin
-  MapIndex := NewNum;
+  if NewNum < MapsList.Count then
+    MapIndex := NewNum;
 end;
 
 function TScriptMapsList.GetMapsCount: Integer;

--- a/server/scriptcore/ScriptPlayer.pas
+++ b/server/scriptcore/ScriptPlayer.pas
@@ -469,6 +469,8 @@ end;
 
 procedure TScriptPlayer.SetFavouriteWeapon(Weapon: string);
 begin
+  if WeaponNameToNum(Weapon) = -1 then
+    Weapon := 'Hands';
   Self.FSpritePtr^.Brain.FavWeapon := WeaponNameToNum(Weapon);
 end;
 

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -194,6 +194,22 @@ begin
   Cvar.FErrorMessage := '';
   Result := True;
 end;
+
+function sv_maplistChange(Cvar: TCvarBase; NewValue: String): Boolean;
+begin
+  Result := False;
+
+  if MapsList = Nil then
+  begin
+    Result := True;
+    Exit;
+  end;
+
+  if LoadMapsList(NewValue) then
+    Result := True
+  else
+    Cvar.FErrorMessage := 'Maps list file not found';
+end;
 {$ENDIF}
 
 {$PUSH}
@@ -878,7 +894,7 @@ begin
   sv_votepercent := TIntegerCvar.Add('sv_votepercent', 'Percentage of players in favor of a map/kick vote to let it pass', 60, [CVAR_SERVER], nil, 0, 200);
   sv_lockedmode := TBooleanCvar.Add('sv_lockedmode', 'When Locked Mode is enabled, admins will not be able to type /loadcon, /password or /maxplayers', False, [CVAR_SERVER], nil);
   sv_pidfilename := TStringCvar.Add('sv_pidfilename', 'Sets the Process ID file name', 'opensoldatserver.pid', [CVAR_SERVER], nil, 1, 256);
-  sv_maplist := TStringCvar.Add('sv_maplist', 'Sets the name of maplist file', 'mapslist.txt', [CVAR_SERVER], nil, 1, 256); // TODO: OnChange load new maplist
+  sv_maplist := TStringCvar.Add('sv_maplist', 'Sets the name of maplist file', 'mapslist.txt', [CVAR_SERVER], @sv_maplistChange, 1, 256);
   sv_lobby := TBooleanCvar.Add('sv_lobby', 'Enables/Disables registering in lobby', False, [CVAR_SERVER], nil);
   sv_lobbyurl := TStringCvar.Add('sv_lobbyurl', 'URL of the lobby server', 'http://api.soldat.pl:443', [CVAR_SERVER], nil, 1, 256);
 

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -722,7 +722,7 @@ begin
   Cvars := TFPHashList.Create;
   CvarsSync := TFPHashList.Create;
 
-  log_level := TIntegerCvar.Add('log_level', 'Sets log level', LEVEL_OFF, [], nil, LEVEL_OFF, LEVEL_TRACE);
+  log_level := TIntegerCvar.Add('log_level', 'Sets log level. 0 = Off, 1 = Debug/Noteworthy events, 2 = Trace function entries', LEVEL_OFF, [], nil, LEVEL_OFF, LEVEL_TRACE);
   log_enable := TBooleanCvar.Add('log_enable', 'Enables logging to file', True, [], nil);
   log_filesupdate := TIntegerCvar.Add('log_filesupdate', 'How often the log files should be updated in ticks (60 ticks = 1 second)', 3600, [], nil, 0, MaxInt);
   {$IFDEF SERVER}

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -723,7 +723,7 @@ begin
   CvarsSync := TFPHashList.Create;
 
   log_level := TIntegerCvar.Add('log_level', 'Sets log level', LEVEL_OFF, [], nil, LEVEL_OFF, LEVEL_TRACE);
-  log_enable := TBooleanCvar.Add('log_enable', 'Enables logging to file', False, [], nil);
+  log_enable := TBooleanCvar.Add('log_enable', 'Enables logging to file', True, [], nil);
   log_filesupdate := TIntegerCvar.Add('log_filesupdate', 'How often the log files should be updated in ticks (60 ticks = 1 second)', 3600, [], nil, 0, MaxInt);
   {$IFDEF SERVER}
   log_timestamp := TBooleanCvar.Add('log_timestamp', 'Enables/Disables timestamps in console', False, [CVAR_SERVER], nil);

--- a/shared/Game.pas
+++ b/shared/Game.pas
@@ -524,7 +524,6 @@ begin
   a := Default(TVector2);
   try
     Debug('ChangeMap');
-    LoadMapsList();
 
     for i := 1 to MAX_WAYPOINTS do
     begin

--- a/shared/Version.pas
+++ b/shared/Version.pas
@@ -20,7 +20,7 @@ const
   {$ELSE}
   DEDVERSION = 'GAME';
   {$ENDIF}
-  DEMO_VERSION = $0000;  // version number for opensoldat demo files
+  DEMO_VERSION = $0000;  // version number for OpenSoldat demo files
 
 implementation
 

--- a/shared/mechanics/Control.pas
+++ b/shared/mechanics/Control.pas
@@ -1996,7 +1996,7 @@ begin
           SpriteC.BodyApplyAnimation(SlideBack, 1);
 
         // this piece of code fixes the infamous crouch bug
-        // how you ask? well once upon time opensoldat's code decided that
+        // how you ask? well once upon time OpenSoldat's code decided that
         // randomly the animation for roll for the body and legs will magically
         // go out of sync, which is causing the crouch bug. so this piece of
         // awesome code simply syncs them when they go out of sync <3

--- a/shared/mechanics/Sprites.pas
+++ b/shared/mechanics/Sprites.pas
@@ -1483,6 +1483,10 @@ begin
   end;
   {$ENDIF}
 
+  if IsPlayerObjectOwner then
+    FreeAndNil(Player);
+  IsPlayerObjectOwner := False;
+
   // sort the players frag list
   SortPlayers;
 end;

--- a/shared/network/Net.pas
+++ b/shared/network/Net.pas
@@ -27,7 +27,7 @@ uses
 
   Steam,
 
-  // opensoldat units
+  // OpenSoldat units
   Weapons, Constants;
 
 const

--- a/shared/network/NetworkClientBullet.pas
+++ b/shared/network/NetworkClientBullet.pas
@@ -9,7 +9,7 @@ uses
   // helper units
   Vector,
 
-  // opensoldat units
+  // OpenSoldat units
   Steam, Net, Sprites, Weapons, Constants, NetworkServerBullet, Demo;
 
 procedure ClientSendBullet(i: Byte);

--- a/shared/network/NetworkClientConnection.pas
+++ b/shared/network/NetworkClientConnection.pas
@@ -12,7 +12,7 @@ uses
   // anti-cheat units
   {$IFDEF ENABLE_FAE}FaeClient,{$ENDIF}
 
-  // opensoldat units
+  // OpenSoldat units
   LogFile, Steam, Net, Sprites, Weapons, Constants, GameStrings,
   Cvar, PhysFS;
 

--- a/shared/network/NetworkClientFunctions.pas
+++ b/shared/network/NetworkClientFunctions.pas
@@ -12,7 +12,7 @@ uses
   // Sound unit
   Sound,
 
-  // opensoldat units
+  // OpenSoldat units
   LogFile, Steam, Net, Sprites, Weapons, Constants;
 
 procedure ClientHandleVoteOn(NetMessage: PSteamNetworkingMessage_t);

--- a/shared/network/NetworkClientGame.pas
+++ b/shared/network/NetworkClientGame.pas
@@ -9,7 +9,7 @@ uses
   // helper units
   Vector,
 
-  // opensoldat units
+  // OpenSoldat units
   Steam, Net, Sprites, Weapons, Sound,
   Constants, GameStrings;
 

--- a/shared/network/NetworkClientHeartbeat.pas
+++ b/shared/network/NetworkClientHeartbeat.pas
@@ -6,7 +6,7 @@ uses
   // delphi and system units
   SysUtils, Classes,
 
-  // opensoldat units
+  // OpenSoldat units
   LogFile, Steam, Net, Sprites, Sound, Constants, GameStrings;
 
 procedure ClientHandleHeartBeat(NetMessage: PSteamNetworkingMessage_t);

--- a/shared/network/NetworkClientMessages.pas
+++ b/shared/network/NetworkClientMessages.pas
@@ -10,7 +10,7 @@ uses
   // helper units
   Vector, Util,
 
-  // opensoldat units
+  // OpenSoldat units
   Steam, Net, Sprites, Constants, GameStrings;
 
 procedure ClientSendStringMessage(Text: WideString; MsgType: Byte);

--- a/shared/network/NetworkClientSprite.pas
+++ b/shared/network/NetworkClientSprite.pas
@@ -9,7 +9,7 @@ uses
   // helper units
   Vector,
 
-  // opensoldat units
+  // OpenSoldat units
   Steam, Net, Sprites, Weapons, Sound,
   Constants, GameStrings;
 

--- a/shared/network/NetworkClientThing.pas
+++ b/shared/network/NetworkClientThing.pas
@@ -9,7 +9,7 @@ uses
   // helper units
   Vector, Util,
 
-  // opensoldat units
+  // OpenSoldat units
   Calc, LogFile, Steam, Net, Sprites, Weapons, Sound,
   Constants, GameStrings;
 

--- a/shared/network/NetworkServerConnection.pas
+++ b/shared/network/NetworkServerConnection.pas
@@ -11,7 +11,7 @@ uses
 
   {$IFDEF SCRIPT}ScriptDispatcher,{$ENDIF}
 
-  // opensoldat units
+  // OpenSoldat units
   PolyMap, {$IFDEF SERVER}Steam,{$ENDIF} Net, Sprites, Weapons, Constants;
 
   {$IFDEF SERVER}

--- a/shared/network/NetworkServerFunctions.pas
+++ b/shared/network/NetworkServerFunctions.pas
@@ -9,7 +9,7 @@ uses
   // helper units
   Vector, Util,
 
-  // opensoldat units
+  // OpenSoldat units
   Steam, Net, Sprites, Weapons, Constants;
 
 procedure SetWeaponActive(ID, WeaponNum: Byte; State: Boolean);

--- a/shared/network/NetworkServerGame.pas
+++ b/shared/network/NetworkServerGame.pas
@@ -10,7 +10,7 @@ uses
   ScriptDispatcher,
   {$ENDIF}
 
-  // opensoldat units
+  // OpenSoldat units
   Steam, Net, Sprites, Constants;
 
 procedure ServerHandlePlayerDisconnect(NetMessage: PSteamNetworkingMessage_t);

--- a/shared/network/NetworkServerHeartbeat.pas
+++ b/shared/network/NetworkServerHeartbeat.pas
@@ -6,7 +6,7 @@ uses
   // delphi and system units
   SysUtils, Classes,
 
-  // opensoldat units
+  // OpenSoldat units
   Net, Sprites, Weapons, Constants;
 
 procedure ServerHeartbeat;

--- a/shared/network/NetworkServerMessages.pas
+++ b/shared/network/NetworkServerMessages.pas
@@ -13,7 +13,7 @@ uses
   ScriptDispatcher,
   {$ENDIF}
 
-  // opensoldat units
+  // OpenSoldat units
   Net, Steam, Sprites, Command, Constants;
 
   procedure ServerSendStringMessage(Text: WideString; ToNum: Byte; From: Byte; MsgType: Byte);

--- a/shared/network/NetworkServerSprite.pas
+++ b/shared/network/NetworkServerSprite.pas
@@ -13,7 +13,7 @@ uses
   ScriptDispatcher,
   {$ENDIF}
 
-  // opensoldat units
+  // OpenSoldat units
   Steam, Net, Sprites, Weapons, Constants, PolyMap;
 
 procedure ServerSpriteSnapshot(r: Byte);

--- a/shared/network/NetworkServerThing.pas
+++ b/shared/network/NetworkServerThing.pas
@@ -6,7 +6,7 @@ uses
   // helper units
   Vector,
 
-  // opensoldat units
+  // OpenSoldat units
   {$IFDEF SERVER}Steam,{$ENDIF}
   Net, Sprites, Constants;
 

--- a/shared/network/NetworkUtils.pas
+++ b/shared/network/NetworkUtils.pas
@@ -11,7 +11,7 @@ uses
   // helper units
   Version, StrUtils,
 
-  // opensoldat units
+  // OpenSoldat units
   {$IFNDEF SERVER}
   Sound,
   {$ENDIF}


### PR DESCRIPTION
- Just some more opensoldat -> OpenSoldat.
- Some mapslist cleanup.
  - Make it so `sv_maplist` is the one source of truth for which maplist file is currently being used. Also, don't reload maplist every time the map is changed. This helps ensure consistency with how the `MapsList` global is used, and there is the `/loadlist` command to refresh the list anyways.
- Enable logging to files by default.
  - Annoying for server owners to encounter issues, and then realize there were no log files created. Also helpful to have chat logs if they are dealing with "he said she said" type situations.
- Add description of log levels to `log_level` cvar.
- Move `GameGLContext` into `GfxContext`.
  - Ideally the fact that we are using OpenGL is an implementation detail of `Gfx.pas`.
- Properly free `TSprite.Player` and don't accidentally double free `DummyPlayer`.
  - The `IsPlayerObjectOwner` implementation was a little half-baked, this finishes it up.
- Validate `TBotData.FavWeapon` from scripts.
- Check if `MapIndex` set from script is less than 0.
- Remove unused parameter in `CommandLoadList`.