### PR TITLE
Fix use latest version of gcarreno/setup-lazarus

### DIFF
--- a/.github/workflows/opensoldat.yml
+++ b/.github/workflows/opensoldat.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get install cmake git libprotobuf-dev protobuf-compiler libssl-dev libsdl2-dev libopenal-dev libphysfs-dev libfreetype6 patchelf
 
       - name: Setup Lazarus environment
-        uses: gcarreno/setup-lazarus@v3.2.17
+        uses: gcarreno/setup-lazarus@v3.3.1
         with:
           lazarus-version: "3.0"
           #include-packages: "Synapse 40.1"
@@ -119,7 +119,7 @@ jobs:
 #        shell: cmd
 
       - name: Setup Lazarus environment
-        uses: gcarreno/setup-lazarus@v3.2.17
+        uses: gcarreno/setup-lazarus@v3.3.1
         with:
           lazarus-version: "3.0"
           #include-packages: "Synapse 40.1"


### PR DESCRIPTION
Attempt at fixing following build error:

Run gcarreno/setup-lazarus@v3.2.17
with:
lazarus-version: 3.0
with-cache: true
Installing Lazarus
installLazarus -- Installing Lazarus 3.0 on platform: "linux"; arch: "x64"
Cache.restore -- Key: 3.0-x64-linux dir: /home/runner/work/_temp/installers
Error: Cache service responded with 400