### PR TITLE
Small misc fixes #5

### DIFF
--- a/client/GameMenus.pas
+++ b/client/GameMenus.pas
@@ -492,7 +492,20 @@ begin
   Result := False;
 
   if HoveredButton <> nil then
+  begin
     Result := GameMenuAction(HoveredMenu, HoveredButtonIndex);
+  end
+  else
+  begin
+    // Clicking off of the Limbo menu hides it. Allows players who leave the
+    // weapons menu active to begin moving quickly without having to press the
+    // right weapon button, or worse yet click on it.
+    if (MySprite > 0) and (Sprite[MySprite].SelWeapon <> 0) and (LimboMenu <> nil) and (LimboMenu.Active) then
+    begin
+      GameMenuShow(LimboMenu, False);
+      Result := True;
+    end;
+  end;
 end;
 
 end.

--- a/client/InterfaceGraphics.pas
+++ b/client/InterfaceGraphics.pas
@@ -1747,7 +1747,8 @@ begin
       i := StrToInt(VoteTarget);
 
       if (i > 0) and (i <= MAX_SPRITES) then
-        Str[1] := WideString(Sprite[i].Player.Name);
+        if Sprite[i].Active then
+          Str[1] := WideString(Sprite[i].Player.Name);
     end;
 
     GfxTextColor(RGBA(254, 104, 104, 225));

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -997,6 +997,7 @@ begin
   a := Default(TVector2);
   b := Default(TVector2);
   RandomizeStart(a, team);
+  // TODO: Probably smarter to check `CreateSprite` return value than rely on `PlayersNum` check alone...
   p := CreateSprite(a, b, 1, 255, NewPlayer, True);
   Result := p;
 

--- a/server/ServerHelper.pas
+++ b/server/ServerHelper.pas
@@ -70,8 +70,9 @@ var
 begin
   Result := 0;
   for i := 1 to MAX_SPRITES do
-    if Sprite[i].Player.Name = Name then
-      Result := i;
+    if Sprite[i].Active then
+      if Sprite[i].Player.Name = Name then
+        Result := i;
 end;
 
 function NameToHW(Name: String): String;
@@ -80,8 +81,9 @@ var
 begin
   Result := '0';
   for i := 1 to MAX_SPRITES do
-    if Sprite[i].Player.Name = Name then
-      Result := Sprite[i].Player.hwid;
+    if Sprite[i].Active then
+      if Sprite[i].Player.Name = Name then
+        Result := Sprite[i].Player.hwid;
 end;
 
 function RGB(r, g, b: Byte): Cardinal;
@@ -299,7 +301,7 @@ begin
   begin
     // Player Left Game
     for i := 1 to MAX_SPRITES do
-      if (Sprite[i].Player.ControlMethod = BOT) and Sprite[i].Active then
+      if Sprite[i].Active and (Sprite[i].Player.ControlMethod = BOT) then
       begin
         if (Teams[1] > Teams[2]) and (Sprite[i].Player.Team = TEAM_ALPHA) then
         begin

--- a/server/ServerLoop.pas
+++ b/server/ServerLoop.pas
@@ -107,9 +107,8 @@ begin
 
     if MainTickCounter mod 1000 = 0 then
       for j := 1 to MAX_PLAYERS do
-      begin
-        Sprite[j].Player.KnifeWarnings := 0;
-      end;
+        if Sprite[j].Active then
+          Sprite[j].Player.KnifeWarnings := 0;
 
     // sync changed cvars to all players
     if CvarsNeedSyncing then
@@ -450,9 +449,13 @@ begin
             MainConsole.Console('** Detected possible Mass-Flag cheating from ' +
               Sprite[j].Player.Name, WARNING_MESSAGE_COLOR);
           end;
-          Sprite[j].Player.GrabsPerSecond := 0;
-          Sprite[j].Player.ScoresPerSecond := 0;
-          Sprite[j].Player.GrabbedInBase := False;
+
+          if Sprite[j].Active then
+          begin
+            Sprite[j].Player.GrabsPerSecond := 0;
+            Sprite[j].Player.ScoresPerSecond := 0;
+            Sprite[j].Player.GrabbedInBase := False;
+          end;
         end;
 
     if sv_healthcooldown.Value > 0 then

--- a/shared/AI.pas
+++ b/shared/AI.pas
@@ -729,7 +729,7 @@ begin
               end;
           end;
 
-          if (SpriteC.Brain.CurrentWaypoint = 0) or (k > 0) then
+          if (SpriteC.Brain.CurrentWaypoint = 0) and (k > 0) then
             if (SpriteC.Brain.PathNum = BotPath.Waypoint[k].PathNum) or
                 (SpriteC.Brain.CurrentWaypoint = 0) then
             begin
@@ -938,6 +938,7 @@ begin
             // dont follow this flag if my flag is not inbase
             if ((sv_gamemode.Value = GAMESTYLE_CTF) or (sv_gamemode.Value = GAMESTYLE_INF)) and
                 (Thing[i].Style <> SpriteC.Player.Team) and
+                (TeamFlag[SpriteC.Player.Team] > 0) and
                 not Thing[TeamFlag[SpriteC.Player.Team]].InBase then
               SeeThing := False;
             // dont take it if is flag in base

--- a/shared/Calc.pas
+++ b/shared/Calc.pas
@@ -202,7 +202,7 @@ var
   U, X, Y: Single;
 begin
   U := ((P3.X - P1.X) * (P2.X - P1.X) + (P3.Y - P1.Y) *
-    (P2.Y - P1.Y)) / (Sqr(P2.X - P1.X) + Sqr(P2.Y - P1.Y));
+    (P2.Y - P1.Y)) / Max(MinSingle, (Sqr(P2.X - P1.X) + Sqr(P2.Y - P1.Y)));
 
   X := P1.X + U * (P2.X - P1.X);
   Y := P1.Y + U * (P2.Y - P1.Y);

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -994,7 +994,7 @@ begin
   sv_advancedspectator := TBooleanCvar.Add('sv_advancedspectator', 'Enables/disables advanced spectator mode', True, [CVAR_SERVER, CVAR_SYNC], nil);
   sv_radio := TBooleanCvar.Add('sv_radio', 'Enables/disables radio chat', False, [CVAR_SERVER, CVAR_SYNC], nil);
   sv_info := TStringCvar.Add('sv_info', 'A website or e-mail address, or any other short text describing your server', '', [CVAR_SERVER, CVAR_SYNC], nil, 0, 60);
-  sv_gravity := TSingleCvar.Add('sv_gravity', 'Gravity', 0.06, [CVAR_SERVER, CVAR_SYNC], @sv_gravityChange, MinSingle, MaxSingle);
+  sv_gravity := TSingleCvar.Add('sv_gravity', 'Gravity', 0.06, [CVAR_SERVER, CVAR_SYNC], @sv_gravityChange, -MaxSingle, MaxSingle);
   sv_hostname := TStringCvar.Add('sv_hostname', 'Name of the server', 'OpenSoldat Server', [CVAR_SERVER, CVAR_SYNC], nil, 0, 24);
   sv_website := TStringCvar.Add('sv_website', 'Server website', '', [CVAR_SERVER, CVAR_SYNC], nil, 0, 255);
 

--- a/shared/Demo.pas
+++ b/shared/Demo.pas
@@ -357,7 +357,7 @@ begin
       Exit;
     end;
 
-    if (FSkipTo > 0) and (MainTickCounter >= FSkipTo) then
+    if (FSkipTo >= 0) and (MainTickCounter >= FSkipTo) then
     begin
       FSkipTo := -1;
       ShouldRenderFrames := True;

--- a/shared/Demo.pas
+++ b/shared/Demo.pas
@@ -245,6 +245,9 @@ procedure TDemoRecorder.SavePosition;
 var
   MovementMsg: TMsg_ServerSpriteDelta_Movement;
 begin
+  if MySprite = 0 then
+    Exit;
+
   MovementMsg.Header.ID := MsgID_Delta_Movement;
 
   MovementMsg.Num := MySprite;

--- a/shared/mechanics/Sprites.pas
+++ b/shared/mechanics/Sprites.pas
@@ -228,14 +228,16 @@ implementation
 
 uses
   {$IFDEF SERVER}
-    {$IFDEF SCRIPT}ScriptDispatcher,{$ENDIF}
-    ServerHelper, LogFile,
-    NetworkServerSprite, NetworkServerMessages, NetworkServerConnection, NetworkServerGame, NetworkServerThing,
+  {$IFDEF SCRIPT}ScriptDispatcher,{$ENDIF}
+  ServerHelper, LogFile,
+  NetworkServerSprite, NetworkServerMessages, NetworkServerConnection, NetworkServerGame, NetworkServerThing,
+  Server,
   {$ELSE}
-    Sound, Demo, GameStrings, ClientGame, GameMenus, Sparks,
-    NetworkClientSprite,
+  Sound, Demo, GameStrings, ClientGame, GameMenus, Sparks,
+  NetworkClientSprite,
+  Client,
   {$ENDIF}
-  Bullets, {$IFDEF SERVER}Server,{$ELSE}Client,{$ENDIF} Util, SysUtils, Calc, Math, TraceLog, Game, Control, Things, Cvar;
+  Bullets, Util, SysUtils, Calc, Math, TraceLog, Game, Control, Things, Cvar;
 
 function CreateSprite(sPos, sVelocity: TVector2; sStyle, N: Byte; Player: TPlayer; TransferOwnership: Boolean): Integer;
 var

--- a/shared/mechanics/Sprites.pas
+++ b/shared/mechanics/Sprites.pas
@@ -13,7 +13,7 @@ unit Sprites;
 interface
 
 uses
-  Parts, Anims, MapFile, PolyMap, Net, Weapons, Constants, Vector;
+  Parts, Anims, MapFile, PolyMap, Weapons, Constants, Vector;
 
 const
   MAX_SPRITES = MAX_PLAYERS;

--- a/shared/mechanics/Sprites.pas
+++ b/shared/mechanics/Sprites.pas
@@ -237,7 +237,7 @@ uses
   NetworkClientSprite,
   Client,
   {$ENDIF}
-  Bullets, Util, SysUtils, Calc, Math, TraceLog, Game, Control, Things, Cvar, Net;
+  Bullets, Util, SysUtils, Calc, Math, TraceLog, Game, Control, Things, Cvar;
 
 function CreateSprite(sPos, sVelocity: TVector2; sStyle, N: Byte; Player: TPlayer; TransferOwnership: Boolean): Integer;
 var
@@ -1488,7 +1488,9 @@ begin
   if IsPlayerObjectOwner then
     FreeAndNil(Player);
   IsPlayerObjectOwner := False;
+  {$IFDEF SERVER}
   Player := DummyPlayer;
+  {$ENDIF}
 
   // sort the players frag list
   SortPlayers;

--- a/shared/mechanics/Sprites.pas
+++ b/shared/mechanics/Sprites.pas
@@ -13,7 +13,7 @@ unit Sprites;
 interface
 
 uses
-  Parts, Anims, MapFile, PolyMap, Weapons, Constants, Vector;
+  Parts, Anims, MapFile, PolyMap, Weapons, Constants, Vector, Net;
 
 const
   MAX_SPRITES = MAX_PLAYERS;

--- a/shared/mechanics/Sprites.pas
+++ b/shared/mechanics/Sprites.pas
@@ -237,7 +237,7 @@ uses
   NetworkClientSprite,
   Client,
   {$ENDIF}
-  Bullets, Util, SysUtils, Calc, Math, TraceLog, Game, Control, Things, Cvar;
+  Bullets, Util, SysUtils, Calc, Math, TraceLog, Game, Control, Things, Cvar, Net;
 
 function CreateSprite(sPos, sVelocity: TVector2; sStyle, N: Byte; Player: TPlayer; TransferOwnership: Boolean): Integer;
 var
@@ -1488,6 +1488,7 @@ begin
   if IsPlayerObjectOwner then
     FreeAndNil(Player);
   IsPlayerObjectOwner := False;
+  Player := DummyPlayer;
 
   // sort the players frag list
   SortPlayers;

--- a/shared/network/Net.pas
+++ b/shared/network/Net.pas
@@ -179,7 +179,6 @@ type
       FActive: Boolean;
       FAddress: SteamNetworkingIPAddr;
 
-      FHost: HSteamListenSocket;
       {$IFDEF SERVER}
       FPollGroup: HSteamNetPollGroup;
       {$ENDIF}
@@ -207,7 +206,6 @@ type
 
       procedure SetDebugLevel(Level: ESteamNetworkingSocketsDebugOutputType);
 
-      property Host: HSteamListenSocket read FHost;
       property NetworkingSocket: PISteamNetworkingSockets read NetworkingSockets;
       property NetworkingUtil: PISteamNetworkingUtils read NetworkingUtils;
 
@@ -217,6 +215,8 @@ type
 
   {$IFDEF SERVER}
   TServerNetwork = class(TNetwork)
+  private
+    FHost: HSteamListenSocket;
   public
     procedure ProcessEvents(pInfo: PSteamNetConnectionStatusChangedCallback_t); override;
     constructor Create(Host: String; Port: Word);
@@ -226,6 +226,7 @@ type
     procedure HandleMessages(IncomingMsg: PSteamNetworkingMessage_t);
     function SendData(var Data; Size: Integer; peer: HSteamNetConnection; Flags: Integer): Boolean;
     procedure UpdateNetworkStats(Player: Byte);
+    property Host: HSteamListenSocket read FHost;
   end;
   {$ELSE}
   TClientNetwork = class(TNetwork)

--- a/shared/network/Net.pas
+++ b/shared/network/Net.pas
@@ -1445,10 +1445,16 @@ var
   PacketHeader: PMsgHeader;
 begin
   if IncomingMsg^.m_cbSize < SizeOf(TMsgHeader) then
+  begin
+    IncomingMsg.Release();
     Exit; // truncated packet
+  end;
 
   if IncomingMsg^.m_nConnUserData = 0 then
+  begin
+    IncomingMsg.Release();
     Exit;
+  end;
 
   Player := TPlayer(IncomingMsg^.m_nConnUserData);
   PacketHeader := PMsgHeader(IncomingMsg^.m_pData);
@@ -1472,7 +1478,10 @@ begin
 
   // all the following commands can only be issued after the player has joined the game.
   if (Player.SpriteNum = 0) or (Sprite[Player.SpriteNum].Player <> Player) then
+  begin
+    IncomingMsg.Release();
     Exit;
+  end;
 
   case PacketHeader.ID of
     MsgID_ClientSpriteSnapshot:

--- a/shared/network/Net.pas
+++ b/shared/network/Net.pas
@@ -1141,6 +1141,7 @@ end;
 procedure TClientNetwork.HandleMessages(IncomingMsg: PSteamNetworkingMessage_t);
 var
   PacketHeader: PMsgHeader;
+  ShouldRelease: Boolean;
 begin
   if IncomingMsg^.m_cbSize < SizeOf(TMsgHeader) then
     Exit; // truncated packet
@@ -1149,6 +1150,8 @@ begin
 
   if DemoRecorder.Active then
     DemoRecorder.SaveRecord(IncomingMsg^.m_pData^, IncomingMsg^.m_cbSize);
+
+  ShouldRelease := not DemoPlayer.Active;
 
   case PacketHeader.ID of
     MsgID_PlayersList:
@@ -1278,7 +1281,7 @@ begin
     {$ENDIF}
   end;
 
-  if not DemoPlayer.Active then
+  if ShouldRelease then
     IncomingMsg.Release();
 end;
 

--- a/shared/network/Net.pas
+++ b/shared/network/Net.pas
@@ -174,43 +174,43 @@ const
 
 type
   TNetwork = class
-    private
-      FInit: Boolean;
-      FActive: Boolean;
-      FAddress: SteamNetworkingIPAddr;
+  private
+    FInit: Boolean;
+    FActive: Boolean;
+    FAddress: SteamNetworkingIPAddr;
 
-      {$IFDEF SERVER}
-      FPollGroup: HSteamNetPollGroup;
-      {$ENDIF}
-      NetworkingSockets: PISteamNetworkingSockets;
-      NetworkingUtils: PISteamNetworkingUtils;
-    public
-      property Active: Boolean read FActive write FActive;
-      constructor Create();
-      destructor Destroy(); override;
+    {$IFDEF SERVER}
+    FPollGroup: HSteamNetPollGroup;
+    {$ENDIF}
+    NetworkingSockets: PISteamNetworkingSockets;
+    NetworkingUtils: PISteamNetworkingUtils;
+  public
+    property Active: Boolean read FActive write FActive;
+    constructor Create();
+    destructor Destroy(); override;
 
-      function Disconnect(Now: Boolean): Boolean; virtual; abstract;
-      procedure ProcessEvents(pInfo: PSteamNetConnectionStatusChangedCallback_t); virtual; abstract;
+    function Disconnect(Now: Boolean): Boolean; virtual; abstract;
+    procedure ProcessEvents(pInfo: PSteamNetConnectionStatusChangedCallback_t); virtual; abstract;
 
-      function GetDetailedConnectionStatus(hConn: HSteamNetConnection): String;
-      function GetConnectionRealTimeStatus(hConn: HSteamNetConnection): SteamNetConnectionRealTimeStatus_t;
-      procedure SetConnectionName(hConn: HSteamNetConnection; Name: AnsiString);
-      function GetStringAddress(pAddress: PSteamNetworkingIPAddr; Port: Boolean): AnsiString;
+    function GetDetailedConnectionStatus(hConn: HSteamNetConnection): String;
+    function GetConnectionRealTimeStatus(hConn: HSteamNetConnection): SteamNetConnectionRealTimeStatus_t;
+    procedure SetConnectionName(hConn: HSteamNetConnection; Name: AnsiString);
+    function GetStringAddress(pAddress: PSteamNetworkingIPAddr; Port: Boolean): AnsiString;
 
-      function SetGlobalConfigValueInt32(eValue: ESteamNetworkingConfigValue; val: int32): Boolean;
-      function SetGlobalConfigValueFloat(eValue: ESteamNetworkingConfigValue; val: Single): Boolean;
-      function SetGlobalConfigValueString(eValue: ESteamNetworkingConfigValue; val: PChar): Boolean;
-      function SetConnectionConfigValueInt32(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: int32): Boolean;
-      function SetConnectionConfigValueFloat(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: int32): Boolean;
-      function SetConnectionConfigValueString(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: int32): Boolean;
+    function SetGlobalConfigValueInt32(eValue: ESteamNetworkingConfigValue; val: int32): Boolean;
+    function SetGlobalConfigValueFloat(eValue: ESteamNetworkingConfigValue; val: Single): Boolean;
+    function SetGlobalConfigValueString(eValue: ESteamNetworkingConfigValue; val: PChar): Boolean;
+    function SetConnectionConfigValueInt32(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: int32): Boolean;
+    function SetConnectionConfigValueFloat(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: int32): Boolean;
+    function SetConnectionConfigValueString(hConn: HSteamNetConnection; eValue: ESteamNetworkingConfigValue; val: int32): Boolean;
 
-      procedure SetDebugLevel(Level: ESteamNetworkingSocketsDebugOutputType);
+    procedure SetDebugLevel(Level: ESteamNetworkingSocketsDebugOutputType);
 
-      property NetworkingSocket: PISteamNetworkingSockets read NetworkingSockets;
-      property NetworkingUtil: PISteamNetworkingUtils read NetworkingUtils;
+    property NetworkingSocket: PISteamNetworkingSockets read NetworkingSockets;
+    property NetworkingUtil: PISteamNetworkingUtils read NetworkingUtils;
 
-      property Port: Word read FAddress.m_port write FAddress.m_port;
-      property Address: SteamNetworkingIPAddr read FAddress;
+    property Port: Word read FAddress.m_port write FAddress.m_port;
+    property Address: SteamNetworkingIPAddr read FAddress;
   end;
 
   {$IFDEF SERVER}

--- a/shared/network/NetworkClientConnection.pas
+++ b/shared/network/NetworkClientConnection.pas
@@ -386,7 +386,7 @@ begin
   ClientPlayerReceivedCounter := CLIENTPLAYERRECIEVED_TIME;
 
   // Begin rendering so that the team menu selection is visible
-  if not (DemoPlayer.Active and (DemoPlayer.SkipTo = -1)) then
+  if not (DemoPlayer.Active and (DemoPlayer.SkipTo >= 0)) then
     ShouldRenderFrames := True;
 
   if cl_player_team.Value > 0 then

--- a/shared/network/NetworkClientGame.pas
+++ b/shared/network/NetworkClientGame.pas
@@ -104,7 +104,8 @@ begin
   if (NewPlayerMsg.AdoptSpriteID = 1) then
   begin
     d := 1;
-    MySprite := i;
+    if (not DemoPlayer.Active) or (i = MAX_PLAYERS) then
+      MySprite := i;
 
     if DemoPlayer.Active then
       Sprite[MySprite].Player.DemoPlayer := True;

--- a/shared/network/NetworkServerConnection.pas
+++ b/shared/network/NetworkServerConnection.pas
@@ -335,8 +335,8 @@ begin
     Player.Team := NewTeam
   else
   begin
-    Sprite[Player.SpriteNum].Kill;
     ServerSendUnAccepted(Player.Peer, SERVER_FULL);
+    Sprite[Player.SpriteNum].Kill;
     Exit;
   end;
   {$ENDIF}
@@ -777,8 +777,6 @@ begin
     if Sprite[Num].IsNotSpectator() and (Why <> KICK_AC) and (Why <> KICK_CHEAT) and (Why <> KICK_CONSOLE) and (Why <> KICK_VOTED) then
       Sprite[Num].DropWeapon();
 
-    Sprite[Num].Kill;
-
     for j := 1 to MAX_PLAYERS do
       if (Trim(TKList[j]) = '') or (TKList[j] = Player.IP) then
       begin
@@ -791,6 +789,8 @@ begin
 
     AddLineToLogFile(GameLog, ' Net - ' + Player.Name +
       ' disconnected ' + DateToStr(Date) + ' ' + TimeToStr(Time), ConsoleLogFileName);
+
+    Sprite[Num].Kill;
   end;
 
   UDP.NetworkingSocket.CloseConnection(Player.Peer, 0, '', not Now);

--- a/shared/network/NetworkServerConnection.pas
+++ b/shared/network/NetworkServerConnection.pas
@@ -778,7 +778,6 @@ begin
       Sprite[Num].DropWeapon();
 
     Sprite[Num].Kill;
-    Sprite[Num].Player := DummyPlayer;
 
     for j := 1 to MAX_PLAYERS do
       if (Trim(TKList[j]) = '') or (TKList[j] = Player.IP) then

--- a/shared/network/NetworkServerGame.pas
+++ b/shared/network/NetworkServerGame.pas
@@ -153,6 +153,9 @@ begin
   Player := TPlayer(NetMessage^.m_nConnUserData);
   i := Player.SpriteNum;
 
+  if not Sprite[Player.SpriteNum].Active then
+    Exit;
+
   if VoteActive then
   begin
     // if a vote against a player is in progress,
@@ -220,6 +223,9 @@ begin
   VoteMapMsg := PMsg_VoteMap(NetMessage^.m_pData)^;
   Player := TPlayer(NetMessage^.m_nConnUserData);
   i := Player.SpriteNum;
+
+  if not Sprite[i].Active then
+    Exit;
 
   if VoteMapMsg.MapID > MapsList.Count - 1 then
     Exit;


### PR DESCRIPTION
- While recording demos, don't record `MySprite` position if `MySprite` is not set.
- Only assign demo viewer sprite to the demo recorder sprite.
  - This isn't a 100% correct approach because it ignores some aspects of client-side demos, but it doesn't crash or have weird behavior which the current code does.
- Don't accidentally double free `TMsg_MapChange` packets.
  - They were getting double freed when playing demos.
- Move `FlushMsg` to `TClientNetwork`.
- Move `FPeer` to `TClientNetwork`, change `TNetwork.Disconnect` to a virtual function.
- Move `FHost` to `TServerNetwork`.
- Indent `TNetwork` like the rest of the classes.
- Don't render frames when seeking in demo, allow seeking to tick 0.
- Clean up `Sprites.pas` usings a bit.
- Always assign `TSprite.Player` to `DummyPlayer` when destructing.
- Add some `TSprite.Active` checks before accessing `TSprite.Player`.
- Make minimum value of `sv_gravity` `-MaxSingle`.
- Avoid division by zero in `PointLineDistance` function, triggered by polygons with degenerate (0, 0, 0) normal vectors.
- Fix some crashes with bots on weird teams.
- Only call `TSprite.Kill` after we are done using it's player object.
- Avoid leaking invalid packets.
- Clicking off of the Limbo menu hides it. Restores 1.7.1 behavior.
  - Closes #152.