### PR TITLE
Small misc fixes #7

### DIFF
--- a/server/Server.pas
+++ b/server/Server.pas
@@ -96,9 +96,9 @@ var
   sv_tm_limit: TIntegerCvar;
   sv_rm_limit: TIntegerCvar;
 
+  sv_inf_redaward: TIntegerCvar;
   sv_inf_limit: TIntegerCvar;
   sv_inf_bluelimit: TIntegerCvar;
-  sv_inf_redaward: TIntegerCvar;
 
   sv_htf_limit: TIntegerCvar;
   sv_htf_pointstime: TIntegerCvar;

--- a/server/ServerLoop.pas
+++ b/server/ServerLoop.pas
@@ -567,7 +567,8 @@ begin
 
   if sv_gamemode.Value = GAMESTYLE_INF then
     if MapChangeCounter < 0 then
-      if Thing[TeamFlag[2]].InBase then
+      if (TeamFlag[2] > 0) and
+         (Thing[TeamFlag[2]].InBase) then
         if (PlayersTeamNum[1] > 0) and (PlayersTeamNum[2] > 0)
           {and(PlayersTeamNum[1] >= PlayersTeamNum[2])} then
           if MainTickCounter mod j = 0 then

--- a/server/scriptcore/ScriptPlayer.pas
+++ b/server/scriptcore/ScriptPlayer.pas
@@ -1747,7 +1747,7 @@ begin
   Self.Muted := Result;
 end;
 
-procedure ScriptActivePlayerGetJets(Self: TScriptActivePlayer; var Result: Byte);
+procedure ScriptActivePlayerGetJets(Self: TScriptActivePlayer; var Result: Integer);
 begin
   Result := Self.Jets;
 end;

--- a/shared/AI.pas
+++ b/shared/AI.pas
@@ -713,7 +713,8 @@ begin
             if SpriteC.Player.Team = TEAM_BRAVO then
               SpriteC.Brain.PathNum := 2;
 
-            if not Thing[TeamFlag[2]].InBase then
+            if (TeamFlag[2] > 0) and
+               (not Thing[TeamFlag[2]].InBase) then
               if SpriteC.Player.Team = TEAM_BRAVO then
                 SpriteC.Brain.PathNum := 2;
 

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -839,7 +839,6 @@ begin
 
   // TODO: Remove
   sv_respawntime := TIntegerCvar.Add('sv_respawntime', 'Respawn time in ticks (60 ticks = 1 second)', 180, [CVAR_SERVER], nil, 0, 9999);
-  sv_inf_redaward := TIntegerCvar.Add('sv_inf_redaward', 'Infiltration: Points awarded for a flag capture', 30, [CVAR_SERVER], nil, 0, 9999);
   net_allowdownload := TBooleanCvar.Add('net_allowdownload', 'Enables/Disables file transfers', True, [CVAR_SERVER], nil);
 
   font_1_name := TStringCvar.Add('font_1_name', 'First font name', 'Play', [CVAR_CLIENT], nil, 0, 100);
@@ -869,6 +868,7 @@ begin
   sv_tm_limit := TIntegerCvar.Add('sv_tm_limit', 'Teammatch point limit', 60, [CVAR_SERVER], @killlimitChange, 0, 9999);
   sv_rm_limit := TIntegerCvar.Add('sv_rm_limit', 'Rambomatch point limit', 30, [CVAR_SERVER], @killlimitChange, 0, 9999);
 
+  sv_inf_redaward := TIntegerCvar.Add('sv_inf_redaward', 'Infiltration: Points awarded for a flag capture', 30, [CVAR_SERVER], nil, 0, 9999);
   sv_inf_limit := TIntegerCvar.Add('sv_inf_limit', 'Infiltration point limit', 90, [CVAR_SERVER], @killlimitChange, 0, 9999);
   sv_inf_bluelimit := TIntegerCvar.Add('sv_inf_bluelimit', 'Infiltration: Time for blue team to get points in seconds', 5, [CVAR_SERVER], nil, 0, 9999);
 

--- a/shared/mechanics/Sprites.pas
+++ b/shared/mechanics/Sprites.pas
@@ -4890,12 +4890,12 @@ end;
 
 function TSprite.IsSolo(): Boolean;
 begin
-  Result := Player.Team = TEAM_NONE;
+  Result := (sv_gamemode.Value = GAMESTYLE_DEATHMATCH) or (Player.Team = TEAM_NONE);
 end;
 
 function TSprite.IsNotSolo(): Boolean;
 begin
-  Result := Player.Team <> TEAM_NONE;
+  Result := not IsSolo();
 end;
 
 function TSprite.IsInTeam(): Boolean;

--- a/shared/mechanics/Sprites.pas
+++ b/shared/mechanics/Sprites.pas
@@ -2133,6 +2133,7 @@ begin
           if not SurvivalEndRound then
             if sv_gamemode.Value = GAMESTYLE_INF then
             begin
+              {$IFDEF SERVER}
               if TeamAliveNum[1] > 0 then
                 Inc(TeamScore[1], sv_inf_redaward.Value);
 
@@ -2141,6 +2142,7 @@ begin
                 Dec(TeamScore[1], 5 * (PlayersTeamNum[1] - PlayersTeamNum[2]));
               if (TeamScore[1] < 0) then
                 TeamScore[1] := 0;
+              {$ENDIF}
             end;
 
           SurvivalEndRound := True;

--- a/shared/mechanics/Things.pas
+++ b/shared/mechanics/Things.pas
@@ -836,11 +836,13 @@ begin
                   b.y := 0;
                   if sv_gamemode.Value = GAMESTYLE_INF then
                   begin
+                    {$IFDEF SERVER}
                     Inc(TeamScore[1], sv_inf_redaward.Value - 1);
                     // penalty
                     if (PlayersTeamNum[1] > PlayersTeamNum[2]) then
                       Dec(TeamScore[1], 5 * (PlayersTeamNum[1] - PlayersTeamNum[2]));
                     if (TeamScore[1] < 0) then TeamScore[1] := 0;
+                    {$ENDIF}
 
                     {$IFNDEF SERVER}
                     // flame it

--- a/shared/network/NetworkClientMessages.pas
+++ b/shared/network/NetworkClientMessages.pas
@@ -115,7 +115,7 @@ begin
   end;
 
   if (MsgType = MSGTYPE_RADIO) and Sprite[i].IsInSameTeam(Sprite[MySprite]) then
-    PlayRadioSound(StrToIntDef(AnsiString(RadioCommand), -1));
+    PlayRadioSound(StrToIntDef(AnsiString(RadioCommand), 0));
 end;
 
 procedure ClientHandleSpecialMessage(NetMessage: PSteamNetworkingMessage_t);


### PR DESCRIPTION
- Bots attack each other regardless of their underlying team.
  - In deathmatch mode, bots added on teams 1-4 were not attacking or damaging other bots on the same team. This fixes it.
- Fix type of `Result` variable in `ScriptActivePlayerGetJets`.
  - On a cute Kirby map with a high jet count this resulted in overflow.
- Fix range check error when handling radio messages.
  - -1 is not a valid value for the unsigned `Byte` type.
- Fix infiltration mode.
  - There were a few issues with bots reading invalid `Thing`s and the `sv_inf_redaward` cvar.