### PR TITLE
Small misc fixes #6

### DIFF
--- a/client/InterfaceGraphics.pas
+++ b/client/InterfaceGraphics.pas
@@ -2765,7 +2765,7 @@ begin
   end;
 
   // Team Box
-  if Int.Team and not DemoPlayer.Active and IsTeamGame then
+  if Int.Team and IsTeamGame then
   begin
     x := Int.TeamBox_X * _iscala.x;
     y := Int.TeamBox_Y * _iscala.y;

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -1120,6 +1120,7 @@ begin
     begin
       MainConsole.Console('Error: Could not load map ' +
         StartMap.Name, DEBUG_MESSAGE_COLOR);
+      ProgReady := False;
       Exit;
     end;
   end;

--- a/shared/AI.pas
+++ b/shared/AI.pas
@@ -729,7 +729,7 @@ begin
               end;
           end;
 
-          if (SpriteC.Brain.CurrentWaypoint = 0) and (k > 0) then
+          if k > 0 then
             if (SpriteC.Brain.PathNum = BotPath.Waypoint[k].PathNum) or
                 (SpriteC.Brain.CurrentWaypoint = 0) then
             begin

--- a/shared/MapFile.pas
+++ b/shared/MapFile.pas
@@ -164,6 +164,9 @@ begin
   if PHYSFS_exists(PChar('maps/' + Map.Name + '.pms')) then
   begin
     Buffer.Data := PHYSFS_readBuffer(PChar('maps/' + Map.Name + '.pms'));
+  end else if PHYSFS_exists(PChar('maps/' + Map.Name + '.PMS')) then
+  begin
+    Buffer.Data := PHYSFS_readBuffer(PChar('maps/' + Map.Name + '.PMS'));
   end else
   begin
     // Unmount previous map
@@ -173,6 +176,8 @@ begin
       Exit;
     // Read PMS file
     Buffer.Data := PHYSFS_readBuffer(PChar('current_map/maps/' + Map.MapName + '.pms'));
+    if Buffer.Data = nil then
+      Buffer.Data := PHYSFS_readBuffer(PChar('current_map/maps/' + Map.MapName + '.PMS'));
   end;
 
   if Buffer.Data = nil then

--- a/shared/Util.pas
+++ b/shared/Util.pas
@@ -241,7 +241,8 @@ end;
 function GetMapChecksum(Map: TMapInfo): TSHA1Digest;
 begin
   Result := Default(TSHA1Digest);
-  if PHYSFS_exists(PChar('maps/' + Map.MapName + '.pms')) then
+  if PHYSFS_exists(PChar('maps/' + Map.MapName + '.pms')) or
+     PHYSFS_exists(PChar('maps/' + Map.MapName + '.PMS')) then
     Result := GameModChecksum
   else if FileExists(Map.Path) then
     Result := Sha1File(Map.Path, 4096);
@@ -300,7 +301,8 @@ begin
     end;
   end else
   begin
-    if PHYSFS_exists(PChar('maps/' + MapName + '.pms')) then
+    if PHYSFS_exists(PChar('maps/' + MapName + '.pms')) or
+       PHYSFS_exists(PChar('maps/' + MapName + '.PMS')) then
     begin
       MapInfo.Name := MapName;
       MapInfo.MapName := MapName;


### PR DESCRIPTION
- Bot needs to move along its path.
  - I previously fixed a minor waypoint bug, but in the wrong way, which resulted in bots not progressing through their waypoint path.
- Render team score interface background while playing demos.
  - It was disabled as a special case but I couldn't figure out why, so I just enabled it.
- Stupidest simplest thing to load .PMS files with capital extension.
  - Needed to load `.PMS` files (which is a huge percentage of Soldat maps due to old PolyWorks behavior) without modification. Still not decided on how to handle all the case sensitivity issues, but this will ease up some annoyances for users in the meantime.