### PR TITLE
Small misc fixes #8

### DIFF
--- a/client/Client.pas
+++ b/client/Client.pas
@@ -229,7 +229,6 @@ var
   ServerIP: string = '127.0.0.1';
   ServerPort: Integer = 23073;
 
-  Grav: Single = 0.06;
   Connection: Byte = INTERNET;
 
   WeaponActive: array[1..MAIN_WEAPONS] of Byte; // sync

--- a/client/Client.pas
+++ b/client/Client.pas
@@ -662,6 +662,7 @@ begin
   CreateDirIfMissing(UserDirectory + '/logs/kills');
   CreateDirIfMissing(UserDirectory + '/maps');
   CreateDirIfMissing(UserDirectory + '/mods');
+  CreateDirIfMissing(UserDirectory + '/custom-interfaces');
 
   PHYSFS_CopyFileFromArchive('configs/bindings.cfg', UserDirectory + '/configs/bindings.cfg');
   PHYSFS_CopyFileFromArchive('configs/client.cfg', UserDirectory + '/configs/client.cfg');

--- a/client/ClientCommands.pas
+++ b/client/ClientCommands.pas
@@ -123,6 +123,7 @@ begin
     MainConsole.Console('Usage: say "text"', GAME_MESSAGE_COLOR);
     Exit;
   end;
+
   ClientSendStringMessage(WideString(Args[1]), MSGTYPE_PUB);
 end;
 
@@ -133,6 +134,7 @@ begin
     MainConsole.Console('Usage: say_team "text"', GAME_MESSAGE_COLOR);
     Exit;
   end;
+
   ClientSendStringMessage(WideString(Args[1]), MSGTYPE_TEAM);
 end;
 
@@ -258,6 +260,7 @@ begin
     MainConsole.Console('Usage: switchcam "id"', GAME_MESSAGE_COLOR);
     Exit;
   end;
+
   if not Sprite[MySprite].IsSpectator then
   begin
     MainConsole.Console('You are not a spectator', DEBUG_MESSAGE_COLOR);
@@ -282,6 +285,7 @@ begin
     MainConsole.Console('Usage: switchcamflag "id"', GAME_MESSAGE_COLOR);
     Exit;
   end;
+
   if Sprite[MySprite].IsSpectator then
   begin
     for i := 1 to MAX_THINGS do
@@ -323,16 +327,16 @@ begin
   CommandAdd('disconnect', CommandDisconnect, 'disconnect from server', [CMD_DEFERRED]);
   CommandAdd('retry', CommandRetry, 'retry connect to last server', [CMD_DEFERRED]);
   CommandAdd('screenshot', CommandScreenshot, 'take a screenshot of game', [CMD_DEFERRED]);
-  CommandAdd('say', CommandSay, 'send chat message', []);
-  CommandAdd('say_team', CommandSayTeam, 'send team chat message', []);
+  CommandAdd('say', CommandSay, 'send chat message', [CMD_INGAMEONLY]);
+  CommandAdd('say_team', CommandSayTeam, 'send team chat message', [CMD_INGAMEONLY]);
   CommandAdd('record', CommandRecord, 'record demo', []);
   CommandAdd('mute', CommandMute, 'mute specific nick or id', []);
   CommandAdd('unbindall', CommandUnbindall, 'Unbinds all binds', []);
   CommandAdd('unmute', CommandUnmute, 'unmute specific nick or id', []);
   CommandAdd('stop', CommandStop, 'stop recording demo', []);
   CommandAdd('shutdown', CommandShutdown, 'shutdown game', []);
-  CommandAdd('switchcam', CommandSwitchCam, 'switches camera to specific player', []);
-  CommandAdd('switchcamflag', CommandSwitchCamFlag, 'switches camera to specific flag', []);
+  CommandAdd('switchcam', CommandSwitchCam, 'switches camera to specific player', [CMD_INGAMEONLY]);
+  CommandAdd('switchcamflag', CommandSwitchCamFlag, 'switches camera to specific flag', [CMD_INGAMEONLY]);
   CommandAdd('demo_tick', CommandDemoTick, 'skips to a tick in demo', []);
   CommandAdd('demo_tick_r', CommandDemoTick, 'skips to a tick (relatively) in demo', []);
 end;

--- a/client/ClientCommands.pas
+++ b/client/ClientCommands.pas
@@ -12,7 +12,7 @@ uses
   {$IFDEF STEAM}Steam,{$ENDIF}
   Client, Command, Util, strutils, Game, ClientGame, Sound,
   GameRendering, NetworkClientMessages, Demo, GameStrings, Net,
-  Sprites, Constants, classes, sysutils, Input;
+  Sprites, Constants, classes, sysutils, Types, Input;
 
 var
   ScreenShotsInARow: Byte = 0;
@@ -21,7 +21,9 @@ procedure CommandBind(Args: array of AnsiString; Sender: Byte);
 var
   BindKeyName: AnsiString;
   CommandString: AnsiString;
-  Modifier: Word;
+  Keys: TStringDynArray;
+  i: Integer;
+  Modifier: TKeyMods;
 begin
   if Length(Args) < 3 then
   begin
@@ -29,19 +31,38 @@ begin
     Exit;
   end;
 
-  BindKeyName := LowerCase(Args[1]);
+  Keys := SplitString(LowerCase(Args[1]), '+');
   CommandString := Args[2];
   Modifier := KM_NONE;
 
-  if AnsiContainsStr(BindKeyName, '+') then
+  BindKeyName := '';
+  for i := Low(Keys) to High(Keys) do
   begin
-    if AnsiContainsText(BindKeyName, 'ctrl') then
-      Modifier := Modifier or KM_CTRL;
-    if AnsiContainsText(BindKeyName, 'shift') then
-      Modifier := Modifier or KM_SHIFT;
-    if AnsiContainsText(BindKeyName, 'alt') then
-      Modifier := Modifier or KM_ALT;
-    BindKeyName := StringsReplace(BindKeyName, ['ctrl', 'shift', 'alt', '+'], ['', '', '', ''], [rfReplaceAll]);
+    if Keys[i] = 'shift' then
+      Modifier := Modifier or KM_SHIFT
+    else if Keys[i] = 'ctrl' then
+      Modifier := Modifier or KM_CTRL
+    else if Keys[i] = 'alt' then
+      Modifier := Modifier or KM_ALT
+    else if BindKeyName = '' then
+      BindKeyName := Keys[i]; // First specific key (can be a specific modifier, like 'left shift') is allowed to be trigger key.
+
+    if Keys[i] = 'left shift' then
+      Modifier := Modifier or KM_LSHIFT
+    else if Keys[i] = 'right shift' then
+      Modifier := Modifier or KM_RSHIFT
+    else if Keys[i] = 'left ctrl' then
+      Modifier := Modifier or KM_LCTRL
+    else if Keys[i] = 'right ctrl' then
+      Modifier := Modifier or KM_RCTRL
+    else if Keys[i] = 'left alt' then
+      Modifier := Modifier or KM_LALT
+    else if Keys[i] = 'right alt' then
+      Modifier := Modifier or KM_RALT
+    else if Keys[i] = 'alt gr' then
+      Modifier := Modifier or KM_RALT
+    else
+      BindKeyName := Keys[i]; // Last non-modifier key is the trigger key.
   end;
 
   if Args[2][1] = '+' then

--- a/client/ClientGame.pas
+++ b/client/ClientGame.pas
@@ -64,7 +64,7 @@ uses
   Net, NetworkClientSprite, NetworkClientConnection,
   {$IFDEF ENABLE_FAE}FaeBase, FaeClient, NetworkClientFae,{$ENDIF}
   {$IFDEF STEAM}Steam, NetworkClientGame,{$ENDIF}
-  GameRendering, Gfx, UpdateFrame, GameMenus, Util, InterfaceGraphics;
+  GameRendering, Gfx, UpdateFrame, GameMenus, Util, InterfaceGraphics, Input;
 
 type
   TFrameTiming = record
@@ -286,6 +286,23 @@ begin
         DemoRecorder.SaveNextFrame;
       if DemoPlayer.Active then
         DemoPlayer.ProcessDemo;
+    end;
+
+    // Mousewheel events do not have a guaranteed inverse (like keyup/keydown). So
+    // instead, mousewheel "pressed" state lasts 1 frame. This must happen
+    // after `UpdateFrame()` is called.
+    if MouseWheelUpCounter > 0 then
+    begin
+      Dec(MouseWheelUpCounter);
+      if MouseWheelUpCounter = 0 then
+        KeyStatus[KEYID_MOUSEWHEEL_UP] := False;
+    end;
+
+    if MouseWheelDownCounter > 0 then
+    begin
+      Dec(MouseWheelDownCounter);
+      if MouseWheelDownCounter = 0 then
+        KeyStatus[KEYID_MOUSEWHEEL_DOWN] := False;
     end;
 
     // Radio Cooldown

--- a/client/ControlGame.pas
+++ b/client/ControlGame.pas
@@ -736,7 +736,7 @@ begin
         else if Event.wheel.y < 0 then
           Bind := FindKeyBind(SDL_GetModState(), KEYID_MOUSEWHEEL_DOWN);
 
-        if not PerformKeyDownBindAction(Bind) then
+        if (Bind <> Nil) and (not PerformKeyDownBindAction(Bind)) then
         begin
           if Bind.keyid = KEYID_MOUSEWHEEL_UP then
             MouseWheelUpCounter := 1

--- a/client/ControlGame.pas
+++ b/client/ControlGame.pas
@@ -352,7 +352,7 @@ begin
         Result := False;
       end;
     end
-    else if KeyMods = KM_NONE then
+    else if KeyModsMatch(KM_NONE, KeyMods, True) then
     begin
       Result := True;
 
@@ -456,7 +456,7 @@ function MenuKeyDown(KeyMods: TKeyMods; KeyCode: TSDL_ScanCode): Boolean;
 begin
   Result := False;
 
-  if (KeyMods = KM_NONE) and (KeyCode = SDL_SCANCODE_ESCAPE) then
+  if KeyModsMatch(KM_NONE, KeyMods, True) and (KeyCode = SDL_SCANCODE_ESCAPE) then
   begin
     Result := True;
 
@@ -474,17 +474,17 @@ begin
   begin
     if TeamMenu.Active then
     begin
-      if KeyMods = KM_NONE then
+      if KeyModsMatch(KM_NONE, KeyMods, True) then
         Result := GameMenuAction(TeamMenu, ((KeyCode - SDL_SCANCODE_1) + 1) mod 10);
     end
     else if EscMenu.Active then
     begin
-      if KeyMods = KM_NONE then
+      if KeyModsMatch(KM_NONE, KeyMods, True) then
         Result := GameMenuAction(EscMenu, KeyCode - SDL_SCANCODE_1);
     end
     else if LimboMenu.Active then
     begin
-      if KeyMods = KM_NONE then
+      if KeyModsMatch(KM_NONE, KeyMods, True) then
         Result := GameMenuAction(LimboMenu, KeyCode - SDL_SCANCODE_1)
       else if KeyModsMatch(KM_CTRL, KeyMods, True) then
         Result := GameMenuAction(LimboMenu, KeyCode - SDL_SCANCODE_1 + 10);
@@ -516,7 +516,7 @@ begin
 
   // other hard coded key bindings
 
-  if KeyMods = KM_NONE then case KeyCode of
+  if KeyModsMatch(KM_NONE, KeyMods, True) then case KeyCode of
     SDL_SCANCODE_ESCAPE: begin
       if not ShouldRenderFrames then
         GameLoopRun := False;

--- a/client/GameRendering.pas
+++ b/client/GameRendering.pas
@@ -299,6 +299,8 @@ begin
     Result := CaseInsensitiveImageMap[Png]
   else if CaseInsensitiveImageMap[Orig] <> '' then
     Result := CaseInsensitiveImageMap[Orig]
+  else if PHYSFS_exists(PChar(Png)) then
+    Result := Png;
 end;
 
 function EaseZoom(Current, Goal: Single): Single;

--- a/client/GameRendering.pas
+++ b/client/GameRendering.pas
@@ -23,6 +23,7 @@ const
 var
   GameRenderingParams: TGameRenderingParams;
   Textures: TGfxSpriteArray;
+  ActualZoom: Single = 0.0;
 
 function InitGameGraphics: Boolean;
 procedure ReloadGraphics;
@@ -36,6 +37,7 @@ function FontStyleSize(Style: Integer): Single;
 procedure TakeScreenshot(Filename: string; Async: Boolean = True);
 procedure FillCaseInsensitiveImageMap;
 function FindImagePath(const Filename: string): string;
+function EaseZoom(Current, Goal: Single): Single;
 
 implementation
 
@@ -297,6 +299,15 @@ begin
     Result := CaseInsensitiveImageMap[Png]
   else if CaseInsensitiveImageMap[Orig] <> '' then
     Result := CaseInsensitiveImageMap[Orig]
+end;
+
+function EaseZoom(Current, Goal: Single): Single;
+const
+  EPSILON = 0.01;
+begin
+  Result := Current + (Goal - Current) / 4;
+  if Abs(Goal - Result) < EPSILON then
+    Result := Goal;
 end;
 
 procedure LoadMainTextures();
@@ -923,8 +934,8 @@ begin
     InterpolationState := Default(TInterpolationState);
     InterpolateState(FramePercent, InterpolationState, Paused);
 
-    w := exp(r_zoom.Value) * GameWidth;
-    h := exp(r_zoom.Value) * GameHeight;
+    w := exp(ActualZoom) * GameWidth;
+    h := exp(ActualZoom) * GameHeight;
 
     dx := CameraX - w / 2;
     dy := CameraY - h / 2;
@@ -997,6 +1008,11 @@ begin
     begin
       w := RenderWidth;
       h := RenderHeight;
+    end
+    else
+    begin
+      w := GameWidth;
+      h := GameHeight;
     end;
 
     if GrabActionSnap then

--- a/client/Input.pas
+++ b/client/Input.pas
@@ -20,56 +20,104 @@ type
     MiniMap, PlayerName, FragsList, SniperLine, Radio, RecordDemo, VolumeUp, VolumeDown,
     MouseSensitivityUp, MouseSensitivityDown, Cmd, Chat, TeamChat, Snap, Weapons, Bind);
 
+  TKeyMods = UInt32;
+
   PBind = ^TBind;
   TBind = record
     Action: TAction;
     keyId: LongWord;
-    keyMod: Word;
+    keyMod: TKeyMods;
     Command: WideString;
+    Specificity: UInt32; // Used to sort/prioritize binds.
   end;
 
 const
-  KM_NONE  = 0;
-  KM_ALT   = 1 shl 0;
-  KM_CTRL  = 1 shl 1;
-  KM_SHIFT = 1 shl 2;
+  // Following modifiers, up to KM_RGUI, are compatible with SDL_Keymod.
+  KM_NONE   = $00000;
+  KM_LSHIFT = $00001;
+  KM_RSHIFT = $00002;
+  KM_LCTRL  = $00040;
+  KM_RCTRL  = $00080;
+  KM_LALT   = $00100;
+  KM_RALT   = $00200;
+  KM_LGUI   = $00400;
+  KM_RGUI   = $00800;
+  // These are our own custom keymod flags, to support either left or right
+  // ctrl/shift/alt.
+  KM_CTRL   = $10000;
+  KM_ALT    = $20000;
+  KM_SHIFT  = $40000;
 
-function BindKey(key, action, command: string; Modifier: Word): Boolean;
-function FindKeyBind(KeyMods: Word; KeyCode: TSDL_ScanCode): PBind;
+  // Custom "KeyIDs" to allow for mousewheel controls.
+  KEYID_MOUSEWHEEL_UP   = 513;
+  KEYID_MOUSEWHEEL_DOWN = 514;
+
+function BindKey(key, action, command: string; Modifier: TKeyMods): Boolean;
+function FindKeyBind(KeyMods: TKeyMods; KeyCode: TSDL_ScanCode; Exact: Boolean = False): PBind;
+function KeyModsMatch(BindKeyMods, KeyMods: TKeyMods; Exclusive: Boolean = False): Boolean;
 procedure StartInput;
 procedure UnbindAll;
 
 var
-  KeyStatus: array [0..512] of Boolean;
+  KeyStatus: array [0..514] of Boolean;
   Binds: array of TBind;
   GameWindow : PSDL_Window;
+  MouseWheelUpCounter: Integer = 0;
+  MouseWheelDownCounter: Integer = 0;
 
 implementation
 
 uses {$IFDEF SERVER}Server,{$ELSE}Client,{$ENDIF} GameRendering, typinfo, TraceLog;
 
-function BindKey(key, action, command: string; Modifier: Word): Boolean;
+// Used to determine the order binds are tried in, so for example
+// "ctrl+shift+x" is run instead of "x" if "ctrl+shift" are held.
+function SpecificityScore(KeyMods: TKeyMods): UInt32;
+begin
+  if (KeyMods and KM_SHIFT) = KM_SHIFT then
+    KeyMods := KeyMods and not (KM_LSHIFT or KM_RSHIFT);
+  if (KeyMods and KM_ALT) = KM_ALT then
+    KeyMods := KeyMods and not (KM_LALT or KM_RALT);
+  if (KeyMods and KM_CTRL) = KM_CTRL then
+    KeyMods := KeyMods and not (KM_LCTRL or KM_RCTRL);
+
+  // Most important component is number of modifier keys.
+  Result := PopCnt(KeyMods) shl 19;
+
+  // One modifier key is more specific than either modifier key.
+  Result := Result or ((KeyMods and (KM_CTRL or KM_ALT or KM_SHIFT)) shr 16);
+  Result := Result or ((KeyMods and not (KM_CTRL or KM_ALT or KM_SHIFT)) shl 4);
+end;
+
+function BindKey(key, action, command: string; Modifier: TKeyMods): Boolean;
 var
+  b: TBind;
   id: Integer;
   i: Integer;
 begin
   Result := False;
-  if Length(Binds) = 0 then
-    SetLength(Binds, 1);
-  id := Length(Binds) - 1;
 
-  if AnsiContainsStr(key, 'mouse') = true then
-    Binds[id].keyId := 300 + StrToIntDef(Copy(Key, 6, 1), 1)
+  // Passing through of key modifiers for the GUI modifier (AKA "Windows key",
+  // "Meta", "Hyper") is spotty on some operating system + window manager
+  // combos, so rather than introducing config options which will only work on
+  // certain systems, we just don't support that modifier key.
+  Modifier := Modifier and not (KM_LGUI or KM_RGUI);
+
+  if key = 'mousewheel up' then
+    b.keyId := KEYID_MOUSEWHEEL_UP
+  else if key = 'mousewheel down' then
+    b.keyId := KEYID_MOUSEWHEEL_DOWN
+  else if AnsiContainsStr(key, 'mouse') = true then
+    b.keyId := 300 + StrToIntDef(Copy(Key, 6, 1), 1)
   else
-    Binds[id].keyId := SDL_GetScancodeFromName(Pchar(key));
+    b.keyId := SDL_GetScancodeFromName(Pchar(key));
 
-  if Binds[id].keyId = 0 then
+  if b.keyId = 0 then
   begin
     Debug('[INPUT] Key ' + key + ' is invalid');
     Exit;
   end;
 
-  if Assigned(FindKeyBind(Modifier, Binds[id].keyId)) then
+  if Assigned(FindKeyBind(Modifier, b.keyId, True)) then
   begin
     Debug('[INPUT] Key ' + key + ' is already binded');
     Exit;
@@ -78,34 +126,103 @@ begin
   for i := Ord(Low(TAction)) to Ord(High(TAction)) do
   begin
      if LowerCase(action) = '+' + LowerCase(GetEnumName(TypeInfo(TAction), Ord(i))) then
-       Binds[id].Action := TAction(Ord(i));
+       b.Action := TAction(Ord(i));
   end;
 
-  Binds[id].Command := WideString(Command);
-  Binds[id].keyMod := Modifier;
+  b.Command := WideString(Command);
+  b.keyMod := Modifier;
+  b.Specificity := SpecificityScore(b.keyMod);
 
-  Debug('[INPUT] BindKey id: ' + IntToStr(id) + ' Key: ' + key + ' (' +
+  SetLength(Binds, Length(Binds) + 1);
+  id := High(Binds);
+  for i := Low(Binds) to High(Binds) - 1 do
+    if Binds[i].Specificity <= b.Specificity then
+    begin
+      id := i;
+      Break;
+    end;
+
+  for i := High(Binds) - 1 downto id do
+    Binds[i + 1] := Binds[i];
+  Binds[id] := b;
+
+  writeln('======');
+  for i := Low(Binds) to High(Binds) do
+    writeln(inttostr(binds[i].specificity));
+  writeln('======');
+
+  Debug('[INPUT] BindKey: Key: ' + key + ' (' +
         IntToStr(Binds[id].keyId) + '), Mod: ' + IntToStr(Binds[id].keyMod) +
         ' Command: ' + command);
-  SetLength(Binds, Length(Binds) + 1);
   Result := True;
 end;
 
-function FindKeyBind(KeyMods: Word; KeyCode: TSDL_ScanCode): PBind;
+function FindKeyBind(KeyMods: TKeyMods; KeyCode: TSDL_ScanCode; Exact: Boolean = False): PBind;
 var
   i: Integer;
 begin
   Result := nil;
 
-  for i := Low(Binds) to High(Binds) - 1 do
+  for i := Low(Binds) to High(Binds) do
   begin
-    if (Binds[i].KeyId = KeyCode) and ((Binds[i].keyMod and KeyMods <> 0) or
-      (Binds[i].keyMod = KeyMods)) then
+    if (Binds[i].KeyId = KeyCode) and Exact and (Binds[i].keymod = KeyMods) then
+    begin
+      Result := @Binds[i];
+      Exit;
+    end;
+
+    if (not Exact) and (Binds[i].KeyId = KeyCode) and KeyModsMatch(Binds[i].keymod, KeyMods, Exact) then
     begin
       Result := @Binds[i];
       Exit;
     end;
   end;
+end;
+
+function KeyModsMatch(BindKeyMods, KeyMods: TKeyMods; Exclusive: Boolean = False): Boolean;
+begin
+  Result := True;
+
+  if (BindKeyMods and KM_SHIFT) = KM_SHIFT then
+  begin
+    if (KeyMods and (KM_LSHIFT or KM_RSHIFT)) = 0 then
+    begin
+      Result := False;
+      Exit;
+    end;
+
+    BindKeyMods := BindKeyMods or KM_LSHIFT or KM_RSHIFT;
+    KeyMods := KeyMods or KM_LSHIFT or KM_RSHIFT;
+  end;
+
+  if (BindKeyMods and KM_CTRL) = KM_CTRL then
+  begin
+    if (KeyMods and (KM_LCTRL or KM_RCTRL)) = 0 then
+    begin
+      Result := False;
+      Exit;
+    end;
+
+    BindKeyMods := BindKeyMods or KM_LCTRL or KM_RCTRL;
+    KeyMods := KeyMods or KM_LCTRL or KM_RCTRL;
+  end;
+
+  if (BindKeyMods and KM_ALT) = KM_ALT then
+  begin
+    if (KeyMods and (KM_LALT or KM_RALT)) = 0 then
+    begin
+      Result := False;
+      Exit;
+    end;
+
+    BindKeyMods := BindKeyMods or KM_LALT or KM_RALT;
+    KeyMods := KeyMods or KM_LALT or KM_RALT;
+  end;
+
+  if Exclusive then
+    Result := Result and ((BindKeyMods and $FFFF) = KeyMods)
+  else
+    Result := Result and ((Keymods and BindKeyMods) = (BindKeyMods and $ffff));
 end;
 
 procedure UnbindAll;

--- a/client/Input.pas
+++ b/client/Input.pas
@@ -146,11 +146,6 @@ begin
     Binds[i + 1] := Binds[i];
   Binds[id] := b;
 
-  writeln('======');
-  for i := Low(Binds) to High(Binds) do
-    writeln(inttostr(binds[i].specificity));
-  writeln('======');
-
   Debug('[INPUT] BindKey: Key: ' + key + ' (' +
         IntToStr(Binds[id].keyId) + '), Mod: ' + IntToStr(Binds[id].keyMod) +
         ' Command: ' + command);

--- a/client/InterfaceGraphics.pas
+++ b/client/InterfaceGraphics.pas
@@ -408,10 +408,10 @@ begin
   );
   GfxDrawQuad(
     Nil,
-    GfxVertex(EndX              , StartY - Thickness, 0.0, 0.0, Color),
-    GfxVertex(EndX   + Thickness, StartY - Thickness, 0.0, 0.0, Color),
-    GfxVertex(EndX   + Thickness, EndY   + Thickness, 0.0, 0.0, Color),
-    GfxVertex(EndX              , EndY   + Thickness, 0.0, 0.0, Color)
+    GfxVertex(EndX              , StartY            , 0.0, 0.0, Color),
+    GfxVertex(EndX   + Thickness, StartY            , 0.0, 0.0, Color),
+    GfxVertex(EndX   + Thickness, EndY              , 0.0, 0.0, Color),
+    GfxVertex(EndX              , EndY              , 0.0, 0.0, Color)
   );
   GfxDrawQuad(
     Nil,
@@ -422,10 +422,10 @@ begin
   );
   GfxDrawQuad(
     Nil,
-    GfxVertex(StartX - Thickness, StartY - Thickness, 0.0, 0.0, Color),
-    GfxVertex(StartX            , StartY - Thickness, 0.0, 0.0, Color),
-    GfxVertex(StartX            , EndY   + Thickness, 0.0, 0.0, Color),
-    GfxVertex(StartX - Thickness, EndY   + Thickness, 0.0, 0.0, Color)
+    GfxVertex(StartX - Thickness, StartY            , 0.0, 0.0, Color),
+    GfxVertex(StartX            , StartY            , 0.0, 0.0, Color),
+    GfxVertex(StartX            , EndY              , 0.0, 0.0, Color),
+    GfxVertex(StartX - Thickness, EndY              , 0.0, 0.0, Color)
   );
 end;
 

--- a/client/InterfaceGraphics.pas
+++ b/client/InterfaceGraphics.pas
@@ -291,8 +291,8 @@ begin
   AddrRec := PInterface(@AddrFile[0])^;
   Int := AddrRec;
 
-  if PHYSFS_exists(PChar(ModDir + CUSTOM_INTERFACE_DIR + InterfaceName +
-    '/health.bmp')) then
+  if PHYSFS_exists(PChar(FindImagePath(ModDir + CUSTOM_INTERFACE_DIR + InterfaceName +
+    '/health.bmp'))) then
   begin
     relinfo.HealthBar_Rel_X := Int.HealthIco_X;
     relinfo.HealthBar_Rel_Y := Int.HealthIco_Y;
@@ -306,8 +306,8 @@ begin
     relinfo.NadesBar_Rel_Y := Int.HealthIco_Y;
   end;
 
-  if PHYSFS_exists(PChar(ModDir + CUSTOM_INTERFACE_DIR + InterfaceName +
-    '/jet.bmp')) then
+  if PHYSFS_exists(PChar(FindImagePath(ModDir + CUSTOM_INTERFACE_DIR + InterfaceName +
+    '/jet.bmp'))) then
   begin
     relinfo.HealthBar_Rel_X := Int.JetIco_X;
     relinfo.HealthBar_Rel_Y := Int.JetIco_Y;
@@ -321,8 +321,8 @@ begin
     relinfo.NadesBar_Rel_Y := Int.JetIco_Y;
   end;
 
-  if PHYSFS_exists(PChar(ModDir + CUSTOM_INTERFACE_DIR + InterfaceName +
-    '/ammo.bmp')) then
+  if PHYSFS_exists(PChar(FindImagePath(ModDir + CUSTOM_INTERFACE_DIR + InterfaceName +
+    '/ammo.bmp'))) then
   begin
     relinfo.HealthBar_Rel_X := Int.AmmoIco_X;
     relinfo.HealthBar_Rel_Y := Int.AmmoIco_Y;
@@ -336,22 +336,22 @@ begin
     relinfo.NadesBar_Rel_Y := Int.AmmoIco_Y;
   end;
 
-  if PHYSFS_exists(PChar(ModDir + CUSTOM_INTERFACE_DIR + InterfaceName +
-    '/health.bmp')) then
+  if PHYSFS_exists(PChar(FindImagePath(ModDir + CUSTOM_INTERFACE_DIR + InterfaceName +
+    '/health.bmp'))) then
   begin
     relinfo.HealthBar_Rel_X := Int.HealthIco_X;
     relinfo.HealthBar_Rel_Y := Int.HealthIco_Y;
   end;
 
-  if PHYSFS_exists(PChar(ModDir + CUSTOM_INTERFACE_DIR + InterfaceName +
-    '/jet.bmp')) then
+  if PHYSFS_exists(PChar(FindImagePath(ModDir + CUSTOM_INTERFACE_DIR + InterfaceName +
+    '/jet.bmp'))) then
   begin
     relinfo.JetBar_Rel_X := Int.JetIco_X;
     relinfo.JetBar_Rel_Y := Int.JetIco_Y;
   end;
 
-  if PHYSFS_exists(PChar(ModDir + CUSTOM_INTERFACE_DIR + InterfaceName +
-    '/ammo.bmp')) then
+  if PHYSFS_exists(PChar(FindImagePath(ModDir + CUSTOM_INTERFACE_DIR + InterfaceName +
+    '/ammo.bmp'))) then
   begin
     relinfo.AmmoBar_Rel_X := Int.AmmoIco_X;
     relinfo.AmmoBar_Rel_Y := Int.AmmoIco_Y;

--- a/client/UpdateFrame.pas
+++ b/client/UpdateFrame.pas
@@ -313,6 +313,8 @@ begin
       ChatTimeCounter := ChatTimeCounter - 1;
   end;  // bullettime off
 
+  ActualZoom := EaseZoom(ActualZoom, r_zoom.Value);
+
   // MOVE -=CAMERA=-
   if (CameraFollowSprite > 0) and (CameraFollowSprite < MAX_SPRITES + 1) then
   begin
@@ -321,11 +323,11 @@ begin
       // FIXME(skoskav): Scope zoom and non-default resolution makes this a bit complicated. Why
       // does the magic number ~6.8 work so well?
 
-      M.X := exp(r_zoom.Value) * ((mx - GameWidthHalf) / Sprite[CameraFollowSprite].AimDistCoef *
+      M.X := exp(ActualZoom) * ((mx - GameWidthHalf) / Sprite[CameraFollowSprite].AimDistCoef *
         ((2 * 640 / GameWidth - 1) +
         (GameWidth - 640) / GameWidth * (DEFAULTAIMDIST - Sprite[CameraFollowSprite].AimDistCoef) / 6.8));
 
-      M.Y := exp(r_zoom.Value) * ((my - GameHeightHalf) / Sprite[CameraFollowSprite].AimDistCoef);
+      M.Y := exp(ActualZoom) * ((my - GameHeightHalf) / Sprite[CameraFollowSprite].AimDistCoef);
       CamV.X := CameraX;
       CamV.Y := CameraY;
       P.X := SpriteParts.Pos[CameraFollowSprite].X;
@@ -352,8 +354,8 @@ begin
     end
     else
     begin
-      M.X := (mx - GameWidthHalf) / SPECTATORAIMDIST;
-      M.Y := (my - GameHeightHalf) / SPECTATORAIMDIST;
+      M.X := exp(ActualZoom) * (mx - GameWidthHalf) / SPECTATORAIMDIST;
+      M.Y := exp(ActualZoom) * (my - GameHeightHalf) / SPECTATORAIMDIST;
     end;
     CamV.X := CameraX;
     CamV.Y := CameraY;

--- a/cmake_modules/OpenSoldatAssets.cmake
+++ b/cmake_modules/OpenSoldatAssets.cmake
@@ -7,9 +7,9 @@ macro(download_assets)
 
   set(BASE_REPOSITORY_URL "https://github.com/opensoldat/base"
       CACHE STRING "We pull soldat.smod and font from here")
-  set(BASE_GIT_TAG "v0.3"
+  set(BASE_GIT_TAG "v0.4"
       CACHE STRING "Git tag associated with release in base repository")
-  set(SOLDAT_SMOD_SHA1 "333e847dbfc0fbf489824af5eed4e3dcb50cd699"
+  set(SOLDAT_SMOD_SHA1 "3441163e969c6059972def2da4542d2bacab516a"
       CACHE STRING "Expected SHA1 of soldat.smod download")
   set(DOWNLOAD_URL ${BASE_REPOSITORY_URL}/releases/download/${BASE_GIT_TAG})
   set(DOWNLOADS_DIR downloads)

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -79,7 +79,6 @@ var
   log_filesupdate: TIntegerCvar;
   log_timestamp: TBooleanCvar;
 
-  fs_localmount: TBooleanCvar;
   fs_mod: TStringCvar;
   fs_portable: TBooleanCvar;
   fs_basepath: TStringCvar;

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -922,8 +922,15 @@ begin
   end
   else
   begin
-    Result := False;
-    MainConsole.Console('Maps list file not found: configs/' + Filename, WARNING_MESSAGE_COLOR);
+    if Filename <> sv_maplist.DefaultValue then
+    begin
+      Result := sv_maplist.SetValue(sv_maplist.DefaultValue);
+    end
+    else
+    begin
+      Result := False;
+      MainConsole.Console('Maps list file not found: configs/' + Filename, WARNING_MESSAGE_COLOR);
+    end;
   end;
 
   // MapsList can't be empty on server's startup. This includes cases where

--- a/server/Server.pas
+++ b/server/Server.pas
@@ -285,8 +285,6 @@ var
   WMName, WMVersion: string;
   LastWepMod: string;
 
-  Grav: Single = 0.06;
-
   ModDir: string = '';
 
   UDP: TServerNetwork;

--- a/server/ServerCommands.pas
+++ b/server/ServerCommands.pas
@@ -60,7 +60,6 @@ begin
   if Length(Args) = 1 then
     Exit;
 
-
   if Length(Args[1]) < 1 then
     Exit;
 
@@ -169,7 +168,7 @@ begin
   if Length(Name) < 1 then
     Exit;
 
-  if Sender = 255 then
+  if (Sender = 0) or (Sender = 255) then
     TempStr := 'an admin'
   else
     TempStr := Sprite[Sender].Player.Name;
@@ -945,38 +944,38 @@ end;
 
 procedure InitServerCommands();
 begin
-  CommandAdd('addbot', CommandAddbot, 'Add specific bot to game', [CMD_ADMINONLY]);
-  CommandAdd('addbot1', CommandAddbot, 'Add specific bot to alpha team', [CMD_ADMINONLY]);
-  CommandAdd('addbot2', CommandAddbot, 'Add specific bot to blue team', [CMD_ADMINONLY]);
-  CommandAdd('addbot3', CommandAddbot, 'Add specific bot to charlie team', [CMD_ADMINONLY]);
-  CommandAdd('addbot4', CommandAddbot, 'Add specific bot to delta team', [CMD_ADMINONLY]);
-  CommandAdd('addbot5', CommandAddbot, 'Add specific bot to spectators', [CMD_ADMINONLY]);
-  CommandAdd('nextmap', CommandNextmap, 'Change map to next in maplist', [CMD_ADMINONLY]);
-  CommandAdd('map', CommandMap, 'Change map to specified mapname', [CMD_ADMINONLY]);
+  CommandAdd('addbot', CommandAddbot, 'Add specific bot to game', [CMD_ADMINONLY, CMD_DEFERRED]);
+  CommandAdd('addbot1', CommandAddbot, 'Add specific bot to alpha team', [CMD_ADMINONLY, CMD_DEFERRED]);
+  CommandAdd('addbot2', CommandAddbot, 'Add specific bot to blue team', [CMD_ADMINONLY, CMD_DEFERRED]);
+  CommandAdd('addbot3', CommandAddbot, 'Add specific bot to charlie team', [CMD_ADMINONLY, CMD_DEFERRED]);
+  CommandAdd('addbot4', CommandAddbot, 'Add specific bot to delta team', [CMD_ADMINONLY, CMD_DEFERRED]);
+  CommandAdd('addbot5', CommandAddbot, 'Add specific bot to spectators', [CMD_ADMINONLY, CMD_DEFERRED]);
+  CommandAdd('nextmap', CommandNextmap, 'Change map to next in maplist', [CMD_ADMINONLY, CMD_DEFERRED, CMD_INGAMEONLY]);
+  CommandAdd('map', CommandMap, 'Change map to specified mapname', [CMD_ADMINONLY, CMD_DEFERRED, CMD_INGAMEONLY]);
   CommandAdd('pause', CommandPause, 'Pause game', [CMD_ADMINONLY]);
-  CommandAdd('unpause', CommandUnpause, 'Unpause game', [CMD_ADMINONLY]);
-  CommandAdd('restart', CommandRestart, 'Restart current map', [CMD_ADMINONLY]);
-  CommandAdd('kick', CommandKick, 'Kick player with specified nick or id', [CMD_ADMINONLY]);
-  CommandAdd('kicklast', CommandKicklast, 'Kick last connected player', [CMD_ADMINONLY]);
-  CommandAdd('ban', CommandBan, 'Ban player with specified nick or id', [CMD_ADMINONLY]);
-  CommandAdd('banip', CommandBaniphw, 'Ban specified IP address', [CMD_ADMINONLY]);
-  CommandAdd('banhw', CommandBaniphw, 'Ban specified hwid', [CMD_ADMINONLY]);
-  CommandAdd('unban', CommandUnban, 'Unban specified ip or hwid', [CMD_ADMINONLY]);
-  CommandAdd('unbanlast', CommandUnban, 'Unban last player', [CMD_ADMINONLY]);
-  CommandAdd('adm', CommandAdm, 'Give admin to specified nick or id', [CMD_ADMINONLY]);
-  CommandAdd('admip', CommandAdmip, 'add the IP number to the Remote Admins list', [CMD_ADMINONLY]);
-  CommandAdd('unadm', CommandUnadm, 'remove the IP number from the admins list', [CMD_ADMINONLY]);
+  CommandAdd('unpause', CommandUnpause, 'Unpause game', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('restart', CommandRestart, 'Restart current map', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('kick', CommandKick, 'Kick player with specified nick or id', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('kicklast', CommandKicklast, 'Kick last connected player', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('ban', CommandBan, 'Ban player with specified nick or id', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('banip', CommandBaniphw, 'Ban specified IP address', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('banhw', CommandBaniphw, 'Ban specified hwid', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('unban', CommandUnban, 'Unban specified ip or hwid', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('unbanlast', CommandUnban, 'Unban last player', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('adm', CommandAdm, 'Give admin to specified nick or id', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('admip', CommandAdmip, 'add the IP number to the Remote Admins list', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('unadm', CommandUnadm, 'remove the IP number from the admins list', [CMD_ADMINONLY, CMD_INGAMEONLY]);
   CommandAdd('setteam1', CommandSetteam, 'move specified id or nick to alpha team', [CMD_ADMINONLY]);
   CommandAdd('setteam2', CommandSetteam, 'move specified id or nick to bravo team', [CMD_ADMINONLY]);
   CommandAdd('setteam3', CommandSetteam, 'move specified id or nick to charlie team', [CMD_ADMINONLY]);
   CommandAdd('setteam4', CommandSetteam, 'move specified id or nick to delta team', [CMD_ADMINONLY]);
   CommandAdd('setteam5', CommandSetteam, 'move specified id or nick to spectators', [CMD_ADMINONLY]);
-  CommandAdd('say', CommandSay, 'Send chat message', [CMD_ADMINONLY]);
-  CommandAdd('pkill', CommandKill, 'Kill specified id or nick', [CMD_ADMINONLY]);
-  CommandAdd('loadwep', CommandLoadwep, 'Load weapons config', [CMD_ADMINONLY]);
-  CommandAdd('loadcon', CommandLoadcon, 'Load server config', [CMD_ADMINONLY]);
+  CommandAdd('say', CommandSay, 'Send chat message', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('pkill', CommandKill, 'Kill specified id or nick', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('loadwep', CommandLoadwep, 'Load weapons config', [CMD_ADMINONLY, CMD_INGAMEONLY]);
+  CommandAdd('loadcon', CommandLoadcon, 'Load server config', [CMD_ADMINONLY, CMD_INGAMEONLY]);
   CommandAdd('loadlist', CommandLoadlist, 'Load maplist', [CMD_ADMINONLY]);
-  CommandAdd('pm', CommandPm, 'Send private message to other player', [CMD_ADMINONLY]);
+  CommandAdd('pm', CommandPm, 'Send private message to other player', [CMD_ADMINONLY, CMD_INGAMEONLY]);
   CommandAdd('gmute', CommandGmute, 'Mute player on server', [CMD_ADMINONLY]);
   CommandAdd('ungmute', CommandUngmute, 'Unmute player on server', [CMD_ADMINONLY]);
   CommandAdd('addmap', CommandAddmap, 'Add map to the maplist', [CMD_ADMINONLY]);

--- a/server/scriptcore/ScriptPlayer.pas
+++ b/server/scriptcore/ScriptPlayer.pas
@@ -955,7 +955,7 @@ procedure TScriptActivePlayer.BigText(Layer: Byte; Text: string;
 begin
   if not Self.Active then
     Exit;
-  ServerSendSpecialMessage(Text, 1, Layer, Delay, Scale, Color, X, Y, Self.ID);
+  ServerSendSpecialMessage(Text, 1, Layer, Delay, Scale, Longword(Color), X, Y, Self.ID);
 end;
 
 procedure TScriptActivePlayer.WorldText(Layer: Byte; Text: string;

--- a/server/scriptcore/ScriptPlayers.pas
+++ b/server/scriptcore/ScriptPlayers.pas
@@ -168,7 +168,7 @@ end;
 procedure TScriptPlayers.BigText(Layer: Byte; Text: string; Delay: Integer;
   Color: Longint; Scale: Single; X, Y: Integer);
 begin
-  NetworkServerMessages.ServerSendSpecialMessage(Text, 1, Layer, Delay, Scale, Color, X, Y, 0);
+  NetworkServerMessages.ServerSendSpecialMessage(Text, 1, Layer, Delay, Scale, Longword(Color), X, Y, 0);
 end;
 
 procedure TScriptPlayers.WorldText(Layer: Byte; Text: string; Delay: Integer;

--- a/shared/Anims.pas
+++ b/shared/Anims.pas
@@ -362,12 +362,12 @@ begin
 
   SpriteParts.Destroy;
   SpriteParts.TimeStep := 1;
-  SpriteParts.Gravity := GRAV;
+  SpriteParts.GravityMultiplier := 1;
   SpriteParts.EDamping := 0.99;
   GostekSkeleton.Destroy;
   GostekSkeleton.LoadPOObject('objects/gostek.po', SCALE);
   GostekSkeleton.TimeStep := 1;
-  GostekSkeleton.Gravity := 1.06 * GRAV;
+  GostekSkeleton.GravityMultiplier := 1.06;
   GostekSkeleton.VDamping := 0.997;
 
   BoxSkeleton.Destroy;
@@ -376,12 +376,12 @@ begin
 
   BulletParts.Destroy;
   BulletParts.TimeStep := 1;
-  BulletParts.Gravity := GRAV * 2.25;
+  BulletParts.GravityMultiplier := 2.25;
   BulletParts.EDamping := 0.99;
 
   SparkParts.Destroy;
   SparkParts.TimeStep := 1;
-  SparkParts.Gravity := GRAV / 1.4;
+  SparkParts.GravityMultiplier := 1 / 1.4;
   SparkParts.EDamping := 0.998;
 
   FlagSkeleton.LoadPOObject('objects/flag.po', 4.0);

--- a/shared/Command.pas
+++ b/shared/Command.pas
@@ -264,6 +264,7 @@ var
   cbResult: csize_t = 0;
   SetResult: Boolean = False;
   ConfigID: Integer;
+  NetworkingUtil: PISteamNetworkingUtils;
 begin
   if Length(Args) < 3 then
   begin
@@ -271,22 +272,27 @@ begin
     Exit;
   end;
 
+  if UDP <> Nil then
+    NetworkingUtil := UDP.NetworkingUtil
+  else
+    NetworkingUtil := SteamAPI_SteamNetworkingUtils_v003();
+
   ConfigID := StrToIntDef(Args[1], -1);
-  ConfigName := UDP.NetworkingUtil.GetConfigValueInfo(ESteamNetworkingConfigValue(ConfigID), @OutDataType, @OutScope);
+  ConfigName := NetworkingUtil.GetConfigValueInfo(ESteamNetworkingConfigValue(ConfigID), @OutDataType, @OutScope);
   if ConfigName <> Nil then
   begin
     if OutDataType = k_ESteamNetworkingConfig_Int32 then
     begin
       cbResult := SizeOf(Integer);
       IntegerValue := StrToIntDef(Args[2], 0);
-      SetResult := UDP.NetworkingUtil.SetConfigValue(ESteamNetworkingConfigValue(StrToInt(Args[1])), k_ESteamNetworkingConfig_Global, 0, OutDataType, @IntegerValue);
+      SetResult := NetworkingUtil.SetConfigValue(ESteamNetworkingConfigValue(StrToInt(Args[1])), k_ESteamNetworkingConfig_Global, 0, OutDataType, @IntegerValue);
       MainConsole.Console(Format('[NET] NetConfig: Set %S to %D, result: %S', [AnsiString(ConfigName), IntegerValue, SetResult.ToString(TUseBoolStrs.True)]), DEBUG_MESSAGE_COLOR{$IFDEF SERVER}, Sender{$ENDIF});
     end
     else if OutDataType = k_ESteamNetworkingConfig_Float then
     begin
       cbResult := SizeOf(Single);
       FloatValue := StrToFloatDef(Args[2], 0.0);
-      SetResult := UDP.NetworkingUtil.SetConfigValue(ESteamNetworkingConfigValue(StrToInt(Args[1])), k_ESteamNetworkingConfig_Global, 0, OutDataType, @FloatValue);
+      SetResult := NetworkingUtil.SetConfigValue(ESteamNetworkingConfigValue(StrToInt(Args[1])), k_ESteamNetworkingConfig_Global, 0, OutDataType, @FloatValue);
       MainConsole.Console(Format('[NET] NetConfig: Set %S to %F, result: %S', [AnsiString(ConfigName), FloatValue, SetResult.ToString(TUseBoolStrs.True)]), DEBUG_MESSAGE_COLOR{$IFDEF SERVER}, Sender{$ENDIF});
     end;
   end

--- a/shared/Command.pas
+++ b/shared/Command.pas
@@ -14,7 +14,7 @@ const
   MAX_COMMANDS = 1024;
 
 type
-  TCommandFlag = (CMD_INIT, CMD_ALIAS, CMD_SCRIPT, CMD_DEFERRED, CMD_ADMINONLY, CMD_PLAYERONLY);
+  TCommandFlag = (CMD_INIT, CMD_ALIAS, CMD_SCRIPT, CMD_DEFERRED, CMD_ADMINONLY, CMD_PLAYERONLY, CMD_INGAMEONLY);
   TCommandFlags = set of TCommandFlag;
   PCommand = ^TCommand;
   TCommandFunction = procedure(Args: array of AnsiString; Sender: Byte);
@@ -429,10 +429,17 @@ begin
     begin
       {$IFDEF SERVER}
       if CMD_ADMINONLY in CommandPtr.Flags then
-        if not ((Sender = 255) or (IsRemoteAdminIP(Sprite[Sender].Player.IP) or IsAdminIP(Sprite[Sender].Player.IP))) then
+        if not ((Sender = 0) or (Sender = 255) or (IsRemoteAdminIP(Sprite[Sender].Player.IP) or IsAdminIP(Sprite[Sender].Player.IP))) then
           Exit;
       if CMD_PLAYERONLY in CommandPtr.Flags then
         if (Sender = 0) or (Sender > MAX_PLAYERS + 1) then
+          Exit;
+      if CMD_INGAMEONLY in CommandPtr.Flags then
+        if UDP = Nil then
+          Exit;
+      {$ELSE}
+      if CMD_INGAMEONLY in CommandPtr.Flags then
+        if MySprite = 0 then
           Exit;
       {$ENDIF}
       CommandFunction := CommandPtr.FunctionPtr;
@@ -677,9 +684,9 @@ begin
   {$IFDEF DEVELOPMENT}
   CommandAdd('netconfig', CommandNetConfig, 'Set GNS config', []);
   CommandAdd('netconfig_conn', CommandNetConfig, 'Set GNS config for specific connection handle', []);
-  CommandAdd('netconfig_list', CommandNetConfigList, 'List GNS cvars', []);
+  CommandAdd('netconfig_list', CommandNetConfigList, 'List GNS cvars', [CMD_INGAMEONLY]);
 
-  CommandAdd('netconfig_loglevel', CommandNetLogLevel, 'Set GNS log level', []);
+  CommandAdd('netconfig_loglevel', CommandNetLogLevel, 'Set GNS log level', [CMD_INGAMEONLY]);
 
   {$ENDIF}
 end;

--- a/shared/Command.pas
+++ b/shared/Command.pas
@@ -177,6 +177,10 @@ begin
   for i:=0 to Commands.Count-1 do
   begin
     CommandPtr := Commands.Items[i];
+    if Length(Args) = 2 then
+      if not AnsiContainsStr(CommandPtr.Name, Args[1]) then
+        Continue;
+
     MainConsole.Console(CommandPtr.Name + ' - ' + CommandPtr.Description, GAME_MESSAGE_COLOR);
   end;
 end;

--- a/shared/Constants.pas
+++ b/shared/Constants.pas
@@ -217,7 +217,7 @@ const
 
   WAVERESPAWN_TIME_MULITPLIER = 1;
 
-  PARA_SPEED    = -0.5 * 0.06; // GRAV
+  PARA_SPEED    = -0.5 * 0.06; // Grav
   PARA_DISTANCE = 500;
 
   MAX_OLDPOS = 125;

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -786,7 +786,7 @@ begin
   r_maxfps := TIntegerCvar.Add('r_maxfps', '', 60, [CVAR_CLIENT], nil, 0, 9999);
   r_fpslimit := TBooleanCvar.Add('r_fpslimit', '', True, [CVAR_CLIENT], nil);
   r_resizefilter := TIntegerCvar.Add('r_resizefilter', '', 2, [CVAR_CLIENT], nil, 0, 2);
-  r_sleeptime := TIntegerCvar.Add('r_sleeptime', '', 0, [CVAR_CLIENT], nil, 0, 100);
+  r_sleeptime := TIntegerCvar.Add('r_sleeptime', 'Amount of time to sleep after rendering a frame (avoids busylooping)', 1, [CVAR_CLIENT], nil, 0, 100);
   r_screenwidth := TIntegerCvar.Add('r_screenwidth', '', 0, [CVAR_CLIENT], nil, 0, MaxInt);
   r_screenheight := TIntegerCvar.Add('r_screenheight', '', 0, [CVAR_CLIENT], nil, 0, MaxInt);
   r_renderwidth := TIntegerCvar.Add('r_renderwidth', '', 0, [CVAR_CLIENT, CVAR_INITONLY], nil, 0, MaxInt);

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -159,7 +159,12 @@ end;
 
 function r_zoomChange(Cvar: TCvarBase; NewValue: Single): Boolean;
 begin
-  if (not Sprite[MySprite].IsSpectator) and (not IsZero(NewValue)) then
+  if MySprite = 0 then
+  begin
+    Cvar.FErrorMessage := 'You need to be in-game to set zoom.';
+    Result := False;
+  end
+  else if (not Sprite[MySprite].IsSpectator) and (not IsZero(NewValue)) then
   begin
     Cvar.FErrorMessage := 'You need to be in the spectators team';
     Result := False;
@@ -169,6 +174,13 @@ end;
 
 function cl_player_wepChange(Cvar: TCvarBase; NewValue: Integer): Boolean;
 begin
+  if MySprite = 0 then
+  begin
+    Cvar.FErrorMessage := 'You need to be in-game to set cl_player_wep.';
+    Result := False;
+    Exit;
+  end;
+
   if WeaponActive[NewValue] = 1 then
     Sprite[MySprite].SelWeapon := NewValue;
   Cvar.FErrorMessage := '';

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -734,7 +734,9 @@ begin
     {$ENDIF}
   {$ENDIF}
 
+  {$IFNDEF SERVER}
   fs_localmount := TBooleanCvar.Add('fs_localmount', 'Mount game directory as game mod', False, [CVAR_CLIENT, CVAR_INITONLY], @CommandLineOnlyChange);
+  {$ENDIF}
   fs_mod := TStringCvar.Add('fs_mod', 'File name of mod placed in mods directory (without .smod extension)', '', [CVAR_INITONLY], nil, 0, 255);
   fs_portable := TBooleanCvar.Add('fs_portable', 'Enables portable mode', True, [CVAR_CLIENT, CVAR_INITONLY], @CommandLineOnlyChange);
   fs_basepath := TStringCvar.Add('fs_basepath', 'Path to base game directory', '', [CVAR_INITONLY], @CommandLineOnlyChange, 0, 255);

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -230,11 +230,7 @@ end;
 function sv_gravityChange(Cvar: TCvarBase; NewValue: Single): Boolean;
 begin
   Cvar := Cvar;
-  GRAV := NewValue;
-  SpriteParts.Gravity := GRAV;
-  GostekSkeleton.Gravity := 1.06 * GRAV;
-  BulletParts.Gravity := GRAV * 2.25;
-  SparkParts.Gravity := GRAV / 1.4;
+  Grav := NewValue;
   Result := True;
 end;
 

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -992,7 +992,7 @@ begin
   sv_advancemode_amount := TIntegerCvar.Add('sv_advancemode_amount', 'Number of kills required in Advance Mode to gain a weapon.', 2, [CVAR_SERVER, CVAR_SYNC], nil, 1, 9999);
   sv_minimap_locations := TBooleanCvar.Add('sv_minimap_locations', 'Enables/disables drawing player and object location indicators on minimap', True, [CVAR_SERVER, CVAR_SYNC], nil);
   sv_advancedspectator := TBooleanCvar.Add('sv_advancedspectator', 'Enables/disables advanced spectator mode', True, [CVAR_SERVER, CVAR_SYNC], nil);
-  sv_radio := TBooleanCvar.Add('sv_radio', 'Enables/disables radio chat', False, [CVAR_SERVER, CVAR_SYNC], nil);
+  sv_radio := TBooleanCvar.Add('sv_radio', 'Enables/disables radio chat', True, [CVAR_SERVER, CVAR_SYNC], nil);
   sv_info := TStringCvar.Add('sv_info', 'A website or e-mail address, or any other short text describing your server', '', [CVAR_SERVER, CVAR_SYNC], nil, 0, 60);
   sv_gravity := TSingleCvar.Add('sv_gravity', 'Gravity', 0.06, [CVAR_SERVER, CVAR_SYNC], @sv_gravityChange, -MaxSingle, MaxSingle);
   sv_hostname := TStringCvar.Add('sv_hostname', 'Name of the server', 'OpenSoldat Server', [CVAR_SERVER, CVAR_SYNC], nil, 0, 24);

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -146,7 +146,7 @@ var
   CvarsInitialized: Boolean = False;
 
 implementation
-  uses {$IFDEF SERVER}Server,{$ELSE}Client,{$ENDIF} TraceLog, Math, Game {$IFNDEF SERVER}, Sound, Demo {$ENDIF};
+  uses {$IFDEF SERVER}Server,{$ELSE}Client,{$ENDIF} TraceLog, Math, Game {$IFNDEF SERVER}, Sound, Demo {$ENDIF}, Things;
 
 {$IFNDEF SERVER}
 function snd_volumeChange(Cvar: TCvarBase; NewValue: Integer): Boolean;
@@ -240,9 +240,16 @@ end;
 {$POP}
 
 function sv_gravityChange(Cvar: TCvarBase; NewValue: Single): Boolean;
+var
+  i: Integer;
 begin
   Cvar := Cvar;
   Grav := NewValue;
+
+  for i := Low(Thing) to High(Thing) do
+    if Thing[i].Active then
+      Thing[i].StaticType := False;
+
   Result := True;
 end;
 

--- a/shared/Cvar.pas
+++ b/shared/Cvar.pas
@@ -288,6 +288,8 @@ begin
     CvarFlags := CvarFlags + ' SC';
   if CVAR_INITONLY in Cvar.FFlags then
     CvarFlags := CvarFlags + ' INITONLY';
+  if CVAR_SERVER_INITONLY in Cvar.FFlags then
+    CvarFlags := CvarFlags + ' SERVER_INITONLY';
 
   Result := CvarFlags;
 end;

--- a/shared/Game.pas
+++ b/shared/Game.pas
@@ -35,6 +35,8 @@ var
 
   BulletTimeTimer: Integer;
 
+  Grav: Single = 0.06;
+
   SpriteParts, BulletParts, SparkParts,
   GostekSkeleton, BoxSkeleton, FlagSkeleton, ParaSkeleton, StatSkeleton,
   RifleSkeleton10, RifleSkeleton11, RifleSkeleton18, RifleSkeleton22,

--- a/shared/Game.pas
+++ b/shared/Game.pas
@@ -537,6 +537,7 @@ begin
       MainConsole.Console('Error: Could not load map (' + MapChange.Name + ')',
         DEBUG_MESSAGE_COLOR);
       NextMap;
+      ChangeMap;
       Exit;
     end;
   {$ENDIF}

--- a/shared/Parts.pas
+++ b/shared/Parts.pas
@@ -46,7 +46,7 @@ type
     Forces: array[1..NUM_PARTICLES] of TVector2;
     OneOverMass: array[1..NUM_PARTICLES] of Single;
     TimeStep: Single;
-    Gravity, VDamping, EDamping: Single;
+    GravityMultiplier, VDamping, EDamping: Single;
     ConstraintCount: Integer;
     PartCount: Integer;
     Constraints: array[1..NUM_PARTICLES] of Constraint;
@@ -71,7 +71,7 @@ type
 implementation
 
 uses
-  SysUtils, PhysFS;
+  Game, SysUtils, PhysFS;
 
 procedure ParticleSystem.DoVerletTimeStep;
 var
@@ -108,7 +108,7 @@ var
   TempPos, S: TVector2;
 begin
   // Accumulate Forces
-  Forces[I].Y := Forces[I].Y + Gravity;
+  Forces[I].Y := Forces[I].Y + (GravityMultiplier * Grav);
   TempPos := Pos[I];
 
   Vec2Scale(S, Forces[I], OneOverMass[I]);
@@ -128,7 +128,7 @@ var
   TempPos, S1, S2, D: TVector2;
 begin
   // Accumulate Forces
-  Forces[I].Y := Forces[I].Y + Gravity;
+  Forces[I].Y := Forces[I].Y + (GravityMultiplier * Grav);
   TempPos := Pos[I];
 
   // Pos[I]:= 2 * Pos[I] - OldPos[I] + Forces[I]{ / Mass} * TimeStep * TimeStep;  {Verlet integration}

--- a/shared/SharedConfig.pas
+++ b/shared/SharedConfig.pas
@@ -155,6 +155,8 @@ begin
 
       ReadConf(conf, 'Favourite_Weapon', FavWeaponName);
       SpriteC.Brain.FavWeapon := WeaponNameToNum(FavWeaponName);
+      if SpriteC.Brain.FavWeapon = -1 then
+        Exit;
       ReadConf(conf, 'Secondary_Weapon', SpriteC.Player.SecWep);
       ReadConf(conf, 'Friend', SpriteC.Brain.Friend, True);
       ReadConf(conf, 'Accuracy', SpriteC.Brain.Accuracy);

--- a/shared/mechanics/Bullets.pas
+++ b/shared/mechanics/Bullets.pas
@@ -1214,12 +1214,12 @@ begin
                     BulletParts.Pos[Num] :=
                       Vec2Subtract(Pos, BulletParts.Velocity[Num]);
                     BulletParts.Forces[Num].Y :=
-                      BulletParts.Forces[Num].Y - BulletParts.Gravity;
+                      BulletParts.Forces[Num].Y - (BulletParts.GravityMultiplier * Grav);
                     if TimeOut > ARROW_RESIST then
                       TimeOut := ARROW_RESIST;
                     if TimeOut < 20 then
                       BulletParts.Forces[Num].Y :=
-                        BulletParts.Forces[Num].Y + BulletParts.Gravity;
+                        BulletParts.Forces[Num].Y + (BulletParts.GravityMultiplier * Grav);
                   end;
                 BULLET_STYLE_FRAGNADE, BULLET_STYLE_FLAME:
                   begin
@@ -1691,7 +1691,7 @@ begin
                 if TimeOut > ARROW_RESIST then
                 begin
                   BulletParts.Pos[Num] := Vec2Subtract(Pos, BulletParts.Velocity[Num]);
-                  BulletParts.Forces[Num].Y := BulletParts.Forces[Num].Y - BulletParts.Gravity;
+                  BulletParts.Forces[Num].Y := BulletParts.Forces[Num].Y - (BulletParts.GravityMultiplier * Grav);
                   if ((not sv_friendlyfire.Value) and
                     Sprite[Owner].IsNotSolo() and
                     Sprite[Owner].IsInSameTeam(Sprite[j])
@@ -2088,7 +2088,7 @@ begin
             if TimeOut > ARROW_RESIST then
             begin
               BulletParts.Forces[Num].Y :=
-                BulletParts.Forces[Num].Y - BulletParts.Gravity;
+                BulletParts.Forces[Num].Y - (BulletParts.GravityMultiplier * Grav);
               Hit(HIT_TYPE_WALL);
 
               Kill;

--- a/shared/mechanics/Bullets.pas
+++ b/shared/mechanics/Bullets.pas
@@ -2721,10 +2721,14 @@ begin
 
       while (j > 1) and (RoughDistance < Distances[j - 1]) do
         j := j - 1;
-      Move(Distances[j], Distances[j + 1], (SpriteCount - j) * SizeOf(Single));
-      Distances[j] := RoughDistance;
 
-      Move(SpriteIndexes[j], SpriteIndexes[j + 1], (SpriteCount - j) * SizeOf(Integer));
+      if (SpriteCount - j) > 0 then
+      begin
+        Move(Distances[j], Distances[j + 1], (SpriteCount - j) * SizeOf(Single));
+        Move(SpriteIndexes[j], SpriteIndexes[j + 1], (SpriteCount - j) * SizeOf(Integer));
+      end;
+
+      Distances[j] := RoughDistance;
       SpriteIndexes[j] := i;
     end;
   end;

--- a/shared/mechanics/Control.pas
+++ b/shared/mechanics/Control.pas
@@ -110,9 +110,9 @@ begin
             begin
               if ChatText = '' then
               begin
-                for i := Low(Binds) to High(Binds) - 1 do
+                for i := Low(Binds) to High(Binds) do
                 begin
-                  if KeyStatus[Binds[i].keyId] and ((Binds[i].keymod = 0) or (Binds[i].keyMod and SDL_GetModState() <> 0)) then
+                  if KeyStatus[Binds[i].keyId] and KeyModsMatch(Binds[i].keymod, SDL_GetModState()) then
                   begin
                     if Binds[i].action = TAction.Left then SpriteC.Control.Left := True;
                     if Binds[i].action = TAction.Right then SpriteC.Control.Right := True;

--- a/shared/mechanics/Control.pas
+++ b/shared/mechanics/Control.pas
@@ -325,16 +325,16 @@ begin
           begin
             if SpriteC.OnGround then
               Spriteparts.Forces[SpriteC.Num].Y :=
-                -2.5 * iif(GRAV > 0.05, JETSPEED, Grav * 2);
+                -2.5 * iif(Grav > 0.05, JETSPEED, Grav * 2);
 
             if not SpriteC.OnGround then
             begin
               if SpriteC.Position <> POS_PRONE then
                 Spriteparts.Forces[SpriteC.Num].Y :=
-                  Spriteparts.Forces[SpriteC.Num].Y - iif(GRAV > 0.05, JETSPEED, Grav * 2)
+                  Spriteparts.Forces[SpriteC.Num].Y - iif(Grav > 0.05, JETSPEED, Grav * 2)
               else
                 Spriteparts.Forces[SpriteC.Num].X := Spriteparts.Forces[SpriteC.Num].X +
-                  (SpriteC.Direction * iif(GRAV > 0.05, JETSPEED, Grav * 2) / 2);
+                  (SpriteC.Direction * iif(Grav > 0.05, JETSPEED, Grav * 2) / 2);
             end;
 
             if (SpriteC.LegsAnimation.ID <> GetUp.ID) and

--- a/shared/mechanics/Sprites.pas
+++ b/shared/mechanics/Sprites.pas
@@ -326,7 +326,7 @@ begin
 
   // create skeleton
   Sprite[i].Skeleton.TimeStep := 1;
-  Sprite[i].Skeleton.Gravity := 1.06 * GRAV;
+  Sprite[i].Skeleton.GravityMultiplier := 1.06;
   Sprite[i].Skeleton := GostekSkeleton;
   Sprite[i].Skeleton.VDamping := 0.9945;
 
@@ -2777,7 +2777,7 @@ begin
                  (Step.Y > SLIDELIMIT) then
               begin
                 SpriteParts.Pos[Num] := SpriteParts.OldPos[Num];
-                SpriteParts.Forces[Num].Y := SpriteParts.Forces[Num].Y - GRAV;
+                SpriteParts.Forces[Num].Y := SpriteParts.Forces[Num].Y - (SpriteParts.GravityMultiplier * Grav);
               end
               else
               begin

--- a/shared/mechanics/Things.pas
+++ b/shared/mechanics/Things.pas
@@ -148,7 +148,7 @@ begin
     OBJECT_ALPHA_FLAG, OBJECT_BRAVO_FLAG, OBJECT_POINTMATCH_FLAG:  // Flag
       begin
         Thing[i].Skeleton.VDamping := 0.991;
-        Thing[i].Skeleton.Gravity := 1.0 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.0;
         Thing[i].Skeleton.Clone(FlagSkeleton);
         // A and B flags face eachother.
         if sStyle = OBJECT_ALPHA_FLAG then
@@ -181,7 +181,7 @@ begin
     OBJECT_USSOCOM:  // Socom
       begin
         Thing[i].Skeleton.VDamping := 0.994;
-        Thing[i].Skeleton.Gravity := 1.05 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.05;
         Thing[i].Skeleton.Clone(RifleSkeleton10);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := GFX_WEAPONS_N_SOCOM + k;
@@ -194,7 +194,7 @@ begin
     OBJECT_DESERT_EAGLE:  // Deagle
       begin
         Thing[i].Skeleton.VDamping := 0.996;
-        Thing[i].Skeleton.Gravity := 1.09 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.09;
         Thing[i].Skeleton.Clone(RifleSkeleton11);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := GFX_WEAPONS_N_DEAGLES + k;
@@ -207,7 +207,7 @@ begin
     OBJECT_HK_MP5:  // Mp5
       begin
         Thing[i].Skeleton.VDamping := 0.995;
-        Thing[i].Skeleton.Gravity := 1.11 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.11;
         Thing[i].Skeleton.Clone(RifleSkeleton22);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := Guns[MP5].TextureNum + k;
@@ -221,7 +221,7 @@ begin
     OBJECT_AK74:  // Ak74
       begin
         Thing[i].Skeleton.VDamping := 0.994;
-        Thing[i].Skeleton.Gravity := 1.16 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.16;
         Thing[i].Skeleton.Clone(RifleSkeleton37);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := Guns[AK74].TextureNum + k;
@@ -235,7 +235,7 @@ begin
     OBJECT_STEYR_AUG:  // SteyrAug
       begin
         Thing[i].Skeleton.VDamping := 0.994;
-        Thing[i].Skeleton.Gravity := 1.16 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.16;
         Thing[i].Skeleton.Clone(RifleSkeleton37);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := Guns[STEYRAUG].TextureNum + k;
@@ -249,7 +249,7 @@ begin
     OBJECT_SPAS12:  // Spas
       begin
         Thing[i].Skeleton.VDamping := 0.993;
-        Thing[i].Skeleton.Gravity := 1.15 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.15;
         Thing[i].Skeleton.Clone(RifleSkeleton36);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := Guns[SPAS12].TextureNum + k;
@@ -262,7 +262,7 @@ begin
     OBJECT_RUGER77:  // Ruger
       begin
         Thing[i].Skeleton.VDamping := 0.993;
-        Thing[i].Skeleton.Gravity := 1.13 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.13;
         Thing[i].Skeleton.Clone(RifleSkeleton36);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := Guns[RUGER77].TextureNum + k;
@@ -275,7 +275,7 @@ begin
     OBJECT_M79:  // M79
       begin
         Thing[i].Skeleton.VDamping := 0.994;
-        Thing[i].Skeleton.Gravity := 1.15 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.15;
         Thing[i].Skeleton.Clone(RifleSkeleton28);
         //FIXME (helloer): Check why Tex1 is different
         {$IFNDEF SERVER}
@@ -289,7 +289,7 @@ begin
     OBJECT_BARRET_M82A1:  // Barrett
       begin
         Thing[i].Skeleton.VDamping := 0.993;
-        Thing[i].Skeleton.Gravity := 1.18 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.18;
         Thing[i].Skeleton.Clone(RifleSkeleton43);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := Guns[BARRETT].TextureNum + k;
@@ -303,7 +303,7 @@ begin
     OBJECT_MINIMI:  // M249
       begin
         Thing[i].Skeleton.VDamping := 0.993;
-        Thing[i].Skeleton.Gravity := 1.2 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.2;
         Thing[i].Skeleton.Clone(RifleSkeleton39);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := Guns[M249].TextureNum + k;
@@ -317,7 +317,7 @@ begin
     OBJECT_MINIGUN:  // Minigun
       begin
         Thing[i].Skeleton.VDamping := 0.991;
-        Thing[i].Skeleton.Gravity := 1.4 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.4;
         Thing[i].Skeleton.Clone(RifleSkeleton55);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := Guns[MINIGUN].TextureNum + k;
@@ -330,7 +330,7 @@ begin
     OBJECT_RAMBO_BOW:  // Bow
       begin
         Thing[i].Skeleton.VDamping := 0.996;
-        Thing[i].Skeleton.Gravity := 0.65 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 0.65;
         Thing[i].Skeleton.Clone(RifleSkeleton50);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := GFX_WEAPONS_N_BOW + k;
@@ -344,7 +344,7 @@ begin
       begin
         Thing[i].Skeleton := BoxSkeleton;
         Thing[i].Skeleton.VDamping := 0.989;
-        Thing[i].Skeleton.Gravity := 1.05 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.05;
         Thing[i].Radius := KIT_RADIUS;
         Thing[i].TimeOut := sv_respawntime.Value * GUNRESISTTIME;
         Thing[i].Interest := DEFAULT_INTEREST_TIME;
@@ -357,7 +357,7 @@ begin
       begin
         Thing[i].Skeleton := BoxSkeleton;
         Thing[i].Skeleton.VDamping := 0.989;
-        Thing[i].Skeleton.Gravity := 1.07 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.07;
         Thing[i].Radius := KIT_RADIUS;
         Thing[i].TimeOut := FLAG_TIMEOUT;
         Thing[i].Interest := DEFAULT_INTEREST_TIME;
@@ -370,7 +370,7 @@ begin
       begin
         Thing[i].Skeleton := BoxSkeleton;
         Thing[i].Skeleton.VDamping := 0.989;
-        Thing[i].Skeleton.Gravity := 1.17 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.17;
         Thing[i].Radius := KIT_RADIUS;
         Thing[i].TimeOut := FLAG_TIMEOUT;
         Thing[i].Interest := DEFAULT_INTEREST_TIME;
@@ -383,7 +383,7 @@ begin
       begin
         Thing[i].Skeleton := BoxSkeleton;
         Thing[i].Skeleton.VDamping := 0.989;
-        Thing[i].Skeleton.Gravity := 1.17 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.17;
         Thing[i].Radius := KIT_RADIUS;
         Thing[i].TimeOut := FLAG_TIMEOUT;
         Thing[i].Interest := DEFAULT_INTEREST_TIME;
@@ -396,7 +396,7 @@ begin
       begin
         Thing[i].Skeleton := BoxSkeleton;
         Thing[i].Skeleton.VDamping := 0.989;
-        Thing[i].Skeleton.Gravity := 1.17 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.17;
         Thing[i].Radius := KIT_RADIUS;
         Thing[i].TimeOut := FLAG_TIMEOUT;
         Thing[i].Interest := DEFAULT_INTEREST_TIME;
@@ -409,7 +409,7 @@ begin
       begin
         Thing[i].Skeleton := BoxSkeleton;
         Thing[i].Skeleton.VDamping := 0.989;
-        Thing[i].Skeleton.Gravity := 1.17 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.17;
         Thing[i].Radius := KIT_RADIUS;
         Thing[i].TimeOut := FLAG_TIMEOUT;
         Thing[i].Interest := DEFAULT_INTEREST_TIME;
@@ -422,7 +422,7 @@ begin
       begin
         Thing[i].Skeleton := BoxSkeleton;
         Thing[i].Skeleton.VDamping := 0.989;
-        Thing[i].Skeleton.Gravity := 1.07 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.07;
         Thing[i].Radius := KIT_RADIUS;
         Thing[i].TimeOut := FLAG_TIMEOUT;
         Thing[i].Interest := DEFAULT_INTEREST_TIME;
@@ -434,7 +434,7 @@ begin
     OBJECT_PARACHUTE:  // para
       begin
         Thing[i].Skeleton.VDamping := 0.993;
-        Thing[i].Skeleton.Gravity := 1.15 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.15;
         Thing[i].Skeleton.Clone(ParaSkeleton);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := GFX_GOSTEK_PARA_ROPE;
@@ -445,7 +445,7 @@ begin
     OBJECT_COMBAT_KNIFE:  // Knife
       begin
         Thing[i].Skeleton.VDamping := 0.994;
-        Thing[i].Skeleton.Gravity := 1.15 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.15;
         Thing[i].Skeleton.Clone(RifleSkeleton18);
 
         a := Thing[i].Skeleton.Pos[2];
@@ -470,7 +470,7 @@ begin
     OBJECT_CHAINSAW:  // Chainsaw
       begin
         Thing[i].Skeleton.VDamping := 0.994;
-        Thing[i].Skeleton.Gravity := 1.15 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.15;
         Thing[i].Skeleton.Clone(RifleSkeleton28);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := Guns[CHAINSAW].TextureNum + k;
@@ -484,7 +484,7 @@ begin
     OBJECT_LAW:  // LAW
       begin
         Thing[i].Skeleton.VDamping := 0.994;
-        Thing[i].Skeleton.Gravity := 1.15 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 1.15;
         Thing[i].Skeleton.Clone(RifleSkeleton28);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := Guns[LAW].TextureNum + k;
@@ -497,7 +497,7 @@ begin
     OBJECT_STATIONARY_GUN:  // stationary gun
       begin
         Thing[i].Skeleton.VDamping := 0.99;
-        Thing[i].Skeleton.Gravity := 0.2 * GRAV;
+        Thing[i].Skeleton.GravityMultiplier := 0.2;
         Thing[i].Skeleton.Clone(StatSkeleton);
         {$IFNDEF SERVER}
         Thing[i].Tex1 := 0;
@@ -702,7 +702,7 @@ begin
               Collided := True;
 
               if Collided then
-                Skeleton.Forces[2].Y := Skeleton.Forces[2].Y + FLAG_STAND_FORCEUP * GRAV;
+                Skeleton.Forces[2].Y := Skeleton.Forces[2].Y + FLAG_STAND_FORCEUP * Grav;
             end;
           end
           else
@@ -751,7 +751,7 @@ begin
       if (HoldingSprite > 0) and (HoldingSprite < MAX_SPRITES + 1) then
       begin
         Skeleton.Pos[1] := Sprite[HoldingSprite].Skeleton.Pos[8];
-        Skeleton.Forces[2].Y := Skeleton.Forces[2].Y + FLAG_HOLDING_FORCEUP * GRAV;
+        Skeleton.Forces[2].Y := Skeleton.Forces[2].Y + FLAG_HOLDING_FORCEUP * Grav;
         Interest := DEFAULT_INTEREST_TIME;
 
         Interest := FLAG_INTEREST_TIME;
@@ -990,7 +990,7 @@ begin
         Skeleton.OldPos[4] := Skeleton.Pos[3];
         Skeleton.Pos[3] := a;
         Skeleton.OldPos[3] := a;
-        SpriteParts.Forces[HoldingSprite].Y := GRAV;
+        SpriteParts.Forces[HoldingSprite].Y := Grav;
       end;
     end else
     begin

--- a/shared/network/NetworkClientGame.pas
+++ b/shared/network/NetworkClientGame.pas
@@ -10,7 +10,7 @@ uses
   Vector,
 
   // OpenSoldat units
-  Steam, Net, Sprites, Weapons, Sound,
+  Steam, Net, Sprites, Weapons, Sound, GameRendering,
   Constants, GameStrings;
 
 procedure ClientHandleNewPlayer(NetMessage: PSteamNetworkingMessage_t);
@@ -130,6 +130,7 @@ begin
     HeartbeatTimeWarnings := 0;
 
     r_zoom.SetValue(0.0);  // Reset zoom
+    ActualZoom := 0.0;
 
     if MapChangeCounter < 999999999 then
       MapChangeCounter := -60;


### PR DESCRIPTION
Some of these should probably be in their own PR, but I'd like to try and get these hosted in time for the usual dev game time.

- Allow `/netconfig` to be called from the command line.
  - Closes #109, allows for easy testing with fake lag and more via GNS.
- `sv_radio` defaults to true.
- Avoid range check error when inserting last sprite in `TBullet.FilterSpritesByDistance`.
- Avoid range check error when sending `BigText` messages from SC3.
- Refactor binds system to support binding to modifier keys, support modifiers more robustly, support vertical scroll mousewheel bindings, and properly sort bindings in the order they should be tried.
  - Specific modifier keys can be used like `bind "left shift" +jump`, and mousewheel via `bind "mousewheel up" "inc r_zoom -5.0 5.0 -0.25"`, `bind "mousewheel down" "inc r_zoom -5.0 5.0 0.25"`. Just a bare generic modifier key like `bind shift +jump` doesn't work currently but could be easily added if people want it. I think the typical use case is to for example bind left shift to prone though (`bind "left shift" +prone`).
  - You can do things like `alt+left shift+ctrl`, `ctrl+mousewheel down`, although you may run into problems with OS/window manager support or key rollover.
  - Launcher doesn't yet have support for this but doesn't seem to overwrite any settings, so I'll just push it.
- Remove superfluous server copy of `fs_localmount`.
- Create `custom-interfaces` folder when starting client.
- Remove debug printing in `Input.pas`.
- After failing to load a map on the server, load the next map immediately.
  - Avoids the server getting stuck if `sv_pauseonidle` is true and a map fails to load.
- Properly handle having other modifiers set, like num/scroll/caps lock.
- Add CVAR_SERVER_INITONLY to `DumpFlags`.
- Modify particle systems to multiply by global gravity, capitalize `GRAV` -> `Grav` to indicate its not a constant, move `Grav` to `Game.pas`.
  - This allows `sv_gravity` updates to filter through to all particle systems (except for static things, which was fixed in a later commit).
- Support filtering commands in `/cmdlist`.
- Implement smooth zooming.
- Properly load `.png` files from custom interfaces.
  - Fixes at least a few old interfaces, although some are hopelessly broken.
- Fail loading bot if `TBotData.FavWeapon` is invalid.
- Add a rectangle indicating which areas of the map you are viewing in spectator mode, and make some interface elements behave more reasonably when zooming.
  - Maybe I could make this optional, with some `ui_spectatorminimapsquare`, but I think it's unobtrusive enough to warrant just being a default feature.
- Don't double draw corners in `DrawBox`.
- Avoid crashes if `r_zoom` or `cl_player_wep` are passed from the command line.
- Try and fallback to default mapslist if passed mapslist is not found.
- Properly check if mousewheel bind is null before dereferencing it.
- Reactivate static things when changing gravity.
  - When Things sit still for a while, they are marked as static and just left to sit still, as an optimization, and also to avoid jittering. To complete the illusion of changing gravity, all Things should respect the new value.
- Avoid crashes from passing certain cvars/commands on the command line or in config files, first go at `CMD_INGAMEONLY`.
  - Ideally the server shouldn't have this, and should use `CMD_DEFERRED` instead. But that would require some rearranging of the server's initialization.
- `r_sleeptime` defaults to 1.
  - Avoid busy waiting.
- Update to v0.4 of OpenSoldat assets
  - Features new kit graphics by AEfremov, and a new medikit graphic that doesn't have the protected America Red Cross symbol.