### PR TITLE
cmake: Condition GNS properties to BUILD_GNS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,9 @@ if(BUILD_SERVER)
   add_subdirectory(server)
 endif()
 
-set_property(TARGET GameNetworkingSockets PROPERTY CXX_STANDARD 17)
+if(BUILD_GNS)
+  set_property(TARGET GameNetworkingSockets PROPERTY CXX_STANDARD 17)
+endif()
 
 # Install step that does 3 things:
 # 1) Cleans binary directory by removing unnecessary files from compilation.


### PR DESCRIPTION
If BUILD_GNS is disabled, we get the following error:

```CMake Error at CMakeLists.txt:190 (set_property):
  set_property could not find TARGET GameNetworkingSockets.  Perhaps it has
  not yet been created.
```