### PR TITLE
Communication between game and launcher

### DIFF
--- a/client/Client.pas
+++ b/client/Client.pas
@@ -190,6 +190,10 @@ var
   font_weaponmenusize: TIntegerCvar;
   font_killconsolenamespace: TIntegerCvar;
 
+  launcher_ipc_enable: TBooleanCvar;
+  launcher_ipc_port: TIntegerCvar;
+  launcher_ipc_reconnect_rate: TIntegerCvar;
+
   sv_respawntime: TIntegerCvar; // TODO: Remove
   sv_inf_redaward: TIntegerCvar; // TODO: Remove
   net_contype: TIntegerCvar; // TODO: Remove
@@ -672,8 +676,10 @@ begin
   // NOTE: Code depending on CVars should be run after this line if possible.
   CvarsInitialized := True;
 
-  LauncherIPC := TClientLauncherIPC.Create;
-  LauncherIPC.Connect(23093);
+  if launcher_ipc_enable.Value then begin
+    LauncherIPC := TClientLauncherIPC.Create;
+    LauncherIPC.Connect(launcher_ipc_port.Value);
+  end;
 
   NewLogFiles;
 

--- a/client/Client.pas
+++ b/client/Client.pas
@@ -983,6 +983,11 @@ begin
 
   PhysFS_deinit();
 
+  if launcher_ipc_enable.Value then begin
+    AddLineToLogFile(GameLog, 'Launcher connection closing.', ConsoleLogFileName);
+    FreeAndNil(LauncherIPC);
+  end;
+
   {$IFDEF STEAM}
   AddLineToLogFile(GameLog, 'Steam API closing.', ConsoleLogFileName);
   SteamAPI_Shutdown();

--- a/client/Client.pas
+++ b/client/Client.pas
@@ -43,7 +43,7 @@ uses
   // OpenSoldat units
   Sprites, Anims, PolyMap, Net, LogFile, Sound, GetText,
   NetworkClientConnection, GameMenus, Demo, Console,
-  Weapons, Constants, Game, GameRendering;
+  Weapons, Constants, Game, GameRendering, ClientLauncherIPC;
 
 procedure JoinServer;
 procedure StartGame;
@@ -243,6 +243,7 @@ var
 
   // Network
   UDP: TClientNetwork;
+  LauncherIPC: TClientLauncherIPC;
 
   // Consoles
   MainConsole: TConsole;
@@ -670,6 +671,9 @@ begin
 
   // NOTE: Code depending on CVars should be run after this line if possible.
   CvarsInitialized := True;
+
+  LauncherIPC := TClientLauncherIPC.Create;
+  LauncherIPC.Connect(23093);
 
   NewLogFiles;
 

--- a/client/ClientGame.pas
+++ b/client/ClientGame.pas
@@ -378,6 +378,10 @@ begin
       ForceClientSpriteSnapshotMov := False;
     end;  // playing
 
+    // Launcher connection
+    if not LauncherIPC.ThreadAlive and (MainTickCounter mod 300 = 0) then
+      LauncherIPC.Connect(23093);
+
     //UDP.FlushMsg;
   end;  // Client
 

--- a/client/ClientGame.pas
+++ b/client/ClientGame.pas
@@ -379,8 +379,9 @@ begin
     end;  // playing
 
     // Launcher connection
-    if not LauncherIPC.ThreadAlive and (MainTickCounter mod 300 = 0) then
-      LauncherIPC.Connect(23093);
+    if launcher_ipc_enable.Value then
+      if not LauncherIPC.ThreadAlive and (MainTickCounter mod launcher_ipc_reconnect_rate.Value = 0) then
+        LauncherIPC.Connect(launcher_ipc_port.Value);
 
     //UDP.FlushMsg;
   end;  // Client

--- a/client/ClientLauncherIPC.pas
+++ b/client/ClientLauncherIPC.pas
@@ -1,0 +1,21 @@
+unit ClientLauncherIPC;
+
+interface
+
+uses
+  LauncherIPC;
+
+type
+  TClientLauncherIPC = class(TLauncherIPC)
+  protected
+    procedure HandleMessage(Message: String); override;
+  end;
+
+implementation
+
+procedure TClientLauncherIPC.HandleMessage(Message: String);
+begin
+
+end;
+
+end.

--- a/client/ClientLauncherIPC.pas
+++ b/client/ClientLauncherIPC.pas
@@ -15,7 +15,7 @@ implementation
 
 procedure TClientLauncherIPC.HandleMessage(Message: String);
 begin
-
+  HandleCommand(Message);
 end;
 
 end.

--- a/client/opensoldat.lpi
+++ b/client/opensoldat.lpi
@@ -566,7 +566,7 @@
         </Mode0>
       </Modes>
     </RunParams>
-    <Units Count="62">
+    <Units Count="65">
       <Unit0>
         <Filename Value="opensoldat.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -815,6 +815,18 @@
         <Filename Value="..\shared\VersionLong.txt"/>
         <IsPartOfProject Value="True"/>
       </Unit61>
+      <Unit62>
+        <Filename Value="..\shared\LauncherIPC.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit62>
+      <Unit63>
+        <Filename Value="..\shared\LauncherConnection.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit63>
+      <Unit64>
+        <Filename Value="ClientLauncherIPC.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit64>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -36,7 +36,7 @@ uses
   Rcon,
   {$ENDIF}
 
-  FileServer, LobbyClient,
+  FileServer, LobbyClient, ServerLauncherIPC,
 
   // OpenSoldat units
   Steam, Net, NetworkUtils,
@@ -291,6 +291,8 @@ var
   ModDir: string = '';
 
   UDP: TServerNetwork;
+
+  LauncherIPC: TServerLauncherIPC;
 
   LobbyThread: TLobbyThread;
 
@@ -656,6 +658,11 @@ begin
 
   // NOTE: Code depending on CVars should be run after this line if possible.
   CvarsInitialized := True;
+
+  if launcher_ipc_enable.Value then begin
+    LauncherIPC := TServerLauncherIPC.Create;
+    LauncherIPC.Connect(launcher_ipc_port.Value);
+  end;
 
   ModDir := '';
 

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -847,6 +847,9 @@ begin
 
   StopFileServer;
 
+  if launcher_ipc_enable.Value then
+    FreeAndNil(LauncherIPC);
+
   FreeAndNil(MapsList);
   FreeAndNil(RemoteIPs);
   FreeAndNil(AdminIPs);

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -196,6 +196,10 @@ var
   fileserver_ip: TStringCvar;
   fileserver_maxconnections: TIntegerCvar;
 
+  launcher_ipc_enable: TBooleanCvar;
+  launcher_ipc_port: TIntegerCvar;
+  launcher_ipc_reconnect_rate: TIntegerCvar;
+
   // syncable cvars
   sv_gamemode: TIntegerCvar;
   sv_friendlyfire: TBooleanCvar;

--- a/server/ServerLauncherIPC.pas
+++ b/server/ServerLauncherIPC.pas
@@ -1,0 +1,23 @@
+unit ServerLauncherIPC;
+
+interface
+
+uses
+  LauncherIPC;
+
+type
+  TServerLauncherIPC = class(TLauncherIPC)
+  protected
+    procedure HandleMessage(Message: String); override;
+  end;
+
+implementation
+
+procedure TServerLauncherIPC.HandleMessage(Message: String);
+begin
+  HandleCommand(Message);
+end;
+
+end.
+
+

--- a/server/ServerLoop.pas
+++ b/server/ServerLoop.pas
@@ -41,6 +41,9 @@ begin
     AdminServer.ProcessCommands();
   {$ENDIF}
 
+  // Run methods Synchronized from threads
+  CheckSynchronize;
+
   // Run every 60 seconds
   if (GetTickCount64 - LastMinuteTick) >= 60000 then
   begin
@@ -287,6 +290,11 @@ begin
             ServerThingSnapshot(j);
         end;
       end;
+
+    // Launcher connection
+    if launcher_ipc_enable.Value then
+      if not LauncherIPC.ThreadAlive and (MainTickCounter mod launcher_ipc_reconnect_rate.Value = 0) then
+         LauncherIPC.Connect(launcher_ipc_port.Value);
 
       //UDP.FlushMsg;
   end;

--- a/server/opensoldatserver.lpi
+++ b/server/opensoldatserver.lpi
@@ -535,7 +535,7 @@
         </Mode0>
       </Modes>
     </RunParams>
-    <Units Count="87">
+    <Units Count="90">
       <Unit0>
         <Filename Value="opensoldatserver.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -885,6 +885,18 @@
         <Filename Value="..\shared\gfx.inc.in"/>
         <IsPartOfProject Value="True"/>
       </Unit86>
+      <Unit87>
+        <Filename Value="..\shared\LauncherConnection.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit87>
+      <Unit88>
+        <Filename Value="..\shared\LauncherIPC.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit88>
+      <Unit89>
+        <Filename Value="ServerLauncherIPC.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit89>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -742,6 +742,11 @@ begin
 
   demo_autorecord := TBooleanCvar.Add('demo_autorecord', 'Auto record demos', False, [], nil);
 
+  // Launcher cvars
+  launcher_ipc_enable := TBooleanCvar.Add('launcher_ipc_enable', 'Enables inter-process communication with launcher', False, [CVAR_INITONLY], nil);
+  launcher_ipc_port := TIntegerCvar.Add('launcher_ipc_port', 'Port of TCP server used for inter-process communication with launcher', 23093, [CVAR_INITONLY], nil, 0, 65535);
+  launcher_ipc_reconnect_rate := TIntegerCvar.Add('launcher_ipc_reconnect_rate', 'How often (in ticks) the game tries to reconnect to launcher', 300, [], nil, 60, 54000);
+
   {$IFNDEF SERVER}
   // Render Cvars
   r_fullscreen := TIntegerCvar.Add('r_fullscreen', 'Set mode of fullscreen', 0, [CVAR_CLIENT], nil, 0, 2);

--- a/shared/LauncherConnection.pas
+++ b/shared/LauncherConnection.pas
@@ -1,0 +1,105 @@
+unit LauncherConnection;
+
+interface
+
+uses
+  Classes, Generics.Collections, ssockets;
+
+type
+  TMessageCallback = procedure(Message: String) of object;
+
+  // Implements the connection between client/server and launcher, using a TCP socket.
+  TLauncherConnection = class(TThread)
+  private
+    FPort: Integer;
+    FSocket: TInetSocket;
+
+    // This is a field so we can access it from Synchronized method.
+    FReceivedMessage: String;
+    FOnMessage: TMessageCallback;
+    FSendQueue: TThreadList<String>;
+    procedure HandleMessage;
+    procedure ProcessSendQueue;
+  public
+    constructor Create(Port: Integer);
+    procedure Execute; override;
+
+    // This callback will be run in main thread through Synchronize.
+    property OnMessage: TMessageCallback read FOnMessage write FOnMessage;
+    procedure SendMessage(Message: String);
+  end;
+
+implementation
+
+uses
+  TraceLog;
+
+const
+  MAX_MESSAGE_LENGTH = 4096;
+
+constructor TLauncherConnection.Create(Port: Integer);
+begin
+  // Thread will be suspended after creation, so that we can set thread's properties.
+  inherited Create(True);
+  FPort := Port;
+  FSendQueue := TThreadList<String>.Create;
+end;
+
+procedure TLauncherConnection.Execute;
+type
+  TBuffer = array[0..MAX_MESSAGE_LENGTH-1] of Char;
+var
+  ReadBuffer: TBuffer;
+  ReadLength: LongInt;
+begin
+  FSocket := TInetSocket.Create('127.0.0.1', FPort, 5000);
+  FSocket.IOTimeout := 1000;
+  ReadBuffer := Default(TBuffer);
+
+  while not Terminated do begin
+    ReadLength := FSocket.Read(ReadBuffer, MAX_MESSAGE_LENGTH);
+    if ReadLength > 0 then begin
+      FReceivedMessage := ReadBuffer;
+      Synchronize(HandleMessage);
+    end;
+
+    ProcessSendQueue;
+    Sleep(250);
+  end;
+end;
+
+procedure TLauncherConnection.HandleMessage;
+begin
+  if Assigned(FOnMessage) then
+    FOnMessage(FReceivedMessage);
+end;
+
+procedure TLauncherConnection.ProcessSendQueue;
+var
+  Message: String;
+  Queue: TList<String>;
+begin
+  Queue := FSendQueue.LockList;
+  if Queue.Count = 0 then begin
+    FSendQueue.UnlockList;
+    Exit;
+  end;
+
+  Message := Queue.First;
+  FSocket.Write(Message[1], Length(Message));
+  Queue.Remove(Message);
+  FSendQueue.UnlockList;
+end;
+
+procedure TLauncherConnection.SendMessage(Message: String);
+var
+  Queue: TList<String>;
+begin
+  Debug('[LauncherConnection] Sending ' + Message);
+  // Locking probably not needed here.
+  Queue := FSendQueue.LockList;
+  Queue.Add(Message);
+  FSendQueue.UnlockList;
+end;
+
+end.

--- a/shared/LauncherConnection.pas
+++ b/shared/LauncherConnection.pas
@@ -72,6 +72,7 @@ begin
       Exit;
     end;
   end;
+  Debug('[LauncherConnection] Connected');
   FSocket.IOTimeout := 1000;
   ReadBuffer := Default(TBuffer);
 

--- a/shared/LauncherConnection.pas
+++ b/shared/LauncherConnection.pas
@@ -35,7 +35,7 @@ implementation
 uses
   TraceLog, SysUtils,
   // These 2 give us a convenient way to access socket/system error codes
-  Sockets, {$IFDEF UNIX}BaseUnix{$ENDIF};
+  {$IFDEF UNIX}BaseUnix,{$ENDIF} Sockets;
 
 const
   MAX_MESSAGE_LENGTH = 4096;

--- a/shared/LauncherConnection.pas
+++ b/shared/LauncherConnection.pas
@@ -2,6 +2,8 @@ unit LauncherConnection;
 
 interface
 
+{$WARN 5071 OFF : Private type "$1.$2" never used}
+
 uses
   Classes, Generics.Collections, ssockets;
 

--- a/shared/LauncherConnection.pas
+++ b/shared/LauncherConnection.pas
@@ -22,6 +22,7 @@ type
     procedure ProcessSendQueue;
   public
     constructor Create(Port: Integer);
+    destructor Destroy; override;
     procedure Execute; override;
 
     // This callback will be run in main thread through Synchronize.
@@ -129,6 +130,14 @@ begin
   Queue := FSendQueue.LockList;
   Queue.Add(Message);
   FSendQueue.UnlockList;
+end;
+
+destructor TLauncherConnection.Destroy;
+begin
+  if Assigned(FSocket) then
+    FSocket.Free;
+  FSendQueue.Free;
+  inherited Destroy;
 end;
 
 end.

--- a/shared/LauncherConnection.pas
+++ b/shared/LauncherConnection.pas
@@ -61,6 +61,9 @@ begin
     if ReadLength > 0 then begin
       FReceivedMessage := ReadBuffer;
       Synchronize(HandleMessage);
+    end else if ReadLength = 0 then begin
+      Debug('[LauncherConnection] Launcher closed the connection');
+      Terminate;
     end;
 
     ProcessSendQueue;

--- a/shared/LauncherIPC.pas
+++ b/shared/LauncherIPC.pas
@@ -28,6 +28,7 @@ uses
 
 procedure TLauncherIPC.Connect(Port: Integer);
 begin
+  Debug('[LauncherIPC] Connecting to launcher...');
   FConnectionThread := TLauncherConnection.Create(Port);
   FConnectionThread.OnMessage := HandleMessage;
   FConnectionThread.OnTerminate := HandleTerminate;

--- a/shared/LauncherIPC.pas
+++ b/shared/LauncherIPC.pas
@@ -30,11 +30,13 @@ uses
 
 procedure TLauncherIPC.Connect(Port: Integer);
 begin
+  FConnectionThread.Free;
+
   Debug('[LauncherIPC] Starting launcher connection thread');
   FConnectionThread := TLauncherConnection.Create(Port);
   FConnectionThread.OnMessage := HandleMessage;
   FConnectionThread.OnTerminate := HandleTerminate;
-  FConnectionThread.FreeOnTerminate := True;
+  FConnectionThread.FreeOnTerminate := False;
   FConnectionThread.Start;
   FThreadAlive := True;
 end;
@@ -64,6 +66,7 @@ begin
     FConnectionThread.WaitFor;
   end;
 
+  FConnectionThread.Free;
   inherited;
 end;
 

--- a/shared/LauncherIPC.pas
+++ b/shared/LauncherIPC.pas
@@ -29,7 +29,7 @@ uses
 
 procedure TLauncherIPC.Connect(Port: Integer);
 begin
-  Debug('[LauncherIPC] Connecting to launcher...');
+  Debug('[LauncherIPC] Starting launcher connection thread');
   FConnectionThread := TLauncherConnection.Create(Port);
   FConnectionThread.OnMessage := HandleMessage;
   FConnectionThread.OnTerminate := HandleTerminate;
@@ -45,7 +45,7 @@ end;
 
 procedure TLauncherIPC.HandleTerminate(Sender: TObject);
 begin
-  Debug('[LauncherIPC] Connection terminated');
+  Debug('[LauncherIPC] Thread terminated');
   FThreadAlive := False;
 end;
 

--- a/shared/LauncherIPC.pas
+++ b/shared/LauncherIPC.pas
@@ -1,0 +1,51 @@
+unit LauncherIPC;
+
+interface
+
+uses
+  LauncherConnection, Classes;
+
+type
+  // Shared base class that manages the connection thread, and provides common
+  // functionalities used by both client and server.
+  TLauncherIPC = class
+  private
+    FConnectionThread: TLauncherConnection;
+    FThreadAlive: Boolean;
+    procedure HandleTerminate(Sender: TObject);
+  protected
+    procedure HandleMessage(Message: String); virtual; abstract;
+  public
+    procedure Connect(Port: Integer);
+    procedure SendMessage(Message: String);
+    property ThreadAlive: Boolean read FThreadAlive;
+  end;
+
+implementation
+
+uses
+  TraceLog;
+
+procedure TLauncherIPC.Connect(Port: Integer);
+begin
+  FConnectionThread := TLauncherConnection.Create(Port);
+  FConnectionThread.OnMessage := HandleMessage;
+  FConnectionThread.OnTerminate := HandleTerminate;
+  FConnectionThread.FreeOnTerminate := True;
+  FConnectionThread.Start;
+  FThreadAlive := True;
+end;
+
+procedure TLauncherIPC.HandleTerminate(Sender: TObject);
+begin
+  Debug('[LauncherIPC] Connection terminated');
+  FThreadAlive := False;
+end;
+
+procedure TLauncherIPC.SendMessage(Message: String);
+begin
+  if FThreadAlive then
+    FConnectionThread.SendMessage(Message);
+end;
+
+end.

--- a/shared/LauncherIPC.pas
+++ b/shared/LauncherIPC.pas
@@ -46,11 +46,14 @@ begin
   ParseInput(Message, 255);
 end;
 
+{$PUSH}
+{$WARN 5024 OFF : Parameter "$1" not used}
 procedure TLauncherIPC.HandleTerminate(Sender: TObject);
 begin
   Debug('[LauncherIPC] Thread terminated');
   FThreadAlive := False;
 end;
+{$POP}
 
 procedure TLauncherIPC.SendMessage(Message: String);
 begin

--- a/shared/LauncherIPC.pas
+++ b/shared/LauncherIPC.pas
@@ -14,6 +14,7 @@ type
     FThreadAlive: Boolean;
     procedure HandleTerminate(Sender: TObject);
   protected
+    procedure HandleCommand(Message: String);
     procedure HandleMessage(Message: String); virtual; abstract;
   public
     procedure Connect(Port: Integer);
@@ -24,7 +25,7 @@ type
 implementation
 
 uses
-  TraceLog;
+  Command, TraceLog;
 
 procedure TLauncherIPC.Connect(Port: Integer);
 begin
@@ -35,6 +36,11 @@ begin
   FConnectionThread.FreeOnTerminate := True;
   FConnectionThread.Start;
   FThreadAlive := True;
+end;
+
+procedure TLauncherIPC.HandleCommand(Message: String);
+begin
+  ParseInput(Message, 255);
 end;
 
 procedure TLauncherIPC.HandleTerminate(Sender: TObject);

--- a/shared/LauncherIPC.pas
+++ b/shared/LauncherIPC.pas
@@ -18,6 +18,7 @@ type
     procedure HandleMessage(Message: String); virtual; abstract;
   public
     procedure Connect(Port: Integer);
+    destructor Destroy; override;
     procedure SendMessage(Message: String);
     property ThreadAlive: Boolean read FThreadAlive;
   end;
@@ -53,6 +54,17 @@ procedure TLauncherIPC.SendMessage(Message: String);
 begin
   if FThreadAlive then
     FConnectionThread.SendMessage(Message);
+end;
+
+destructor TLauncherIPC.Destroy;
+begin
+  if FThreadAlive then begin
+    Debug('[LauncherIPC] Killing thread...');
+    FConnectionThread.Terminate;
+    FConnectionThread.WaitFor;
+  end;
+
+  inherited;
 end;
 
 end.


### PR DESCRIPTION
Here's my attempt to implement inter-process communication between client/server and launcher, using a TCP socket. It may be a bit over-engineered, but I think it allows adding new messages without any effort.

**Key ideas**
- Launcher is listening on port 23093, and game connects to it
- We spawn a new thread for launcher connection. In code, I make the assumption that when thread is alive, then it means we're connected with launcher
- Messages that we send between game and launcher are strings with UTF-8 encoding. Honestly I was expecting that I would have to deal with buffer arrays of wide chars, but seems like sending and receiving strings works fine. It may need some more testing though
- As of now the messages don't have any format. I'm personally leaning towards JSON, for the sake of easier maintenance 
- If launcher connection terminates (for example when closing the launcher, while the game is still running), then we keep trying to reconnect, in case user starts launcher again. I hope it's not a performance problem to spawn a new thread every few seconds :)
- Launcher connection is configurable with CVars

**Important notes**
1. Before calling `*LauncherIPC` methods, you must check if `launcher_ipc_enable` cvar is True. Otherwise, LauncherIPC variable will not be assigned.
2. Default value of `launcher_ipc_enable` is False, so launcher must set its value (could be configurable through UI; internally, it could be passed as command-line parameter as it affects both client and server)
3. Launcher may need to enforce `sv_pauseonidle 0` on local server, so that launcher IPC works as expected

When it comes to code's architecture, my idea is that every message we send or receive should be implemented as a method of `ClientLauncherIPC` or `ServerLauncherIPC` class. Those 2 classes implement `HandleMessage` method - here we explicitly list the message handlers (which are just methods) that client/server should call when receiving a new message from launcher. According to me, every message handler should check if the received message should be handled by this handler (by checking some identifier sent along with the message - here's where JSON would come handy), and if not then it should stop processing the message. Similarly, every message that we want to send should be implemented as a method. In this way, the implementation of launcher IPC barely touches the main codebase - we just call `Connect` and the methods for sending messages. All the rest is implemented by those 2 *IPC classes.


**Testing**
To test the changes, remember to set `launcher_ipc_enable 1` and `log_level 1` on client and server. For the server, I additionally recommend `sv_pauseonidle 0`.
Some cases to check:

---
1. Start launcher (from [opensoldat-ipc branch](https://github.com/opensoldat/launcher/tree/opensoldat-ipc))
2. Run client and server

Expected result: all parties involved are detecting the connection - you should see logs on both game's and launcher's side. In client and server you will see messages with `[LauncherIPC]` and `[LauncherConnection]` headers. Launcher just reacts with `New IPC connection` and `Client disconnected`

---
1. Make sure launcher is stopped
2. Run client and server

Expected result: game will fail to connect to launcher, but it should keep trying to reconnect every 5 seconds

---
1. Start launcher
2. Run client and server
3. While client and/or server is running, stop the launcher

Expected result: game detects that launcher has stopped the connection, and as a reaction it keeps trying to reconnect every 5 seconds

---

**TODO**
- [X] CVars to customize launcher IPC
- [X] Better error handling, if needed (for example exceptions are thrown in connection thread)
- [X] Add launcher IPC to server project

These changes are meant to be merged together with changes in launcher's repo: https://github.com/opensoldat/launcher/tree/opensoldat-ipc
